### PR TITLE
Fix Volume Controls

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1906,6 +1906,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private void Render()
 		{
+			if (Global.Config.DispSpeedupFeatures == 0)
+			{
+				return;
+			}
 			//private Size _lastVideoSize = new Size(-1, -1), _lastVirtualSize = new Size(-1, -1);
 			var video = Global.Emulator.VideoProvider();
 			//bool change = false;

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -534,8 +534,6 @@ namespace BizHawk.Client.EmuHawk
 				{
 					break;
 				}
-
-				Thread.Sleep(0);
 			}
 
 			Shutdown();

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2729,9 +2729,7 @@ namespace BizHawk.Client.EmuHawk
 
 			bool isRewinding = suppressCaptureRewind = Rewind(ref runFrame, currentTimestamp);
 			
-			float atten = Global.Config.SoundVolume / 100.0f;
-			if (!Global.Config.SoundEnabledNormal)
-				atten = 0;
+			float atten = 0;
 
 			var coreskipaudio = false;
 			if (runFrame || force)
@@ -2803,12 +2801,11 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				CaptureRewind(suppressCaptureRewind);
+				
+				if (Global.Config.SoundEnabledNormal)
+					atten = Global.Config.SoundVolume / 100.0f;
 
-				if (!_runloopFrameadvance)
-				{
-					
-				}
-				else if (!Global.Config.MuteFrameAdvance)
+				if (_runloopFrameadvance && !Global.Config.MuteFrameAdvance)
 				{
 					atten = 0;
 				}
@@ -2890,10 +2887,6 @@ namespace BizHawk.Client.EmuHawk
 						GlobalWin.Tools.TAStudio.StopSeeking();
 					}
 				}
-			}
-			else
-			{
-				atten = 0;
 			}
 
 			if (Global.ClientControls["Rewind"] || PressRewind)

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2691,12 +2691,12 @@ namespace BizHawk.Client.EmuHawk
 
 			if (Global.ClientControls["Frame Advance"] || PressFrameAdvance || HoldFrameAdvance)
 			{
+				_runloopFrameadvance = true;
 				// handle the initial trigger of a frame advance
 				if (_frameAdvanceTimestamp == 0)
 				{
 					PauseEmulator();
 					runFrame = true;
-					_runloopFrameadvance = true;
 					_frameAdvanceTimestamp = currentTimestamp;
 				}
 				else
@@ -2804,8 +2804,8 @@ namespace BizHawk.Client.EmuHawk
 				
 				if (Global.Config.SoundEnabledNormal)
 					atten = Global.Config.SoundVolume / 100.0f;
-
-				if (_runloopFrameadvance && !Global.Config.MuteFrameAdvance)
+				
+				if (_runloopFrameadvance && Global.Config.MuteFrameAdvance)
 				{
 					atten = 0;
 				}

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2777,7 +2777,7 @@ namespace BizHawk.Client.EmuHawk
 					if (isFastForwarding || IsTurboing || isRewinding)
 					{
 						if (Global.Config.SoundEnabledRWFF)
-							atten = Global.Config.SoundVolumeRWFF / 100.0f;
+							atten *= Global.Config.SoundVolumeRWFF / 100.0f;
 						else
 							atten = 0;
 					}

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -534,6 +534,10 @@ namespace BizHawk.Client.EmuHawk
 				{
 					break;
 				}
+				if (Global.Config.DispSpeedupFeatures != 0)
+				{
+					Thread.Sleep(0);
+				}
 			}
 
 			Shutdown();

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -612,7 +612,6 @@ namespace BizHawk.Client.EmuHawk
 		public bool FastForward = false;
 		public bool TurboFastForward = false;
 		public bool RestoreReadWriteOnStop = false;
-		public bool UpdateFrame = false;
 
 		private int? _pauseOnFrame;
 		public int? PauseOnFrame // If set, upon completion of this frame, the client wil pause
@@ -2729,12 +2728,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			bool isRewinding = suppressCaptureRewind = Rewind(ref runFrame, currentTimestamp);
-
-			if (UpdateFrame)
-			{
-				runFrame = true;
-			}
-
+			
 			float atten = Global.Config.SoundVolume / 100.0f;
 			if (!Global.Config.SoundEnabledNormal)
 				atten = 0;
@@ -2906,11 +2900,6 @@ namespace BizHawk.Client.EmuHawk
 			{
 				UpdateToolsAfter();
 				//PressRewind = false;
-			}
-
-			if (UpdateFrame)
-			{
-				UpdateFrame = false;
 			}
 
 			GlobalWin.Sound.UpdateSound(atten);

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2731,7 +2731,6 @@ namespace BizHawk.Client.EmuHawk
 			
 			float atten = 0;
 
-			var coreskipaudio = false;
 			if (runFrame || force)
 			{
 				var isFastForwarding = Global.ClientControls["Fast Forward"] || IsTurboing;
@@ -2824,19 +2823,12 @@ namespace BizHawk.Client.EmuHawk
 				
 				Global.MovieSession.HandleMovieOnFrameLoop();
 
-				coreskipaudio = IsTurboing && _currAviWriter == null;
-
 				//why not skip audio if the user doesnt want sound
-				if (!Global.Config.SoundEnabled)
-					coreskipaudio = true;
+				bool renderSound = Global.Config.SoundEnabled || !IsTurboing;
+				renderSound |= (_currAviWriter != null && _currAviWriter.UsesAudio);
 
-				{
-					bool render = !_throttle.skipnextframe;
-					bool renderSound = !coreskipaudio;
-					if (_currAviWriter != null && _currAviWriter.UsesVideo) render = true;
-					if (_currAviWriter != null && _currAviWriter.UsesAudio) renderSound = true;
-					Global.Emulator.FrameAdvance(render, renderSound);
-				}
+				bool render = !_throttle.skipnextframe || (_currAviWriter != null && _currAviWriter.UsesVideo);
+				Global.Emulator.FrameAdvance(render, renderSound);
 
 				Global.MovieSession.HandleMovieAfterFrameLoop();
 

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2810,7 +2810,7 @@ namespace BizHawk.Client.EmuHawk
 					if (isFastForwarding || IsTurboing || isRewinding)
 					{
 						if (Global.Config.SoundEnabledRWFF)
-							atten *= Global.Config.SoundVolumeRWFF / 100.0f;
+							atten = Global.Config.SoundVolumeRWFF / 100.0f;
 						else
 							atten = 0;
 					}

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2801,22 +2801,27 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				CaptureRewind(suppressCaptureRewind);
-				
+
+				// Set volume, if enabled
 				if (Global.Config.SoundEnabledNormal)
+				{
 					atten = Global.Config.SoundVolume / 100.0f;
-				
-				if (_runloopFrameadvance && Global.Config.MuteFrameAdvance)
-				{
-					atten = 0;
-				}
 
-				if (isFastForwarding || IsTurboing || isRewinding)
-				{
-					atten *= Global.Config.SoundVolumeRWFF / 100.0f;
-					if (!Global.Config.SoundEnabledRWFF)
+					if (isFastForwarding || IsTurboing || isRewinding)
+					{
+						if (Global.Config.SoundEnabledRWFF)
+							atten *= Global.Config.SoundVolumeRWFF / 100.0f;
+						else
+							atten = 0;
+					}
+
+					// Mute if using Frame Advance/Frame Progress
+					if (_runloopFrameadvance && Global.Config.MuteFrameAdvance)
+					{
 						atten = 0;
+					}
 				}
-
+				
 				Global.MovieSession.HandleMovieOnFrameLoop();
 
 				coreskipaudio = IsTurboing && _currAviWriter == null;


### PR DESCRIPTION
1) Refactors volume calculations to be easier to follow by putting them near eachother.

2) Fixes Mute Frame Advance setting. Previously it didn't do anything. Now when you hold "F", it will mute as expected.

_[removed, but easy to add back in] 3) Allow Fast Forward Volume setting to be louder than Normal Volume. Previously it multiplied by the Normal Volume setting, which could only make it quieter._
