### PR TITLE
C64 delta savestates

### DIFF
--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.Input.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.Input.cs
@@ -2,23 +2,23 @@
 {
 	public sealed partial class Motherboard
 	{
-		private readonly int[] _joystickPressed = new int[10];
-		private readonly int[] _keyboardPressed = new int[64];
+		private readonly bool[] _joystickPressed = new bool[10];
+		private readonly bool[] _keyboardPressed = new bool[64];
 
-		private static readonly string[,] JoystickMatrix = {
-			{"P1 Up", "P1 Down", "P1 Left", "P1 Right", "P1 Button"},
-			{"P2 Up", "P2 Down", "P2 Left", "P2 Right", "P2 Button"}
+		private static readonly string[][] JoystickMatrix = {
+            new[] {"P1 Up", "P1 Down", "P1 Left", "P1 Right", "P1 Button"},
+            new[] {"P2 Up", "P2 Down", "P2 Left", "P2 Right", "P2 Button"}
 		};
 
-		private static readonly string[,] KeyboardMatrix = {
-			{ "Key Insert/Delete", "Key Return", "Key Cursor Left/Right", "Key F7", "Key F1", "Key F3", "Key F5", "Key Cursor Up/Down" },
-			{ "Key 3", "Key W", "Key A", "Key 4", "Key Z", "Key S", "Key E", "Key Left Shift" },
-			{ "Key 5", "Key R", "Key D", "Key 6", "Key C", "Key F", "Key T", "Key X" },
-			{ "Key 7", "Key Y", "Key G", "Key 8", "Key B", "Key H", "Key U", "Key V" },
-			{ "Key 9", "Key I", "Key J", "Key 0", "Key M", "Key K", "Key O", "Key N" },
-			{ "Key Plus", "Key P", "Key L", "Key Minus", "Key Period", "Key Colon", "Key At", "Key Comma" },
-			{ "Key Pound", "Key Asterisk", "Key Semicolon", "Key Clear/Home", "Key Right Shift", "Key Equal", "Key Up Arrow", "Key Slash" },
-			{ "Key 1", "Key Left Arrow", "Key Control", "Key 2", "Key Space", "Key Commodore", "Key Q", "Key Run/Stop" }
+		private static readonly string[][] KeyboardMatrix = {
+			new[] { "Key Insert/Delete", "Key Return", "Key Cursor Left/Right", "Key F7", "Key F1", "Key F3", "Key F5", "Key Cursor Up/Down" },
+			new[] { "Key 3", "Key W", "Key A", "Key 4", "Key Z", "Key S", "Key E", "Key Left Shift" },
+			new[] { "Key 5", "Key R", "Key D", "Key 6", "Key C", "Key F", "Key T", "Key X" },
+            new[] { "Key 7", "Key Y", "Key G", "Key 8", "Key B", "Key H", "Key U", "Key V" },
+            new[] { "Key 9", "Key I", "Key J", "Key 0", "Key M", "Key K", "Key O", "Key N" },
+            new[] { "Key Plus", "Key P", "Key L", "Key Minus", "Key Period", "Key Colon", "Key At", "Key Comma" },
+            new[] { "Key Pound", "Key Asterisk", "Key Semicolon", "Key Clear/Home", "Key Right Shift", "Key Equal", "Key Up Arrow", "Key Slash" },
+            new[] { "Key 1", "Key Left Arrow", "Key Control", "Key 2", "Key Space", "Key Commodore", "Key Q", "Key Run/Stop" }
 		};
 
 	    [SaveState.DoNotSave] int _pollIndex;
@@ -33,9 +33,10 @@
 			{
 				for (var i = 0; i < 5; i++)
 				{
-					_joystickPressed[_pollIndex++] = Controller[JoystickMatrix[j, i]] ? -1 : 0;
+                    _joystickPressed[_pollIndex] = Controller[JoystickMatrix[j][i]];
+				    _pollIndex++;
 				}
-			}
+            }
 
 			// scan keyboard
 			_pollIndex = 0;
@@ -43,7 +44,7 @@
 			{
 				for (var j = 0; j < 8; j++)
 				{
-					_keyboardPressed[_pollIndex++] = Controller[KeyboardMatrix[i, j]] ? -1 : 0;
+					_keyboardPressed[_pollIndex++] = Controller[KeyboardMatrix[i][j]];
 				}
 			}
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.Motherboard.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.Motherboard.cs
@@ -102,22 +102,22 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 			{
 				case C64.VicType.Ntsc:
                     Vic = Chip6567R8.Create(borderType);
-                    Cia0 = Chip6526.Create(C64.CiaType.Ntsc,  _keyboardPressed, _joystickPressed);
+                    Cia0 = Chip6526.Create(C64.CiaType.Ntsc,  Input_ReadKeyboard, Input_ReadJoysticks);
                     Cia1 = Chip6526.Create(C64.CiaType.Ntsc, Cia1_ReadPortA);
                     break;
 				case C64.VicType.Pal:
                     Vic = Chip6569.Create(borderType);
-                    Cia0 = Chip6526.Create(C64.CiaType.Pal, _keyboardPressed, _joystickPressed);
+                    Cia0 = Chip6526.Create(C64.CiaType.Pal, Input_ReadKeyboard, Input_ReadJoysticks);
                     Cia1 = Chip6526.Create(C64.CiaType.Pal, Cia1_ReadPortA);
                     break;
                 case C64.VicType.NtscOld:
                     Vic = Chip6567R56A.Create(borderType);
-                    Cia0 = Chip6526.Create(C64.CiaType.NtscRevA, _keyboardPressed, _joystickPressed);
+                    Cia0 = Chip6526.Create(C64.CiaType.NtscRevA, Input_ReadKeyboard, Input_ReadJoysticks);
                     Cia1 = Chip6526.Create(C64.CiaType.NtscRevA, Cia1_ReadPortA);
 			        break;
                 case C64.VicType.Drean:
                     Vic = Chip6572.Create(borderType);
-                    Cia0 = Chip6526.Create(C64.CiaType.Pal, _keyboardPressed, _joystickPressed);
+                    Cia0 = Chip6526.Create(C64.CiaType.Pal, Input_ReadKeyboard, Input_ReadJoysticks);
                     Cia1 = Chip6526.Create(C64.CiaType.Pal, Cia1_ReadPortA);
                     break;
 			}

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.MotherboardInterface.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.MotherboardInterface.cs
@@ -89,6 +89,16 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
             return !_restorePressed && Cia1.ReadIrq() && CartPort.ReadNmi();
         }
 
+        private bool[] Input_ReadJoysticks()
+        {
+            return _joystickPressed;
+        }
+
+        private bool[] Input_ReadKeyboard()
+	    {
+	        return _keyboardPressed;
+	    }
+
         private bool Pla_ReadCharen()
 		{
 			return (Cpu.PortData & 0x04) != 0;

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgeDevice.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/CartridgeDevice.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 {
 	public abstract partial class CartridgeDevice
 	{
-		// ---------------------------------
-
 		public static CartridgeDevice Load(byte[] crtFile)
 		{
 			var mem = new MemoryStream(crtFile);
@@ -71,13 +69,13 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
             switch (mapper)
 		    {
 		        case 0x0000:
-		            result = new Mapper0000(chipAddress, chipBank, chipData, game, exrom);
+		            result = new Mapper0000(chipAddress, chipData, game, exrom);
 		            break;
 		        case 0x0005:
 		            result = new Mapper0005(chipAddress, chipBank, chipData);
 		            break;
 		        case 0x000B:
-		            result = new Mapper000B(chipAddress, chipBank, chipData);
+		            result = new Mapper000B(chipAddress, chipData);
 		            break;
 		        case 0x000F:
 		            result = new Mapper000F(chipAddress, chipBank, chipData);
@@ -116,14 +114,18 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
                 reader.ReadByte();
 		}
 
-		// ---------------------------------
-
+        [SaveState.SaveWithName("ExRom")]
 		protected bool pinExRom;
-		protected bool pinGame;
-		protected bool pinIRQ;
-		protected bool pinNMI;
-		protected bool pinReset;
-		protected bool validCartridge;
+        [SaveState.SaveWithName("Game")]
+        protected bool pinGame;
+        [SaveState.SaveWithName("IRQ")]
+        protected bool pinIRQ;
+        [SaveState.SaveWithName("NMI")]
+        protected bool pinNMI;
+        [SaveState.SaveWithName("Reset")]
+        protected bool pinReset;
+        [SaveState.DoNotSave]
+        protected bool validCartridge;
 
 		public virtual void ExecutePhase1()
 		{
@@ -133,6 +135,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 		{
 		}
 
+        [SaveState.DoNotSave]
 		public bool ExRom
 		{
 			get
@@ -141,7 +144,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			}
 		}
 
-		public bool Game
+        [SaveState.DoNotSave]
+        public bool Game
 		{
 			get
 			{
@@ -156,7 +160,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			pinReset = true;
 		}
 
-		public bool IRQ
+        [SaveState.DoNotSave]
+        public bool IRQ
 		{
 			get
 			{
@@ -164,7 +169,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			}
 		}
 
-		public bool NMI
+        [SaveState.DoNotSave]
+        public bool NMI
 		{
 			get
 			{
@@ -228,7 +234,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			return 0xFF;
 		}
 
-		public bool Reset
+        [SaveState.DoNotSave]
+        public bool Reset
 		{
 			get
 			{
@@ -241,7 +248,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 			SaveState.SyncObject(ser, this);
 		}
 
-		public bool Valid
+        [SaveState.DoNotSave]
+        public bool Valid
 		{
 			get
 			{

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0000.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0000.cs
@@ -8,15 +8,19 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private sealed class Mapper0000 : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[] _romA;
+            [SaveState.SaveWithName("RomMaskA")]
             private readonly int _romAMask;
+            [SaveState.DoNotSave]
             private readonly int[] _romB;
+            [SaveState.SaveWithName("RomMaskB")]
             private readonly int _romBMask;
 
             // standard cartridge mapper (Commodore)
             // note that this format also covers Ultimax carts
 
-            public Mapper0000(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData, bool game, bool exrom)
+            public Mapper0000(IList<int> newAddresses, IList<int[]> newData, bool game, bool exrom)
             {
                 pinGame = game;
                 pinExRom = exrom;

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0005.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0005.cs
@@ -9,12 +9,19 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private sealed class Mapper0005 : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[][] _banksA; //8000
+            [SaveState.DoNotSave]
             private readonly int[][] _banksB = new int[0][]; //A000
+            [SaveState.SaveWithName("BankMask")]
             private readonly int _bankMask;
+            [SaveState.SaveWithName("BankNumber")]
             private int _bankNumber;
+            [SaveState.DoNotSave]
             private int[] _currentBankA;
+            [SaveState.DoNotSave]
             private int[] _currentBankB;
+            [SaveState.DoNotSave]
             private readonly int[] _dummyBank;
 
             public Mapper0005(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData)

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000B.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000B.cs
@@ -14,9 +14,10 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private sealed class Mapper000B : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[] _rom = new int[0x4000];
 
-            public Mapper000B(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData)
+            public Mapper000B(IList<int> newAddresses, IList<int[]> newData)
             {
                 validCartridge = false;
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000F.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper000F.cs
@@ -16,9 +16,13 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private class Mapper000F : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[][] _banks; //8000
+            [SaveState.SaveWithName("BankMask")]
             private readonly int _bankMask;
+            [SaveState.SaveWithName("BankNumber")]
             private int _bankNumber;
+            [SaveState.SaveWithName("CurrentBank")]
             private int[] _currentBank;
 
             public Mapper000F(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData)

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0012.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0012.cs
@@ -8,9 +8,13 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private sealed class Mapper0012 : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[] _bankMain;
+            [SaveState.DoNotSave]
             private readonly int[][] _bankHigh;
+            [SaveState.SaveWithName("BankHighSelected")]
             private int[] _bankHighSelected;
+            [SaveState.SaveWithName("BankIndex")]
             private int _bankIndex;
 
             // Zaxxon and Super Zaxxon cartridges

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0013.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0013.cs
@@ -16,10 +16,15 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
     {
         private sealed class Mapper0013 : CartridgeDevice
         {
+            [SaveState.DoNotSave]
             private readonly int[][] _banks; //8000
+            [SaveState.SaveWithName("BankMask")]
             private readonly int _bankMask;
+            [SaveState.SaveWithName("BankNumber")]
             private int _bankNumber;
+            [SaveState.DoNotSave]
             private int[] _currentBank;
+            [SaveState.SaveWithName("ROMEnable")]
             private bool _romEnable;
 
             public Mapper0013(IList<int> newAddresses, IList<int> newBanks, IList<int[]> newData)

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0020.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cartridge/Mapper0020.cs
@@ -286,8 +286,8 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cartridge
 
             public override void SyncState(Serializer ser)
             {
-                SaveState.SyncDeltaBytes("MediaStateA", ser, _originalMediaA, ref _banksA);
-                SaveState.SyncDeltaBytes("MediaStateB", ser, _originalMediaB, ref _banksB);
+                SaveState.SyncDelta("MediaStateA", ser, _originalMediaA, ref _banksA);
+                SaveState.SyncDelta("MediaStateB", ser, _originalMediaB, ref _banksB);
                 base.SyncState(ser);
             }
         }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/CassettePort.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/CassettePort.cs
@@ -5,9 +5,14 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cassette
 {
     public sealed class CassettePort
     {
+        [SaveState.DoNotSave]
         public Func<bool> ReadDataOutput = () => true;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMotor = () => true;
+
+        [SaveState.SaveWithName("Device")]
         private CassettePortDevice _device;
+        [SaveState.SaveWithName("Connected")]
         private bool _connected;
 
         public void HardReset()

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/CassettePortDevice.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/CassettePortDevice.cs
@@ -5,7 +5,9 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cassette
 {
     public abstract class CassettePortDevice
     {
+        [SaveState.DoNotSave]
         public Func<bool> ReadDataOutput;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMotor;
 
         public virtual void ExecutePhase2()

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/TapeDrive.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Cassette/TapeDrive.cs
@@ -5,6 +5,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Cassette
 {
     public class TapeDrive : CassettePortDevice
     {
+        [SaveState.SaveWithName("Tape")]
         private Tape _tape;
 
         public override void ExecutePhase2()

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6526.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6526.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
             }
         }
 
-        public static Cia Create(C64.CiaType type, bool[] keyboard, bool[] joysticks)
+        public static Cia Create(C64.CiaType type, Func<bool[]> keyboard, Func<bool[]> joysticks)
 	    {
 	        switch (type)
 	        {

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6526.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6526.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
             }
         }
 
-        public static Cia Create(C64.CiaType type, int[] keyboard, int[] joysticks)
+        public static Cia Create(C64.CiaType type, bool[] keyboard, bool[] joysticks)
 	    {
 	        switch (type)
 	        {

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.Port.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.Port.cs
@@ -36,37 +36,40 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
         {
             [SaveState.DoNotSave] private int _ret;
             [SaveState.DoNotSave] private int _tst;
-            [SaveState.DoNotSave] private readonly bool[] _joyData;
-            [SaveState.DoNotSave] private readonly bool[] _keyData;
+            [SaveState.DoNotSave] private readonly Func<bool[]> _readJoyData;
+            [SaveState.DoNotSave] private readonly Func<bool[]> _readKeyData;
 
-            public JoystickKeyboardPort(bool[] joyData, bool[] keyData)
+            public JoystickKeyboardPort(Func<bool[]> readJoyData, Func<bool[]> readKeyData)
             {
-                _joyData = joyData;
-                _keyData = keyData;
+                _readJoyData = readJoyData;
+                _readKeyData = readKeyData;
             }
 
             private int GetJoystick1()
             {
+                var joyData = _readJoyData();
                 return 0xE0 |
-                       (_joyData[0] ? 0x00 : 0x01) |
-                       (_joyData[1] ? 0x00 : 0x02) |
-                       (_joyData[2] ? 0x00 : 0x04) |
-                       (_joyData[3] ? 0x00 : 0x08) |
-                       (_joyData[4] ? 0x00 : 0x10);
+                       (joyData[0] ? 0x00 : 0x01) |
+                       (joyData[1] ? 0x00 : 0x02) |
+                       (joyData[2] ? 0x00 : 0x04) |
+                       (joyData[3] ? 0x00 : 0x08) |
+                       (joyData[4] ? 0x00 : 0x10);
             }
 
             private int GetJoystick2()
             {
+                var joyData = _readJoyData();
                 return 0xE0 |
-                       (_joyData[5] ? 0x00 : 0x01) |
-                       (_joyData[6] ? 0x00 : 0x02) |
-                       (_joyData[7] ? 0x00 : 0x04) |
-                       (_joyData[8] ? 0x00 : 0x08) |
-                       (_joyData[9] ? 0x00 : 0x10);
+                       (joyData[5] ? 0x00 : 0x01) |
+                       (joyData[6] ? 0x00 : 0x02) |
+                       (joyData[7] ? 0x00 : 0x04) |
+                       (joyData[8] ? 0x00 : 0x08) |
+                       (joyData[9] ? 0x00 : 0x10);
             }
 
             private int GetKeyboardRows(int activeColumns)
             {
+                var keyData = _readKeyData();
                 var result = 0xFF;
                 for (var r = 0; r < 8; r++)
                 {
@@ -75,7 +78,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
                         var i = r << 3;
                         for (var c = 0; c < 8; c++)
                         {
-                            if (_keyData[i++])
+                            if (keyData[i++])
                             {
                                 result &= ~(1 << c);
                             }
@@ -88,6 +91,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 
             private int GetKeyboardColumns(int activeRows)
             {
+                var keyData = _readKeyData();
                 var result = 0xFF;
                 for (var c = 0; c < 8; c++)
                 {
@@ -96,7 +100,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
                         var i = c;
                         for (var r = 0; r < 8; r++)
                         {
-                            if (_keyData[i])
+                            if (keyData[i])
                             {
                                 result &= ~(1 << r);
                             }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.Port.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.Port.cs
@@ -36,10 +36,10 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
         {
             [SaveState.DoNotSave] private int _ret;
             [SaveState.DoNotSave] private int _tst;
-            [SaveState.DoNotSave] private readonly int[] _joyData;
-            [SaveState.DoNotSave] private readonly int[] _keyData;
+            [SaveState.DoNotSave] private readonly bool[] _joyData;
+            [SaveState.DoNotSave] private readonly bool[] _keyData;
 
-            public JoystickKeyboardPort(int[] joyData, int[] keyData)
+            public JoystickKeyboardPort(bool[] joyData, bool[] keyData)
             {
                 _joyData = joyData;
                 _keyData = keyData;
@@ -48,21 +48,21 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
             private int GetJoystick1()
             {
                 return 0xE0 |
-                       (_joyData[0] == 0 ? 0x01 : 0x00) |
-                       (_joyData[1] == 0 ? 0x02 : 0x00) |
-                       (_joyData[2] == 0 ? 0x04 : 0x00) |
-                       (_joyData[3] == 0 ? 0x08 : 0x00) |
-                       (_joyData[4] == 0 ? 0x10 : 0x00);
+                       (_joyData[0] ? 0x00 : 0x01) |
+                       (_joyData[1] ? 0x00 : 0x02) |
+                       (_joyData[2] ? 0x00 : 0x04) |
+                       (_joyData[3] ? 0x00 : 0x08) |
+                       (_joyData[4] ? 0x00 : 0x10);
             }
 
             private int GetJoystick2()
             {
                 return 0xE0 |
-                       (_joyData[5] == 0 ? 0x01 : 0x00) |
-                       (_joyData[6] == 0 ? 0x02 : 0x00) |
-                       (_joyData[7] == 0 ? 0x04 : 0x00) |
-                       (_joyData[8] == 0 ? 0x08 : 0x00) |
-                       (_joyData[9] == 0 ? 0x10 : 0x00);
+                       (_joyData[5] ? 0x00 : 0x01) |
+                       (_joyData[6] ? 0x00 : 0x02) |
+                       (_joyData[7] ? 0x00 : 0x04) |
+                       (_joyData[8] ? 0x00 : 0x08) |
+                       (_joyData[9] ? 0x00 : 0x10);
             }
 
             private int GetKeyboardRows(int activeColumns)
@@ -75,7 +75,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
                         var i = r << 3;
                         for (var c = 0; c < 8; c++)
                         {
-                            if (_keyData[i++] != 0)
+                            if (_keyData[i++])
                             {
                                 result &= ~(1 << c);
                             }
@@ -96,7 +96,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
                         var i = c;
                         for (var r = 0; r < 8; r++)
                         {
-                            if (_keyData[i] != 0)
+                            if (_keyData[i])
                             {
                                 result &= ~(1 << r);
                             }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
             _todDen = todDen;
         }
 
-        public Cia(int todNum, int todDen, bool[] keyboard, bool[] joysticks) : this(todNum, todDen)
+        public Cia(int todNum, int todDen, Func<bool[]> keyboard, Func<bool[]> joysticks) : this(todNum, todDen)
         {
             _port = new JoystickKeyboardPort(joysticks, keyboard);
         }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Cia.cs
@@ -87,7 +87,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
             _todDen = todDen;
         }
 
-        public Cia(int todNum, int todDen, int[] keyboard, int[] joysticks) : this(todNum, todDen)
+        public Cia(int todNum, int todDen, bool[] keyboard, bool[] joysticks) : this(todNum, todDen)
         {
             _port = new JoystickKeyboardPort(joysticks, keyboard);
         }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Media/Tape.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Media/Tape.cs
@@ -4,17 +4,19 @@ using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.Commodore64.Media
 {
-	/**
-		* This class represents a tape. Only TAP-style tapes are supported for now.
-		*/
 	public class Tape
 	{
         [SaveState.DoNotSave] private readonly byte[] _tapeData;
 		[SaveState.DoNotSave] private readonly byte _version;
 	    [SaveState.DoNotSave] private readonly int _start;
         [SaveState.DoNotSave] private readonly int _end;
-		private int _pos, _cycle;
-	    private bool _data;
+
+        [SaveState.SaveWithName("Position")]
+	    private int _pos;
+        [SaveState.SaveWithName("Cycle")]
+        private int _cycle;
+        [SaveState.SaveWithName("Data")]
+        private bool _data;
 
 		public Tape(byte version, byte[] tapeData, int start, int end)
 		{

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
@@ -19,10 +19,6 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 	    {
             public string Name { get; set; }
 
-	        public SaveWithName()
-	        {
-	        }
-
 	        public SaveWithName(string name)
 	        {
 	            Name = name;

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
@@ -97,15 +97,15 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 
         public static void SyncDelta(string name, Serializer ser, int[] source, ref int[] data)
         {
-            byte[] delta = null;
+            int[] delta = null;
             if (ser.IsWriter && data != null)
             {
-                delta = CompressInts(GetDelta(source, data));
+                delta = GetDelta(source, data);
             }
             ser.Sync(name, ref delta, false);
             if (ser.IsReader && delta != null)
             {
-                data = GetDelta(source, DecompressInts(delta));
+                data = GetDelta(source, delta);
             }
         }
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/SaveState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
@@ -14,9 +15,62 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 	    {
 	    }
 
+	    public class SaveWithName : Attribute
+	    {
+            public string Name { get; set; }
+
+	        public SaveWithName()
+	        {
+	        }
+
+	        public SaveWithName(string name)
+	        {
+	            Name = name;
+	        }
+	    }
+
 		private static readonly Encoding Encoding = Encoding.Unicode;
 
-		public static void SyncObject(Serializer ser, object obj)
+        private static int[] GetDelta(IList<int> source, IList<int> data)
+        {
+            var length = Math.Min(source.Count, data.Count);
+            var delta = new int[length];
+            for (var i = 0; i < length; i++)
+            {
+                delta[i] = source[i] ^ data[i];
+            }
+            return delta;
+        }
+
+        public static void SyncDeltaBytes(string name, Serializer ser, int[] source, ref int[] data)
+        {
+            byte[] delta = null;
+            if (ser.IsWriter && data != null)
+            {
+                delta = GetDelta(source, data).Select(d => unchecked((byte)d)).ToArray();
+            }
+            ser.Sync(name, ref delta, false);
+            if (ser.IsReader && delta != null)
+            {
+                data = GetDelta(source, delta.Select(d => (int)d).ToArray());
+            }
+        }
+
+        public static void SyncDeltaInts(string name, Serializer ser, int[] source, ref int[] data)
+        {
+            int[] delta = null;
+            if (ser.IsWriter && data != null)
+            {
+                delta = GetDelta(source, data);
+            }
+            ser.Sync(name, ref delta, false);
+            if (ser.IsReader && delta != null)
+            {
+                data = GetDelta(source, delta);
+            }
+        }
+
+        public static void SyncObject(Serializer ser, object obj)
 		{
 			const BindingFlags defaultFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
 		    var objType = obj.GetType();
@@ -28,6 +82,14 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
                 {
                     continue;
                 }
+
+			    var name = member.Name;
+			    var nameAttribute = member.GetCustomAttributes(true).FirstOrDefault(a => a is SaveWithName);
+			    if (nameAttribute != null)
+			    {
+			        name = ((SaveWithName) nameAttribute).Name;
+			    }
+
 
                 object currentValue = null;
 				var fail = false;
@@ -54,34 +116,35 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
                             break;
                         case "Bit":
 			                var refBit = (Bit)currentValue;
-			                ser.Sync(member.Name, ref refBit);
+			                ser.Sync(name, ref refBit);
 			                currentValue = refBit;
 			                break;
 			            case "Boolean":
 			                var refBool = (bool)currentValue;
-			                ser.Sync(member.Name, ref refBool);
+			                ser.Sync(name, ref refBool);
 			                currentValue = refBool;
 			                break;
 			            case "Boolean[]":
 			            {
 			                var tmp = (bool[])currentValue;
-			                ser.Sync(member.Name, ref tmp, false);
+			                ser.Sync(name, ref tmp, false);
 			                currentValue = tmp;
 			            }
 			                break;
 			            case "Byte":
 			                var refByte = (byte)currentValue;
-			                ser.Sync(member.Name, ref refByte);
+			                ser.Sync(name, ref refByte);
 			                currentValue = refByte;
 			                break;
 			            case "Byte[]":
 			                refByteBuffer = new ByteBuffer((byte[])currentValue);
-			                ser.Sync(member.Name, ref refByteBuffer);
-			                currentValue = refByteBuffer.Arr;
+			                ser.Sync(name, ref refByteBuffer);
+			                currentValue = refByteBuffer.Arr.Select(d => d).ToArray();
+                            refByteBuffer.Dispose();
 			                break;
 			            case "ByteBuffer":
 			                refByteBuffer = (ByteBuffer)currentValue;
-			                ser.Sync(member.Name, ref refByteBuffer);
+			                ser.Sync(name, ref refByteBuffer);
 			                currentValue = refByteBuffer;
 			                break;
 			            case "Func`1":
@@ -89,29 +152,30 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
                             break;
 			            case "Int16":
 			                var refInt16 = (short)currentValue;
-			                ser.Sync(member.Name, ref refInt16);
+			                ser.Sync(name, ref refInt16);
 			                currentValue = refInt16;
 			                break;
 			            case "Int32":
 			                refInt32 = (int)currentValue;
-			                ser.Sync(member.Name, ref refInt32);
+			                ser.Sync(name, ref refInt32);
 			                currentValue = refInt32;
 			                break;
 			            case "Int32[]":
 			                refIntBuffer = new IntBuffer((int[])currentValue);
-			                ser.Sync(member.Name, ref refIntBuffer);
-			                currentValue = refIntBuffer.Arr;
+			                ser.Sync(name, ref refIntBuffer);
+			                currentValue = refIntBuffer.Arr.Select(d => d).ToArray();
+                            refIntBuffer.Dispose();
 			                break;
 			            case "IntBuffer":
 			                refIntBuffer = (IntBuffer)currentValue;
-			                ser.Sync(member.Name, ref refIntBuffer);
+			                ser.Sync(name, ref refIntBuffer);
 			                currentValue = refIntBuffer;
 			                break;
 			            case "Point":
 			                refPointX = ((Point)currentValue).X;
 			                refPointY = ((Point)currentValue).Y;
-			                ser.Sync(member.Name + "_X", ref refPointX);
-			                ser.Sync(member.Name + "_Y", ref refPointY);
+			                ser.Sync(name + "_X", ref refPointX);
+			                ser.Sync(name + "_Y", ref refPointY);
 			                currentValue = new Point(refPointX, refPointY);
 			                break;
 			            case "Rectangle":
@@ -119,31 +183,32 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 			                refPointY = ((Rectangle)currentValue).Y;
 			                var refRectWidth = ((Rectangle)currentValue).Width;
 			                var refRectHeight = ((Rectangle)currentValue).Height;
-			                ser.Sync(member.Name + "_X", ref refPointX);
-			                ser.Sync(member.Name + "_Y", ref refPointY);
-			                ser.Sync(member.Name + "_Height", ref refRectHeight);
-			                ser.Sync(member.Name + "_Width", ref refRectWidth);
+			                ser.Sync(name + "_X", ref refPointX);
+			                ser.Sync(name + "_Y", ref refPointY);
+			                ser.Sync(name + "_Height", ref refRectHeight);
+			                ser.Sync(name + "_Width", ref refRectWidth);
 			                currentValue = new Rectangle(refPointX, refPointY, refRectWidth, refRectHeight);
 			                break;
 			            case "SByte":
 			                var refSByte = (sbyte)currentValue;
-			                ser.Sync(member.Name, ref refSByte);
+			                ser.Sync(name, ref refSByte);
 			                currentValue = refSByte;
 			                break;
 			            case "String":
 			                var refString = (string)currentValue;
 			                var refVal = new ByteBuffer(Encoding.GetBytes(refString));
-			                ser.Sync(member.Name, ref refVal);
+			                ser.Sync(name, ref refVal);
 			                currentValue = Encoding.GetString(refVal.Arr);
+                            refVal.Dispose();
 			                break;
 			            case "UInt16":
 			                var refUInt16 = (ushort)currentValue;
-			                ser.Sync(member.Name, ref refUInt16);
+			                ser.Sync(name, ref refUInt16);
 			                currentValue = refUInt16;
 			                break;
 			            case "UInt32":
 			                var refUInt32 = (uint)currentValue;
-			                ser.Sync(member.Name, ref refUInt32);
+			                ser.Sync(name, ref refUInt32);
 			                currentValue = refUInt32;
 			                break;
 			            default:
@@ -151,7 +216,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 			                if (t.IsEnum)
 			                {
 			                    refInt32 = (int)currentValue;
-			                    ser.Sync(member.Name, ref refInt32);
+			                    ser.Sync(name, ref refInt32);
 			                    currentValue = refInt32;
 			                }
                             else if (t.IsArray)
@@ -159,7 +224,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
                                 var currentValueArray = (Array) currentValue;
                                 for (var i = 0; i < currentValueArray.Length; i++)
                                 {
-                                    ser.BeginSection(string.Format("{0}_{1}", member.Name, i));
+                                    ser.BeginSection(string.Format("{0}_{1}", name, i));
                                     SyncObject(ser, currentValueArray.GetValue(i));
                                     ser.EndSection();
                                 }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.FluxTransitions.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.FluxTransitions.cs
@@ -8,18 +8,29 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 {
     public sealed partial class Drive1541
     {
+        [SaveState.DoNotSave]
         private const long LEHMER_RNG_PRIME = 48271;
-
+        [SaveState.SaveWithName("DiskDensityCounter")]
         private int _diskDensityCounter; // density .. 16
+        [SaveState.SaveWithName("DiskSupplementaryCounter")]
         private int _diskSupplementaryCounter; // 0 .. 16
+        [SaveState.SaveWithName("DiskFluxReversalDetected")]
         private bool _diskFluxReversalDetected;
+        [SaveState.SaveWithName("DiskBitsRemainingInDataEntry")]
         private int _diskBitsLeft;
+        [SaveState.SaveWithName("DiskDataEntryIndex")]
         private int _diskByteOffset;
+        [SaveState.SaveWithName("DiskDataEntry")]
         private int _diskBits;
+        [SaveState.SaveWithName("DiskCurrentCycle")]
         private int _diskCycle;
+        [SaveState.SaveWithName("DiskDensityConfig")]
         private int _diskDensity;
+        [SaveState.SaveWithName("PreviousCA1")]
         private bool _previousCa1;
+        [SaveState.SaveWithName("CountsBeforeRandomTransition")]
         private int _countsBeforeRandomTransition;
+        [SaveState.SaveWithName("CurrentRNG")]
         private int _rngCurrent;
 
         // Lehmer RNG

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.FluxTransitions.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.FluxTransitions.cs
@@ -40,12 +40,12 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
                     if (_diskBitsLeft <= 0)
                     {
                         _diskByteOffset++;
-                        if (_diskByteOffset == Disk.FLUX_ENTRIES_PER_TRACK)
+                        if (_diskByteOffset == Disk.FluxEntriesPerTrack)
                         {
                             _diskByteOffset = 0;
                         }
                         _diskBits = _trackImageData[_diskByteOffset];
-                        _diskBitsLeft = Disk.FLUX_BITS_PER_ENTRY;
+                        _diskBitsLeft = Disk.FluxBitsPerEntry;
                     }
                     if ((_diskBits & 1) != 0)
                     {

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.IDisassemblable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.IDisassemblable.cs
@@ -8,11 +8,13 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 {
     public sealed partial class Drive1541 : IDisassemblable
     {
+        [SaveState.DoNotSave]
         IEnumerable<string> IDisassemblable.AvailableCpus
         {
             get { yield return "Disk Drive 6502"; }
         }
 
+        [SaveState.DoNotSave]
         string IDisassemblable.Cpu
         {
             get { return "Disk Drive 6502"; }
@@ -21,6 +23,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
             }
         }
 
+        [SaveState.DoNotSave]
         string IDisassemblable.PCRegisterName
         {
             get { return "PC"; }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
@@ -13,28 +13,49 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 {
     public sealed partial class Drive1541 : SerialPortDevice
     {
+        [SaveState.SaveWithName("Disk")]
         private Disk _disk;
+        [SaveState.SaveWithName("BitHistory")]
         private int _bitHistory;
+        [SaveState.SaveWithName("BitsRemainingInLatchedByte")]
         private int _bitsRemainingInLatchedByte;
+        [SaveState.SaveWithName("Sync")]
         private bool _sync;
+        [SaveState.SaveWithName("ByteReady")]
         private bool _byteReady;
-        [SaveState.DoNotSave] private readonly int _driveCpuClockNum;
+        [SaveState.SaveWithName("DriveCpuClockNumerator")]
+        private readonly int _driveCpuClockNum;
+        [SaveState.SaveWithName("TrackNumber")]
         private int _trackNumber;
+        [SaveState.SaveWithName("MotorEnabled")]
         private bool _motorEnabled;
+        [SaveState.SaveWithName("LedEnabled")]
         private bool _ledEnabled;
+        [SaveState.SaveWithName("MotorStep")]
         private int _motorStep;
+        [SaveState.DoNotSave]
         private int _via0PortBtemp;
+        [SaveState.SaveWithName("CPU")]
         private readonly MOS6502X _cpu;
+        [SaveState.SaveWithName("RAM")]
         private readonly int[] _ram;
+        [SaveState.SaveWithName("VIA0")]
         public readonly Via Via0;
+        [SaveState.SaveWithName("VIA1")]
         public readonly Via Via1;
+        [SaveState.SaveWithName("SystemCpuClockNumerator")]
         private readonly int _cpuClockNum;
+        [SaveState.SaveWithName("SystemDriveCpuRatioDifference")]
         private int _ratioDifference;
+        [SaveState.SaveWithName("DriveLightOffTime")]
         private int _driveLightOffTime;
-        [SaveState.DoNotSave] private int[] _trackImageData = new int[1];
-
+        [SaveState.DoNotSave]
+        private int[] _trackImageData = new int[1];
+        [SaveState.DoNotSave]
         public Func<int> ReadIec = () => 0xFF;
+        [SaveState.DoNotSave]
         public Action DebuggerStep;
+        [SaveState.DoNotSave]
         public readonly Chip23128 DriveRom;
 
         public Drive1541(int clockNum, int clockDen)

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
@@ -191,7 +191,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
             if (_disk != null)
             {
                 _trackImageData = _disk.GetDataForTrack(_trackNumber);
-                _diskBits = _trackImageData[_diskByteOffset] >> (Disk.FLUX_BITS_PER_ENTRY - _diskBitsLeft);
+                _diskBits = _trackImageData[_diskByteOffset] >> (Disk.FluxBitsPerEntry - _diskBitsLeft);
             }
         }
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPort.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPort.cs
@@ -10,11 +10,16 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 {
     public sealed class SerialPort : IDriveLight
     {
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterAtn = () => true;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterClk = () => true;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterData = () => true;
 
+        [SaveState.SaveWithName("Device")]
         private SerialPortDevice _device;
+        [SaveState.SaveWithName("Connected")]
         private bool _connected;
 
         public void HardReset()
@@ -75,7 +80,9 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
             _device.ReadMasterData = () => ReadMasterData();
         }
 
+        [SaveState.DoNotSave]
         public bool DriveLightEnabled { get { return true; } }
+        [SaveState.DoNotSave]
         public bool DriveLightOn { get { return ReadDeviceLight(); } }
     }
 }

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPortDevice.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/SerialPortDevice.cs
@@ -8,8 +8,11 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 {
     public abstract class SerialPortDevice
     {
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterAtn;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterClk;
+        [SaveState.DoNotSave]
         public Func<bool> ReadMasterData;
 
         public virtual void ExecutePhase()


### PR DESCRIPTION
When saving data from modified cartridge flash (EasyFlash) or on disk (D64, G64), savestates will now have a delta of the modified data rather than an image of the original data, preventing from distributing the original media in savestates.