### PR TITLE
Fix File->Save Log menu item in Trace Logger window

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
+++ b/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
@@ -302,7 +302,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void StartLogFile(FileInfo file)
 		{
-			using (var sw = new StreamWriter(_logFile.FullName, append: false))
+			using (var sw = new StreamWriter(file.FullName, append: false))
 			{
 				sw.WriteLine(Tracer.Header);
 			}


### PR DESCRIPTION
- Prevents an unhandled exception when saving a log from the window
  (opposed to file)