### PR TITLE
Added togglepause to the list of lua commands

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Tastudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Tastudio.cs
@@ -270,5 +270,14 @@ namespace BizHawk.Client.EmuHawk
 				};
 			}
 		}
+
+		[LuaMethodAttributes(
+			"togglepause",
+			"Toggles the current pause state"
+		)]
+		public static void TogglePause()
+		{
+			GlobalWin.MainForm.TogglePause();
+		}
 	}
 }


### PR DESCRIPTION
@zeromus I probably don't know what I am doing here but, I would like to be able to toggle pausing so that I can pause the emulator after I am done running my script and before I exit out of it. This way if I run my script for 1000 iterations, I don't have to sit around to see when the frame is that it stops or be required to set marker and hope the emulator doesn't crash by the time I get back to it.