### PR TITLE
NesHawk and 6502 bug Fixes

### DIFF
--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
@@ -153,7 +153,12 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			ser.Sync("VRAMBuffer", ref VRAMBuffer);
 			ser.Sync("ppu_addr_temp", ref ppu_addr_temp);
 
-			ser.Sync("OAM", ref OAM, false);
+            ser.Sync("Read_Value", ref read_value);
+            ser.Sync("Prev_soam_index", ref soam_index_prev);
+            ser.Sync("Spr_Zero_Go", ref sprite_zero_go);
+            ser.Sync("Spr_zero_in_Range", ref sprite_zero_in_range);
+
+            ser.Sync("OAM", ref OAM, false);
 			ser.Sync("PALRAM", ref PALRAM, false);
 
 			ser.Sync("Reg2002_objoverflow", ref Reg2002_objoverflow);
@@ -210,7 +215,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			for (int i = 0; i < x; i++)
 			{
 				ppur.status.cycle++;
-
+                is_even_cycle = !is_even_cycle;
 				//might not actually run a cpu cycle if there are none to be run right now
 				nes.RunCpuOne();
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
@@ -395,7 +395,31 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			OAM[reg_2003] = value;
 			reg_2003++;
 		}
-		byte read_2004() { return OAM[reg_2003]; }
+		byte read_2004()
+        {
+            if (ppur.status.sl < 241)
+            {
+                if (ppur.status.cycle < 64)
+                {
+                    return 0xFF; // during this time all reads return FF
+                }
+                else if (ppur.status.cycle < 256)
+                {
+                    return read_value;
+                }
+                else if (ppur.status.cycle < 320)
+                {
+                    return read_value;
+                }
+                else
+                {
+                    return soam[0];
+                }
+            } else
+            {
+                return OAM[reg_2003];
+            }
+        }
 		byte peek_2004() { return OAM[reg_2003]; }
 
 		//SCROLL (write)


### PR DESCRIPTION
6502: Update behaviour of some undocumented opcodes. Now passes instr_misc/instr_misc. I couldn't find anything else to test it against.

NesHawk: Fixes 4014 read behavior. Fixes sprite evaluation. Combination of these things fixes Micro Machines, and also passes:
sprite_overflow_tests/3.Timing
sprite_overflow_tests/4.Obscure

Feedback welcome! 
I did a lot of testing and didn't find any bugs, but maybe someone will spot something.