### PR TITLE
Create Smoother FPS Counter

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1337,10 +1337,11 @@ namespace BizHawk.Client.EmuHawk
 		private bool _runloopFrameProgress;
 		private long _frameAdvanceTimestamp;
 		private long _frameRewindTimestamp;
-		private int _runloopFps;
-		private int _runloopLastFps;
-		private bool _runloopFrameadvance;
-		private long _runloopSecond;
+        private double _runloopLastFps;
+        private bool _runloopFrameadvance;
+        private double _runloopUpdatesPerSecond = 16.0;
+        private double _runloopFpsSmoothing = 8.0;
+        private long _runloopSecond;
 		private bool _runloopLastFf;
 		private bool _inResizeLoop;
 
@@ -2768,20 +2769,19 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.UpdateToolsBefore();
 				}
 
-				_runloopFps++;
+				_runloopLastFps+= _runloopFpsSmoothing;
 
-				if ((double)(currentTimestamp - _runloopSecond) / Stopwatch.Frequency >= 1.0)
-				{
-					_runloopLastFps = _runloopFps;
-					_runloopSecond = currentTimestamp;
-					_runloopFps = 0;
+                if ((currentTimestamp - _runloopSecond) * _runloopUpdatesPerSecond >= Stopwatch.Frequency)
+                {
+                    _runloopLastFps = Stopwatch.Frequency * (_runloopLastFps / (Stopwatch.Frequency + (currentTimestamp - _runloopSecond) * _runloopFpsSmoothing));
+                    _runloopSecond = currentTimestamp;
 					updateFpsString = true;
 				}
 
 				if (updateFpsString)
 				{
-					var fps_string = _runloopLastFps + " fps";
-					if (isRewinding)
+                    var fps_string = string.Format("{0:0} fps", _runloopLastFps);
+                    if (isRewinding)
 					{
 						if (IsTurboing || isFastForwarding)
 						{

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1337,11 +1337,11 @@ namespace BizHawk.Client.EmuHawk
 		private bool _runloopFrameProgress;
 		private long _frameAdvanceTimestamp;
 		private long _frameRewindTimestamp;
-        private double _runloopLastFps;
-        private bool _runloopFrameadvance;
-        private double _runloopUpdatesPerSecond = 16.0;
-        private double _runloopFpsSmoothing = 8.0;
-        private long _runloopSecond;
+		private double _runloopLastFps;
+		private bool _runloopFrameadvance;
+		private double _runloopUpdatesPerSecond = 16.0;
+		private double _runloopFpsSmoothing = 8.0;
+		private long _runloopSecond;
 		private bool _runloopLastFf;
 		private bool _inResizeLoop;
 
@@ -2771,17 +2771,17 @@ namespace BizHawk.Client.EmuHawk
 
 				_runloopLastFps+= _runloopFpsSmoothing;
 
-                if ((currentTimestamp - _runloopSecond) * _runloopUpdatesPerSecond >= Stopwatch.Frequency)
-                {
-                    _runloopLastFps = Stopwatch.Frequency * (_runloopLastFps / (Stopwatch.Frequency + (currentTimestamp - _runloopSecond) * _runloopFpsSmoothing));
-                    _runloopSecond = currentTimestamp;
+				if ((currentTimestamp - _runloopSecond) * _runloopUpdatesPerSecond >= Stopwatch.Frequency)
+				{
+					_runloopLastFps = Stopwatch.Frequency * (_runloopLastFps / (Stopwatch.Frequency + (currentTimestamp - _runloopSecond) * _runloopFpsSmoothing));
+					_runloopSecond = currentTimestamp;
 					updateFpsString = true;
 				}
 
 				if (updateFpsString)
 				{
-                    var fps_string = string.Format("{0:0} fps", _runloopLastFps);
-                    if (isRewinding)
+					var fps_string = string.Format("{0:0} fps", _runloopLastFps);
+					if (isRewinding)
 					{
 						if (IsTurboing || isFastForwarding)
 						{
@@ -3528,7 +3528,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					//This shows up if there's a problem                
+					//This shows up if there's a problem
 					// TODO: put all these in a single method or something
 
 					//The ROM has been loaded by a recursive invocation of the LoadROM method.


### PR DESCRIPTION


Changes the FPS counter to be smoother.

Why: FPS counter has a bug where it doesn't normalize the frame count to
the time passed since last update. This can result in an error of 1 FPS.
When running at 30 FPS, that is ~3.33%. The lower the FPS, the worse
this error grows.

1) Adds a parameter for how often to update the FPS (e.g. 16 times per
second).

2) Normalizes to the number of seconds passed since last update (fixing
the bug).

3) Adds a smoothing parameter (e.g. weigh the most recent interval at
8x, and normalize with current displayed data). This results in less
jumpy FPS because it takes into account historical data.
