### PR TITLE
Rewrite A2600 Audio

### DIFF
--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
@@ -363,6 +363,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			StartFrameCond();
 			while (_tia.LineCount < _tia.NominalNumScanlines)
 				Cycle();
+            if (rendersound==false)
+                _tia._audioClocks = 0; // we need this here since the async sound provider won't check in this case
 			FinishFrameCond();
 		}
 


### PR DESCRIPTION
Now samples sound at exact explicit times each scanline.
Much simpler, but still sounds the same as before (i.e. some sounds are still wrong.)
Next Step: fix TIA.Audio