### PR TITLE
MultiHawk: Make unreachable code in Mainform ctor reachable again.

### DIFF
--- a/BizHawk.Client.MultiHawk/Mainform.cs
+++ b/BizHawk.Client.MultiHawk/Mainform.cs
@@ -74,37 +74,37 @@ namespace BizHawk.Client.MultiHawk
 					return NesCartFile
 						.GetStream()
 						.ReadAllBytes();
-				};
-
-				Database.LoadDatabase(Path.Combine(PathManager.GetExeDirectoryAbsolute(), "gamedb", "gamedb.txt"));
-
-				Input.Initialize(this.Handle);
-				InitControls();
-
-				// TODO
-				//CoreFileProvider.SyncCoreCommInputSignals();
-
-				Global.ActiveController = new Controller(NullController.Instance.Definition);
-				Global.AutoFireController = Global.AutofireNullControls;
-				Global.AutofireStickyXORAdapter.SetOnOffPatternFromConfig();
-
-				Closing += (o, e) =>
-				{
-					Global.MovieSession.Movie.Stop();
-
-					foreach (var ew in EmulatorWindows.ToList())
-					{
-						ew.ShutDown();
-					}
-
-					SaveConfig();
-				};
-
-				if (Global.Config.MainWndx != -1 && Global.Config.MainWndy != -1 && Global.Config.SaveWindowPosition)
-				{
-					Location = new Point(Global.Config.MainWndx, Global.Config.MainWndy);
 				}
 			};
+
+			Database.LoadDatabase(Path.Combine(PathManager.GetExeDirectoryAbsolute(), "gamedb", "gamedb.txt"));
+
+			Input.Initialize(this.Handle);
+			InitControls();
+
+			// TODO
+			//CoreFileProvider.SyncCoreCommInputSignals();
+
+			Global.ActiveController = new Controller(NullController.Instance.Definition);
+			Global.AutoFireController = Global.AutofireNullControls;
+			Global.AutofireStickyXORAdapter.SetOnOffPatternFromConfig();
+
+			Closing += (o, e) =>
+			{
+				Global.MovieSession.Movie.Stop();
+
+				foreach (var ew in EmulatorWindows.ToList())
+				{
+					ew.ShutDown();
+				}
+
+				SaveConfig();
+			};
+
+			if (Global.Config.MainWndx != -1 && Global.Config.MainWndy != -1 && Global.Config.SaveWindowPosition)
+			{
+				Location = new Point(Global.Config.MainWndx, Global.Config.MainWndy);
+			}
 		}
 
 		// TODO: make this an actual property, set it when loading a Rom, and pass it dialogs, etc


### PR DESCRIPTION
I noticed an unreachable code warning when compiling, so I investigated.

This corrects a merge error from 0b4fc8b6a540ed43bdfde24bcc09f5cebf64f3ff that was incorrectly fixed in 20fb060c65bb7973862b399f8dc59ad28019c540.

Specifically, all code after the `NES.BootGodDB.GetDatabaseBytes` delegate creation was put inside the delegate instead of remaining after it. This made it unreachable and never execute, which in turn made it impossible to actually run MultiHawk.

This has been broken for over three months, which makes me wonder if anyone actually uses MultiHawk?