### PR TITLE
Timed SaveRAM flush to disk

### DIFF
--- a/BizHawk.Client.Common/PathManager.cs
+++ b/BizHawk.Client.Common/PathManager.cs
@@ -266,6 +266,12 @@ namespace BizHawk.Client.Common
 
 			return Path.Combine(MakeAbsolutePath(pathEntry.Path, game.System), name) + ".SaveRAM";
 		}
+		
+		public static string AutoSaveRamPath(GameInfo game)
+		{
+			var path = SaveRamPath(game);
+			return path.Insert(path.Length - 8, ".AutoSaveRAM");
+		}
 
 		public static string RetroSaveRAMDirectory(GameInfo game)
 		{

--- a/BizHawk.Client.Common/config/Config.cs
+++ b/BizHawk.Client.Common/config/Config.cs
@@ -134,7 +134,10 @@ namespace BizHawk.Client.Common
 		public string Update_IgnoreVersion = "";
 		public bool CDLAutoSave = true, CDLAutoStart = true;
 
-		public int FlushSaveRamFrames = 0;
+		private int _flushSaveRAMFrames;
+		public int FlushSaveRamFrames { get { return _flushSaveRAMFrames; } set { _flushSaveRAMFrames = value; } }
+		private bool _autosaveSaveRAM;
+		public bool AutosaveSaveRAM { get { return _autosaveSaveRAM; } set { _autosaveSaveRAM = value; } }
 		//check CurrentDomain_AssemblyResolve if you change the defaults or name of this key
 		public bool UseNLua = true; // Whether or not to use a good, reliable, memory-leak-free lua interface that is slower than the original luainterface
 

--- a/BizHawk.Client.Common/config/Config.cs
+++ b/BizHawk.Client.Common/config/Config.cs
@@ -114,6 +114,8 @@ namespace BizHawk.Client.Common
 		public bool ShowLogWindow = false;
 		public bool BackupSavestates = true;
 		public bool BackupSaveram = true;
+		private int _flushSaveRAMFrames = 5 * 60 * 60;
+		private bool _autosaveSaveRAM = false;
 		public bool SaveScreenshotWithStates = true;
 		public int BigScreenshotSize = 128 * 1024;
 		public bool NoLowResLargeScreenshotWithStates = false;
@@ -134,9 +136,7 @@ namespace BizHawk.Client.Common
 		public string Update_IgnoreVersion = "";
 		public bool CDLAutoSave = true, CDLAutoStart = true;
 
-		private int _flushSaveRAMFrames;
 		public int FlushSaveRamFrames { get { return _flushSaveRAMFrames; } set { _flushSaveRAMFrames = value; } }
-		private bool _autosaveSaveRAM;
 		public bool AutosaveSaveRAM { get { return _autosaveSaveRAM; } set { _autosaveSaveRAM = value; } }
 		//check CurrentDomain_AssemblyResolve if you change the defaults or name of this key
 		public bool UseNLua = true; // Whether or not to use a good, reliable, memory-leak-free lua interface that is slower than the original luainterface

--- a/BizHawk.Client.Common/config/Config.cs
+++ b/BizHawk.Client.Common/config/Config.cs
@@ -134,6 +134,7 @@ namespace BizHawk.Client.Common
 		public string Update_IgnoreVersion = "";
 		public bool CDLAutoSave = true, CDLAutoStart = true;
 
+		public int FlushSaveRamFrames = 0;
 		//check CurrentDomain_AssemblyResolve if you change the defaults or name of this key
 		public bool UseNLua = true; // Whether or not to use a good, reliable, memory-leak-free lua interface that is slower than the original luainterface
 

--- a/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -72,8 +72,16 @@
             this.SaveToCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.LoadCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SaveRAMSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.FlushSaveRAMMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.FlushSaveRAMMenuItem = new System.Windows.Forms.ToolStripMenuItem(); this.AutoFlushMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlushOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
+			this.AutoFlush1sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlush5sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlush15sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlush30sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlush60sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoFlush300sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.MovieSubMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.ReadonlyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
@@ -902,26 +910,96 @@
             this.LoadCurrentSlotMenuItem.Size = new System.Drawing.Size(178, 22);
             this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
             this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
-            // 
-            // SaveRAMSubMenu
-            // 
-            this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FlushSaveRAMMenuItem});
-            this.SaveRAMSubMenu.Name = "SaveRAMSubMenu";
-            this.SaveRAMSubMenu.Size = new System.Drawing.Size(159, 22);
-            this.SaveRAMSubMenu.Text = "Save &RAM";
-            this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.FlushSaveRAMSubMenu_DropDownOpened);
-            // 
-            // FlushSaveRAMMenuItem
-            // 
-            this.FlushSaveRAMMenuItem.Name = "FlushSaveRAMMenuItem";
-            this.FlushSaveRAMMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
-            this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-            // 
-            // toolStripMenuItem2
-            // 
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+
+			// 
+			// SaveRAMSubMenu
+			// 
+			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.FlushSaveRAMMenuItem, this.AutoFlushMenuItem});
+			this.SaveRAMSubMenu.Name = "SaveRAMSubMenu";
+			this.SaveRAMSubMenu.Size = new System.Drawing.Size(159, 22);
+			this.SaveRAMSubMenu.Text = "Save &RAM";
+			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRAMSubMenu_DropDownOpened);
+			// 
+			// FlushSaveRAMMenuItem
+			// 
+			this.FlushSaveRAMMenuItem.Name = "FlushSaveRAMMenuItem";
+			this.FlushSaveRAMMenuItem.Size = new System.Drawing.Size(156, 22);
+			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
+			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
+			// 
+			// AutoFlushMenuItem
+			// 
+			this.AutoFlushMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.AutoFlushOffToolStripMenuItem,
+			this.toolStripSeparator35,
+			this.AutoFlush1sToolStripMenuItem,
+			this.AutoFlush5sToolStripMenuItem,
+			this.AutoFlush15sToolStripMenuItem,
+			this.AutoFlush30sToolStripMenuItem,
+			this.AutoFlush60sToolStripMenuItem,
+			this.AutoFlush300sToolStripMenuItem });
+			this.AutoFlushMenuItem.Name = "AutoFlushMenuItem";
+			this.AutoFlushMenuItem.Size = new System.Drawing.Size(187, 22);
+			this.AutoFlushMenuItem.Text = "Flush &Save Ram Every";
+			this.AutoFlushMenuItem.DropDownOpened += new System.EventHandler(this.AutoFlushMenuItem_DropDownOpened);
+			// 
+			// AutoFlushOffToolStripMenuItem
+			// 
+			this.AutoFlushOffToolStripMenuItem.Name = "AutoFlushOffToolStripMenuItem";
+			this.AutoFlushOffToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlushOffToolStripMenuItem.Text = "Off";
+			this.AutoFlushOffToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// toolStripSeparator35
+			// 
+			this.toolStripSeparator35.Name = "toolStripSeparator35";
+			this.toolStripSeparator35.Size = new System.Drawing.Size(149, 6);
+			// 
+			// AutoFlush1sToolStripMenuItem
+			// 
+			this.AutoFlush1sToolStripMenuItem.Name = "AutoFlush1sToolStripMenuItem";
+			this.AutoFlush1sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush1sToolStripMenuItem.Text = "1s";
+			this.AutoFlush1sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// AutoFlush5sToolStripMenuItem
+			// 
+			this.AutoFlush5sToolStripMenuItem.Name = "AutoFlush5sToolStripMenuItem";
+			this.AutoFlush5sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush5sToolStripMenuItem.Text = "5s";
+			this.AutoFlush5sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// AutoFlush15sToolStripMenuItem
+			// 
+			this.AutoFlush15sToolStripMenuItem.Name = "AutoFlush15sToolStripMenuItem";
+			this.AutoFlush15sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush15sToolStripMenuItem.Text = "15s";
+			this.AutoFlush15sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// AutoFlush30sToolStripMenuItem
+			// 
+			this.AutoFlush30sToolStripMenuItem.Name = "AutoFlush30sToolStripMenuItem";
+			this.AutoFlush30sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush30sToolStripMenuItem.Text = "30s";
+			this.AutoFlush30sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// AutoFlush60sToolStripMenuItem
+			// 
+			this.AutoFlush60sToolStripMenuItem.Name = "AutoFlush60sToolStripMenuItem";
+			this.AutoFlush60sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush60sToolStripMenuItem.Text = "1m";
+			this.AutoFlush60sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
+			// 
+			// AutoFlush300sToolStripMenuItem
+			// 
+			this.AutoFlush300sToolStripMenuItem.Name = "AutoFlush300sToolStripMenuItem";
+			this.AutoFlush300sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.AutoFlush300sToolStripMenuItem.Text = "5m";
+			this.AutoFlush300sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);            // 
+																														   // toolStripMenuItem2
+																														   // 
+			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
             this.toolStripMenuItem2.Size = new System.Drawing.Size(156, 6);
             // 
             // MovieSubMenu
@@ -4358,6 +4436,14 @@
 		private System.Windows.Forms.ToolStripMenuItem IntvSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem IntVControllerSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SNESControllerConfigurationMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlushMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlushOffToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush1sToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush5sToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush15sToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush30sToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush60sToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem AutoFlush300sToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator35;
 		private System.Windows.Forms.ToolStripMenuItem C64DisksSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;

--- a/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -72,15 +72,7 @@
             this.SaveToCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.LoadCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SaveRAMSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.FlushSaveRAMMenuItem = new System.Windows.Forms.ToolStripMenuItem(); this.AutoFlushMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlushOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoFlush1sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlush5sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlush15sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlush30sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlush60sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoFlush300sToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.FlushSaveRAMMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.MovieSubMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.ReadonlyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -246,8 +238,9 @@
             this.coreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.quickNESToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nesHawkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator34 = new System.Windows.Forms.ToolStripSeparator();
-            this.NESPPUViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator34 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
+			this.NESPPUViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.NESNametableViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.NESGameGenieCodesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.musicRipperToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -337,7 +330,6 @@
             this.SnesOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ColecoSubMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.ColecoControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
             this.ColecoSkipBiosMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.N64SubMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.N64PluginSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -915,7 +907,7 @@
 			// SaveRAMSubMenu
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FlushSaveRAMMenuItem, this.AutoFlushMenuItem});
+			this.FlushSaveRAMMenuItem});
 			this.SaveRAMSubMenu.Name = "SaveRAMSubMenu";
 			this.SaveRAMSubMenu.Size = new System.Drawing.Size(159, 22);
 			this.SaveRAMSubMenu.Text = "Save &RAM";
@@ -927,77 +919,7 @@
 			this.FlushSaveRAMMenuItem.Size = new System.Drawing.Size(156, 22);
 			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
 			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-			// 
-			// AutoFlushMenuItem
-			// 
-			this.AutoFlushMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AutoFlushOffToolStripMenuItem,
-			this.toolStripSeparator35,
-			this.AutoFlush1sToolStripMenuItem,
-			this.AutoFlush5sToolStripMenuItem,
-			this.AutoFlush15sToolStripMenuItem,
-			this.AutoFlush30sToolStripMenuItem,
-			this.AutoFlush60sToolStripMenuItem,
-			this.AutoFlush300sToolStripMenuItem });
-			this.AutoFlushMenuItem.Name = "AutoFlushMenuItem";
-			this.AutoFlushMenuItem.Size = new System.Drawing.Size(187, 22);
-			this.AutoFlushMenuItem.Text = "Flush &Save Ram Every";
-			this.AutoFlushMenuItem.DropDownOpened += new System.EventHandler(this.AutoFlushMenuItem_DropDownOpened);
-			// 
-			// AutoFlushOffToolStripMenuItem
-			// 
-			this.AutoFlushOffToolStripMenuItem.Name = "AutoFlushOffToolStripMenuItem";
-			this.AutoFlushOffToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlushOffToolStripMenuItem.Text = "Off";
-			this.AutoFlushOffToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// toolStripSeparator35
-			// 
-			this.toolStripSeparator35.Name = "toolStripSeparator35";
-			this.toolStripSeparator35.Size = new System.Drawing.Size(149, 6);
-			// 
-			// AutoFlush1sToolStripMenuItem
-			// 
-			this.AutoFlush1sToolStripMenuItem.Name = "AutoFlush1sToolStripMenuItem";
-			this.AutoFlush1sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush1sToolStripMenuItem.Text = "1s";
-			this.AutoFlush1sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// AutoFlush5sToolStripMenuItem
-			// 
-			this.AutoFlush5sToolStripMenuItem.Name = "AutoFlush5sToolStripMenuItem";
-			this.AutoFlush5sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush5sToolStripMenuItem.Text = "5s";
-			this.AutoFlush5sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// AutoFlush15sToolStripMenuItem
-			// 
-			this.AutoFlush15sToolStripMenuItem.Name = "AutoFlush15sToolStripMenuItem";
-			this.AutoFlush15sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush15sToolStripMenuItem.Text = "15s";
-			this.AutoFlush15sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// AutoFlush30sToolStripMenuItem
-			// 
-			this.AutoFlush30sToolStripMenuItem.Name = "AutoFlush30sToolStripMenuItem";
-			this.AutoFlush30sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush30sToolStripMenuItem.Text = "30s";
-			this.AutoFlush30sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// AutoFlush60sToolStripMenuItem
-			// 
-			this.AutoFlush60sToolStripMenuItem.Name = "AutoFlush60sToolStripMenuItem";
-			this.AutoFlush60sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush60sToolStripMenuItem.Text = "1m";
-			this.AutoFlush60sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);
-			// 
-			// AutoFlush300sToolStripMenuItem
-			// 
-			this.AutoFlush300sToolStripMenuItem.Name = "AutoFlush300sToolStripMenuItem";
-			this.AutoFlush300sToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-			this.AutoFlush300sToolStripMenuItem.Text = "5m";
-			this.AutoFlush300sToolStripMenuItem.Click += new System.EventHandler(this.AutoFlushMenuItem_Click);            // 
-																														   // toolStripMenuItem2
+			// toolStripMenuItem2
 																														   // 
 			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
             this.toolStripMenuItem2.Size = new System.Drawing.Size(156, 6);
@@ -4387,6 +4309,7 @@
 		private System.Windows.Forms.ToolStripMenuItem quickNESToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem nesHawkToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator34;
+		private System.Windows.Forms.ToolStripSeparator toolStripSeparator35;
 		private System.Windows.Forms.ToolStripMenuItem GBACoreSelectionSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem GBAmGBAMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GBAVBANextMenuItem;
@@ -4436,15 +4359,6 @@
 		private System.Windows.Forms.ToolStripMenuItem IntvSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem IntVControllerSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SNESControllerConfigurationMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlushMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlushOffToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush1sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush5sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush15sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush30sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush60sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoFlush300sToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator35;
 		private System.Windows.Forms.ToolStripMenuItem C64DisksSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;
 		private System.Windows.Forms.ToolStripMenuItem sNESToolStripMenuItem;

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -53,6 +53,7 @@ namespace BizHawk.Client.EmuHawk
 			SaveRAMSubMenu.Enabled = hasSaveRam;
 			if (SaveRAMSubMenu.Font.Bold != needBold)
 			{
+				AutoFlushMenuItem.Font = new Font(AutoFlushMenuItem.Font, FontStyle.Regular);
 				var font = new Font(SaveRAMSubMenu.Font, needBold ? FontStyle.Bold : FontStyle.Regular);
 				SaveRAMSubMenu.Font = font;
 			}
@@ -229,6 +230,24 @@ namespace BizHawk.Client.EmuHawk
 		private void FlushSaveRAMSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			FlushSaveRAMMenuItem.ShortcutKeyDisplayString = Global.Config.HotkeyBindings["Flush SRAM"].Bindings;
+			AutoFlushMenuItem.Checked = Global.Config.FlushSaveRamFrames > 0;
+		}
+
+		private void SaveRAMSubMenu_DropDownOpened(object sender, EventArgs e)
+		{
+			FlushSaveRAMMenuItem.ShortcutKeyDisplayString = Global.Config.HotkeyBindings["Save SRAM"].Bindings;
+			AutoFlushMenuItem.Checked = Global.Config.FlushSaveRamFrames > 0;
+		}
+
+		private void AutoFlushMenuItem_DropDownOpened(object sender, EventArgs e)
+		{
+			AutoFlushOffToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 0;
+			AutoFlush1sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 1 * 60;
+			AutoFlush5sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 5 * 60;
+			AutoFlush15sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 15 * 60;
+			AutoFlush30sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 30 * 60;
+			AutoFlush60sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 60 * 60;
+			AutoFlush300sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 300 * 60;
 		}
 
 		private void MovieSubMenu_DropDownOpened(object sender, EventArgs e)
@@ -451,6 +470,22 @@ namespace BizHawk.Client.EmuHawk
 		private void FlushSaveRAMMenuItem_Click(object sender, EventArgs e)
 		{
 			FlushSaveRAM();
+		}
+
+		private void AutoFlushMenuItem_Click(object sender, EventArgs e)
+		{
+			switch (((ToolStripMenuItem)sender).Text)
+			{
+				case "Off": Global.Config.FlushSaveRamFrames = 0; break;
+				case "1s": Global.Config.FlushSaveRamFrames = 1 * 60; break;
+				case "5s": Global.Config.FlushSaveRamFrames = 5 * 60; break;
+				case "15s": Global.Config.FlushSaveRamFrames = 15 * 60; break;
+				case "30s": Global.Config.FlushSaveRamFrames = 30 * 60; break;
+				case "1m": Global.Config.FlushSaveRamFrames = 60 * 60; break;
+				case "5m": Global.Config.FlushSaveRamFrames = 300 * 60; break;
+			}
+			if (_flushSaveRamIn > Global.Config.FlushSaveRamFrames)
+				_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
 		}
 
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -453,22 +453,6 @@ namespace BizHawk.Client.EmuHawk
 			FlushSaveRAM();
 		}
 
-		private void AutoFlushMenuItem_Click(object sender, EventArgs e)
-		{
-			switch (((ToolStripMenuItem)sender).Text)
-			{
-				case "Off": Global.Config.FlushSaveRamFrames = 0; break;
-				case "1s": Global.Config.FlushSaveRamFrames = 1 * 60; break;
-				case "5s": Global.Config.FlushSaveRamFrames = 5 * 60; break;
-				case "15s": Global.Config.FlushSaveRamFrames = 15 * 60; break;
-				case "30s": Global.Config.FlushSaveRamFrames = 30 * 60; break;
-				case "1m": Global.Config.FlushSaveRamFrames = 60 * 60; break;
-				case "5m": Global.Config.FlushSaveRamFrames = 300 * 60; break;
-			}
-			if (_flushSaveRamIn > Global.Config.FlushSaveRamFrames)
-				_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
-		}
-
 		private void ReadonlyMenuItem_Click(object sender, EventArgs e)
 		{
 			ToggleReadOnly();

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -53,7 +53,6 @@ namespace BizHawk.Client.EmuHawk
 			SaveRAMSubMenu.Enabled = hasSaveRam;
 			if (SaveRAMSubMenu.Font.Bold != needBold)
 			{
-				AutoFlushMenuItem.Font = new Font(AutoFlushMenuItem.Font, FontStyle.Regular);
 				var font = new Font(SaveRAMSubMenu.Font, needBold ? FontStyle.Bold : FontStyle.Regular);
 				SaveRAMSubMenu.Font = font;
 			}
@@ -227,27 +226,9 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void FlushSaveRAMSubMenu_DropDownOpened(object sender, EventArgs e)
-		{
-			FlushSaveRAMMenuItem.ShortcutKeyDisplayString = Global.Config.HotkeyBindings["Flush SRAM"].Bindings;
-			AutoFlushMenuItem.Checked = Global.Config.FlushSaveRamFrames > 0;
-		}
-
 		private void SaveRAMSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
-			FlushSaveRAMMenuItem.ShortcutKeyDisplayString = Global.Config.HotkeyBindings["Save SRAM"].Bindings;
-			AutoFlushMenuItem.Checked = Global.Config.FlushSaveRamFrames > 0;
-		}
-
-		private void AutoFlushMenuItem_DropDownOpened(object sender, EventArgs e)
-		{
-			AutoFlushOffToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 0;
-			AutoFlush1sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 1 * 60;
-			AutoFlush5sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 5 * 60;
-			AutoFlush15sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 15 * 60;
-			AutoFlush30sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 30 * 60;
-			AutoFlush60sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 60 * 60;
-			AutoFlush300sToolStripMenuItem.Checked = Global.Config.FlushSaveRamFrames == 300 * 60;
+			FlushSaveRAMMenuItem.ShortcutKeyDisplayString = Global.Config.HotkeyBindings["Flush SaveRAM"].Bindings;
 		}
 
 		private void MovieSubMenu_DropDownOpened(object sender, EventArgs e)

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -406,6 +406,8 @@ namespace BizHawk.Client.EmuHawk
 				PauseEmulator();
 			}
 
+			_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
+
 			// start dumping, if appropriate
 			if (argParse.cmdDumpType != null && argParse.cmdDumpName != null)
 			{
@@ -1415,6 +1417,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public PresentationPanel PresentationPanel { get; }
 
+		private int _flushSaveRamIn;
 		#endregion
 
 		#region Private methods
@@ -1635,6 +1638,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					writer.Write(saveram, 0, saveram.Length);
 				}
+				_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
 
 				writer.Close();
 			}
@@ -2906,6 +2910,15 @@ namespace BizHawk.Client.EmuHawk
 
 				Global.MovieSession.HandleMovieOnFrameLoop();
 
+				if (Global.Config.FlushSaveRamFrames > 0)
+				{
+					_flushSaveRamIn -= 1;
+					if (_flushSaveRamIn <= 0)
+					{
+						FlushSaveRAM();
+						_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
+					}
+				}
 				// why not skip audio if the user doesnt want sound
 				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing) || (_currAviWriter?.UsesAudio ?? false);
 				if (!renderSound)

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2912,7 +2912,7 @@ namespace BizHawk.Client.EmuHawk
 
 				Global.MovieSession.HandleMovieOnFrameLoop();
 
-				if (Global.Config.FlushSaveRamFrames > 0)
+				if (Global.Config.AutosaveSaveRAM && Global.Config.FlushSaveRamFrames > 0)
 				{
 					_flushSaveRamIn -= 1;
 					if (_flushSaveRamIn <= 0)

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1607,11 +1607,13 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		public void FlushSaveRAM()
+		public void FlushSaveRAM(bool autosave = false)
 		{
 			if (Emulator.HasSaveRam())
 			{
 				var path = PathManager.SaveRamPath(Global.Game);
+				if (autosave)
+					path=path.Insert(path.Length-8, ".autosave"); //becomes path\name.autosave.SaveRAM
 				var f = new FileInfo(path);
 				if (f.Directory != null && !f.Directory.Exists)
 				{
@@ -2915,7 +2917,7 @@ namespace BizHawk.Client.EmuHawk
 					_flushSaveRamIn -= 1;
 					if (_flushSaveRamIn <= 0)
 					{
-						FlushSaveRAM();
+						FlushSaveRAM(true);
 						_flushSaveRamIn = Global.Config.FlushSaveRamFrames;
 					}
 				}

--- a/BizHawk.Client.EmuHawk/config/GuiOptions.Designer.cs
+++ b/BizHawk.Client.EmuHawk/config/GuiOptions.Designer.cs
@@ -48,6 +48,17 @@
             this.EnableContextMenuCheckbox = new System.Windows.Forms.CheckBox();
             this.PauseWhenMenuActivatedCheckbox = new System.Windows.Forms.CheckBox();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.AutosaveSRAMtextBox = new System.Windows.Forms.NumericUpDown();
+            this.AutosaveSRAMradioButton1 = new System.Windows.Forms.RadioButton();
+            this.label8 = new System.Windows.Forms.Label();
+            this.AutosaveSRAMradioButton2 = new System.Windows.Forms.RadioButton();
+            this.AutosaveSRAMradioButton3 = new System.Windows.Forms.RadioButton();
+            this.AutosaveSRAMCheckbox = new System.Windows.Forms.CheckBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.label7 = new System.Windows.Forms.Label();
+            this.LuaInterfaceRadio = new System.Windows.Forms.RadioButton();
+            this.NLuaRadio = new System.Windows.Forms.RadioButton();
             this.label6 = new System.Windows.Forms.Label();
             this.cbMoviesInAWE = new System.Windows.Forms.CheckBox();
             this.label5 = new System.Windows.Forms.Label();
@@ -56,20 +67,16 @@
             this.label12 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
             this.FrameAdvSkipLagCheckbox = new System.Windows.Forms.CheckBox();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
             this.BackupSRamCheckbox = new System.Windows.Forms.CheckBox();
             this.label4 = new System.Windows.Forms.Label();
             this.LogWindowAsConsoleCheckbox = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.NLuaRadio = new System.Windows.Forms.RadioButton();
-            this.LuaInterfaceRadio = new System.Windows.Forms.RadioButton();
-            this.label7 = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tabPage3.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.AutosaveSRAMtextBox)).BeginInit();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -270,6 +277,8 @@
             // 
             // tabPage3
             // 
+            this.tabPage3.Controls.Add(this.groupBox2);
+            this.tabPage3.Controls.Add(this.AutosaveSRAMCheckbox);
             this.tabPage3.Controls.Add(this.panel1);
             this.tabPage3.Controls.Add(this.label6);
             this.tabPage3.Controls.Add(this.cbMoviesInAWE);
@@ -279,8 +288,6 @@
             this.tabPage3.Controls.Add(this.label12);
             this.tabPage3.Controls.Add(this.label13);
             this.tabPage3.Controls.Add(this.FrameAdvSkipLagCheckbox);
-            this.tabPage3.Controls.Add(this.label9);
-            this.tabPage3.Controls.Add(this.label10);
             this.tabPage3.Controls.Add(this.BackupSRamCheckbox);
             this.tabPage3.Controls.Add(this.label4);
             this.tabPage3.Controls.Add(this.LogWindowAsConsoleCheckbox);
@@ -290,6 +297,126 @@
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Advanced";
             this.tabPage3.UseVisualStyleBackColor = true;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.AutosaveSRAMtextBox);
+            this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton1);
+            this.groupBox2.Controls.Add(this.label8);
+            this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton2);
+            this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton3);
+            this.groupBox2.Location = new System.Drawing.Point(27, 74);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(0);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(244, 38);
+            this.groupBox2.TabIndex = 27;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Autosave SaveRAM to .autosave.SaveRAM";
+            // 
+            // AutosaveSRAMtextBox
+            // 
+            this.AutosaveSRAMtextBox.Location = new System.Drawing.Point(106, 14);
+            this.AutosaveSRAMtextBox.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.AutosaveSRAMtextBox.Name = "AutosaveSRAMtextBox";
+            this.AutosaveSRAMtextBox.Size = new System.Drawing.Size(50, 20);
+            this.AutosaveSRAMtextBox.TabIndex = 27;
+            // 
+            // AutosaveSRAMradioButton1
+            // 
+            this.AutosaveSRAMradioButton1.AutoSize = true;
+            this.AutosaveSRAMradioButton1.Location = new System.Drawing.Point(6, 14);
+            this.AutosaveSRAMradioButton1.Name = "AutosaveSRAMradioButton1";
+            this.AutosaveSRAMradioButton1.Size = new System.Drawing.Size(36, 17);
+            this.AutosaveSRAMradioButton1.TabIndex = 22;
+            this.AutosaveSRAMradioButton1.TabStop = true;
+            this.AutosaveSRAMradioButton1.Text = "5s";
+            this.AutosaveSRAMradioButton1.UseVisualStyleBackColor = true;
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(165, 18);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(47, 13);
+            this.label8.TabIndex = 26;
+            this.label8.Text = "seconds";
+            // 
+            // AutosaveSRAMradioButton2
+            // 
+            this.AutosaveSRAMradioButton2.AutoSize = true;
+            this.AutosaveSRAMradioButton2.Location = new System.Drawing.Point(46, 14);
+            this.AutosaveSRAMradioButton2.Name = "AutosaveSRAMradioButton2";
+            this.AutosaveSRAMradioButton2.Size = new System.Drawing.Size(39, 17);
+            this.AutosaveSRAMradioButton2.TabIndex = 23;
+            this.AutosaveSRAMradioButton2.TabStop = true;
+            this.AutosaveSRAMradioButton2.Text = "5m";
+            this.AutosaveSRAMradioButton2.UseVisualStyleBackColor = true;
+            // 
+            // AutosaveSRAMradioButton3
+            // 
+            this.AutosaveSRAMradioButton3.AutoSize = true;
+            this.AutosaveSRAMradioButton3.Location = new System.Drawing.Point(88, 16);
+            this.AutosaveSRAMradioButton3.Name = "AutosaveSRAMradioButton3";
+            this.AutosaveSRAMradioButton3.Size = new System.Drawing.Size(14, 13);
+            this.AutosaveSRAMradioButton3.TabIndex = 24;
+            this.AutosaveSRAMradioButton3.TabStop = true;
+            this.AutosaveSRAMradioButton3.UseVisualStyleBackColor = true;
+            this.AutosaveSRAMradioButton3.CheckedChanged += new System.EventHandler(this.AutosaveSRAMradioButton3_CheckedChanged);
+            // 
+            // AutosaveSRAMCheckbox
+            // 
+            this.AutosaveSRAMCheckbox.AutoSize = true;
+            this.AutosaveSRAMCheckbox.Location = new System.Drawing.Point(6, 77);
+            this.AutosaveSRAMCheckbox.Name = "AutosaveSRAMCheckbox";
+            this.AutosaveSRAMCheckbox.Size = new System.Drawing.Size(15, 14);
+            this.AutosaveSRAMCheckbox.TabIndex = 21;
+            this.AutosaveSRAMCheckbox.UseVisualStyleBackColor = true;
+            this.AutosaveSRAMCheckbox.CheckedChanged += new System.EventHandler(this.AutosaveSRAMCheckbox_CheckedChanged);
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.label7);
+            this.panel1.Controls.Add(this.LuaInterfaceRadio);
+            this.panel1.Controls.Add(this.NLuaRadio);
+            this.panel1.Location = new System.Drawing.Point(6, 312);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(377, 61);
+            this.panel1.TabIndex = 20;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(3, 1);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(50, 13);
+            this.label7.TabIndex = 2;
+            this.label7.Text = "Lua Core";
+            // 
+            // LuaInterfaceRadio
+            // 
+            this.LuaInterfaceRadio.AutoSize = true;
+            this.LuaInterfaceRadio.Location = new System.Drawing.Point(4, 36);
+            this.LuaInterfaceRadio.Name = "LuaInterfaceRadio";
+            this.LuaInterfaceRadio.Size = new System.Drawing.Size(338, 17);
+            this.LuaInterfaceRadio.TabIndex = 1;
+            this.LuaInterfaceRadio.TabStop = true;
+            this.LuaInterfaceRadio.Text = "Lua+LuaInterface - Faster but memory leaks,  use at your own risk!";
+            this.LuaInterfaceRadio.UseVisualStyleBackColor = true;
+            // 
+            // NLuaRadio
+            // 
+            this.NLuaRadio.AutoSize = true;
+            this.NLuaRadio.Location = new System.Drawing.Point(4, 17);
+            this.NLuaRadio.Name = "NLuaRadio";
+            this.NLuaRadio.Size = new System.Drawing.Size(194, 17);
+            this.NLuaRadio.TabIndex = 0;
+            this.NLuaRadio.TabStop = true;
+            this.NLuaRadio.Text = "NLua+KopiLua - Reliable but slower";
+            this.NLuaRadio.UseVisualStyleBackColor = true;
             // 
             // label6
             // 
@@ -370,32 +497,14 @@
             this.FrameAdvSkipLagCheckbox.Text = "Frame advance button skips non-input frames";
             this.FrameAdvSkipLagCheckbox.UseVisualStyleBackColor = true;
             // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(24, 94);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(99, 13);
-            this.label9.TabIndex = 11;
-            this.label9.Text = "before overwriting it";
-            // 
-            // label10
-            // 
-            this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(24, 81);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(277, 13);
-            this.label10.TabIndex = 10;
-            this.label10.Text = "When set, the client will make a backup copy of saveram";
-            // 
             // BackupSRamCheckbox
             // 
             this.BackupSRamCheckbox.AutoSize = true;
-            this.BackupSRamCheckbox.Location = new System.Drawing.Point(6, 61);
+            this.BackupSRamCheckbox.Location = new System.Drawing.Point(6, 55);
             this.BackupSRamCheckbox.Name = "BackupSRamCheckbox";
-            this.BackupSRamCheckbox.Size = new System.Drawing.Size(108, 17);
+            this.BackupSRamCheckbox.Size = new System.Drawing.Size(203, 17);
             this.BackupSRamCheckbox.TabIndex = 9;
-            this.BackupSRamCheckbox.Text = "Backup Saveram";
+            this.BackupSRamCheckbox.Text = "Backup SaveRAM to .SaveRAM.bak";
             this.BackupSRamCheckbox.UseVisualStyleBackColor = true;
             // 
             // label4
@@ -416,47 +525,6 @@
             this.LogWindowAsConsoleCheckbox.TabIndex = 1;
             this.LogWindowAsConsoleCheckbox.Text = "Create the log window as a console window";
             this.LogWindowAsConsoleCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.label7);
-            this.panel1.Controls.Add(this.LuaInterfaceRadio);
-            this.panel1.Controls.Add(this.NLuaRadio);
-            this.panel1.Location = new System.Drawing.Point(6, 312);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(377, 61);
-            this.panel1.TabIndex = 20;
-            // 
-            // NLuaRadio
-            // 
-            this.NLuaRadio.AutoSize = true;
-            this.NLuaRadio.Location = new System.Drawing.Point(4, 17);
-            this.NLuaRadio.Name = "NLuaRadio";
-            this.NLuaRadio.Size = new System.Drawing.Size(194, 17);
-            this.NLuaRadio.TabIndex = 0;
-            this.NLuaRadio.TabStop = true;
-            this.NLuaRadio.Text = "NLua+KopiLua - Reliable but slower";
-            this.NLuaRadio.UseVisualStyleBackColor = true;
-            // 
-            // LuaInterfaceRadio
-            // 
-            this.LuaInterfaceRadio.AutoSize = true;
-            this.LuaInterfaceRadio.Location = new System.Drawing.Point(4, 36);
-            this.LuaInterfaceRadio.Name = "LuaInterfaceRadio";
-            this.LuaInterfaceRadio.Size = new System.Drawing.Size(338, 17);
-            this.LuaInterfaceRadio.TabIndex = 1;
-            this.LuaInterfaceRadio.TabStop = true;
-            this.LuaInterfaceRadio.Text = "Lua+LuaInterface - Faster but memory leaks,  use at your own risk!";
-            this.LuaInterfaceRadio.UseVisualStyleBackColor = true;
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 1);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(50, 13);
-            this.label7.TabIndex = 2;
-            this.label7.Text = "Lua Core";
             // 
             // EmuHawkOptions
             // 
@@ -480,6 +548,9 @@
             this.groupBox1.PerformLayout();
             this.tabPage3.ResumeLayout(false);
             this.tabPage3.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.AutosaveSRAMtextBox)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.ResumeLayout(false);
@@ -508,8 +579,6 @@
 		private System.Windows.Forms.Label label4;
 		private System.Windows.Forms.ToolTip toolTip1;
 		private System.Windows.Forms.CheckBox BackupSRamCheckbox;
-		private System.Windows.Forms.Label label9;
-		private System.Windows.Forms.Label label10;
 		private System.Windows.Forms.CheckBox FrameAdvSkipLagCheckbox;
 		private System.Windows.Forms.Label label12;
 		private System.Windows.Forms.Label label13;
@@ -525,5 +594,12 @@
 		private System.Windows.Forms.Label label7;
 		private System.Windows.Forms.RadioButton LuaInterfaceRadio;
 		private System.Windows.Forms.RadioButton NLuaRadio;
+		private System.Windows.Forms.CheckBox AutosaveSRAMCheckbox;
+		private System.Windows.Forms.Label label8;
+		private System.Windows.Forms.RadioButton AutosaveSRAMradioButton3;
+		private System.Windows.Forms.RadioButton AutosaveSRAMradioButton2;
+		private System.Windows.Forms.RadioButton AutosaveSRAMradioButton1;
+		private System.Windows.Forms.GroupBox groupBox2;
+		private System.Windows.Forms.NumericUpDown AutosaveSRAMtextBox;
 	}
 }

--- a/BizHawk.Client.EmuHawk/config/GuiOptions.Designer.cs
+++ b/BizHawk.Client.EmuHawk/config/GuiOptions.Designer.cs
@@ -71,6 +71,8 @@
             this.label4 = new System.Windows.Forms.Label();
             this.LogWindowAsConsoleCheckbox = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.label9 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -130,7 +132,7 @@
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(386, 368);
+            this.tabPage1.Size = new System.Drawing.Size(386, 376);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -300,22 +302,24 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.label10);
+            this.groupBox2.Controls.Add(this.label9);
             this.groupBox2.Controls.Add(this.AutosaveSRAMtextBox);
             this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton1);
             this.groupBox2.Controls.Add(this.label8);
             this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton2);
             this.groupBox2.Controls.Add(this.AutosaveSRAMradioButton3);
-            this.groupBox2.Location = new System.Drawing.Point(27, 74);
+            this.groupBox2.Location = new System.Drawing.Point(27, 59);
             this.groupBox2.Margin = new System.Windows.Forms.Padding(0);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(244, 38);
+            this.groupBox2.Size = new System.Drawing.Size(265, 60);
             this.groupBox2.TabIndex = 27;
             this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Autosave SaveRAM to .autosave.SaveRAM";
+            this.groupBox2.Text = "AutoSaveRAM";
             // 
             // AutosaveSRAMtextBox
             // 
-            this.AutosaveSRAMtextBox.Location = new System.Drawing.Point(106, 14);
+            this.AutosaveSRAMtextBox.Location = new System.Drawing.Point(151, 33);
             this.AutosaveSRAMtextBox.Maximum = new decimal(new int[] {
             100000,
             0,
@@ -328,7 +332,7 @@
             // AutosaveSRAMradioButton1
             // 
             this.AutosaveSRAMradioButton1.AutoSize = true;
-            this.AutosaveSRAMradioButton1.Location = new System.Drawing.Point(6, 14);
+            this.AutosaveSRAMradioButton1.Location = new System.Drawing.Point(48, 33);
             this.AutosaveSRAMradioButton1.Name = "AutosaveSRAMradioButton1";
             this.AutosaveSRAMradioButton1.Size = new System.Drawing.Size(36, 17);
             this.AutosaveSRAMradioButton1.TabIndex = 22;
@@ -339,16 +343,16 @@
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(165, 18);
+            this.label8.Location = new System.Drawing.Point(202, 35);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(47, 13);
+            this.label8.Size = new System.Drawing.Size(12, 13);
             this.label8.TabIndex = 26;
-            this.label8.Text = "seconds";
+            this.label8.Text = "s";
             // 
             // AutosaveSRAMradioButton2
             // 
             this.AutosaveSRAMradioButton2.AutoSize = true;
-            this.AutosaveSRAMradioButton2.Location = new System.Drawing.Point(46, 14);
+            this.AutosaveSRAMradioButton2.Location = new System.Drawing.Point(90, 34);
             this.AutosaveSRAMradioButton2.Name = "AutosaveSRAMradioButton2";
             this.AutosaveSRAMradioButton2.Size = new System.Drawing.Size(39, 17);
             this.AutosaveSRAMradioButton2.TabIndex = 23;
@@ -359,7 +363,7 @@
             // AutosaveSRAMradioButton3
             // 
             this.AutosaveSRAMradioButton3.AutoSize = true;
-            this.AutosaveSRAMradioButton3.Location = new System.Drawing.Point(88, 16);
+            this.AutosaveSRAMradioButton3.Location = new System.Drawing.Point(131, 35);
             this.AutosaveSRAMradioButton3.Name = "AutosaveSRAMradioButton3";
             this.AutosaveSRAMradioButton3.Size = new System.Drawing.Size(14, 13);
             this.AutosaveSRAMradioButton3.TabIndex = 24;
@@ -370,7 +374,7 @@
             // AutosaveSRAMCheckbox
             // 
             this.AutosaveSRAMCheckbox.AutoSize = true;
-            this.AutosaveSRAMCheckbox.Location = new System.Drawing.Point(6, 77);
+            this.AutosaveSRAMCheckbox.Location = new System.Drawing.Point(6, 62);
             this.AutosaveSRAMCheckbox.Name = "AutosaveSRAMCheckbox";
             this.AutosaveSRAMCheckbox.Size = new System.Drawing.Size(15, 14);
             this.AutosaveSRAMCheckbox.TabIndex = 21;
@@ -462,7 +466,7 @@
             // LuaDuringTurboCheckbox
             // 
             this.LuaDuringTurboCheckbox.AutoSize = true;
-            this.LuaDuringTurboCheckbox.Location = new System.Drawing.Point(6, 174);
+            this.LuaDuringTurboCheckbox.Location = new System.Drawing.Point(6, 178);
             this.LuaDuringTurboCheckbox.Name = "LuaDuringTurboCheckbox";
             this.LuaDuringTurboCheckbox.Size = new System.Drawing.Size(166, 17);
             this.LuaDuringTurboCheckbox.TabIndex = 15;
@@ -472,7 +476,7 @@
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(24, 149);
+            this.label12.Location = new System.Drawing.Point(24, 162);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(231, 13);
             this.label12.TabIndex = 14;
@@ -481,7 +485,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(24, 136);
+            this.label13.Location = new System.Drawing.Point(24, 149);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(268, 13);
             this.label13.TabIndex = 13;
@@ -490,7 +494,7 @@
             // FrameAdvSkipLagCheckbox
             // 
             this.FrameAdvSkipLagCheckbox.AutoSize = true;
-            this.FrameAdvSkipLagCheckbox.Location = new System.Drawing.Point(6, 116);
+            this.FrameAdvSkipLagCheckbox.Location = new System.Drawing.Point(6, 129);
             this.FrameAdvSkipLagCheckbox.Name = "FrameAdvSkipLagCheckbox";
             this.FrameAdvSkipLagCheckbox.Size = new System.Drawing.Size(241, 17);
             this.FrameAdvSkipLagCheckbox.TabIndex = 12;
@@ -500,7 +504,7 @@
             // BackupSRamCheckbox
             // 
             this.BackupSRamCheckbox.AutoSize = true;
-            this.BackupSRamCheckbox.Location = new System.Drawing.Point(6, 55);
+            this.BackupSRamCheckbox.Location = new System.Drawing.Point(6, 39);
             this.BackupSRamCheckbox.Name = "BackupSRamCheckbox";
             this.BackupSRamCheckbox.Size = new System.Drawing.Size(203, 17);
             this.BackupSRamCheckbox.TabIndex = 9;
@@ -510,7 +514,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(24, 37);
+            this.label4.Location = new System.Drawing.Point(24, 23);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(234, 13);
             this.label4.TabIndex = 2;
@@ -519,12 +523,30 @@
             // LogWindowAsConsoleCheckbox
             // 
             this.LogWindowAsConsoleCheckbox.AutoSize = true;
-            this.LogWindowAsConsoleCheckbox.Location = new System.Drawing.Point(6, 17);
+            this.LogWindowAsConsoleCheckbox.Location = new System.Drawing.Point(6, 3);
             this.LogWindowAsConsoleCheckbox.Name = "LogWindowAsConsoleCheckbox";
             this.LogWindowAsConsoleCheckbox.Size = new System.Drawing.Size(233, 17);
             this.LogWindowAsConsoleCheckbox.TabIndex = 1;
             this.LogWindowAsConsoleCheckbox.Text = "Create the log window as a console window";
             this.LogWindowAsConsoleCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(6, 16);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(225, 13);
+            this.label9.TabIndex = 28;
+            this.label9.Text = "Save SaveRAM to .AutoSaveRAM.SaveRAM";
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(9, 34);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(33, 13);
+            this.label10.TabIndex = 29;
+            this.label10.Text = "every";
             // 
             // EmuHawkOptions
             // 
@@ -601,5 +623,7 @@
 		private System.Windows.Forms.RadioButton AutosaveSRAMradioButton1;
 		private System.Windows.Forms.GroupBox groupBox2;
 		private System.Windows.Forms.NumericUpDown AutosaveSRAMtextBox;
+		private System.Windows.Forms.Label label10;
+		private System.Windows.Forms.Label label9;
 	}
 }

--- a/BizHawk.Client.EmuHawk/config/GuiOptions.cs
+++ b/BizHawk.Client.EmuHawk/config/GuiOptions.cs
@@ -89,6 +89,8 @@ namespace BizHawk.Client.EmuHawk
 			Global.Config.BackupSaveram = BackupSRamCheckbox.Checked;
 			Global.Config.AutosaveSaveRAM = AutosaveSRAMCheckbox.Checked;
 			Global.Config.FlushSaveRamFrames = AutosaveSaveRAMSeconds * 60;
+			if (GlobalWin.MainForm.FlushSaveRamIn > Global.Config.FlushSaveRamFrames)
+				GlobalWin.MainForm.FlushSaveRamIn = Global.Config.FlushSaveRamFrames;
 			Global.Config.SkipLagFrame = FrameAdvSkipLagCheckbox.Checked;
 			Global.Config.WIN32_CONSOLE = LogWindowAsConsoleCheckbox.Checked;
 			Global.Config.RunLuaDuringTurbo = LuaDuringTurboCheckbox.Checked;

--- a/BizHawk.Client.EmuHawk/config/GuiOptions.cs
+++ b/BizHawk.Client.EmuHawk/config/GuiOptions.cs
@@ -7,6 +7,34 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class EmuHawkOptions : Form
 	{
+		public int AutosaveSaveRAMSeconds {
+			get {
+				if (AutosaveSRAMradioButton1.Checked)
+					return 5;
+				if (AutosaveSRAMradioButton2.Checked)
+					return 5 * 60;
+				return (int)AutosaveSRAMtextBox.Value;
+			}
+			set {
+				switch (value)
+				{
+					case 5:
+						AutosaveSRAMradioButton1.Checked = true;
+						AutosaveSRAMtextBox.Enabled = false;
+						break;
+					case 5 * 60:
+						AutosaveSRAMradioButton2.Checked = true;
+						AutosaveSRAMtextBox.Enabled = false;
+						break;
+					default:
+						AutosaveSRAMradioButton3.Checked = true;
+						AutosaveSRAMtextBox.Enabled = true;
+						break;
+				}
+				AutosaveSRAMtextBox.Value = value;
+			}
+		}
+
 		public EmuHawkOptions()
 		{
 			InitializeComponent();
@@ -25,6 +53,9 @@ namespace BizHawk.Client.EmuHawk
 			SingleInstanceModeCheckbox.Checked = Global.Config.SingleInstanceMode;
 
 			BackupSRamCheckbox.Checked = Global.Config.BackupSaveram;
+			AutosaveSRAMCheckbox.Checked = Global.Config.AutosaveSaveRAM;
+			groupBox2.Enabled = AutosaveSRAMCheckbox.Checked;
+			AutosaveSaveRAMSeconds = Global.Config.FlushSaveRamFrames / 60;
 			FrameAdvSkipLagCheckbox.Checked = Global.Config.SkipLagFrame;
 			LogWindowAsConsoleCheckbox.Checked = Global.Config.WIN32_CONSOLE;
 			LuaDuringTurboCheckbox.Checked = Global.Config.RunLuaDuringTurbo;
@@ -56,6 +87,8 @@ namespace BizHawk.Client.EmuHawk
 			Global.Config.SingleInstanceMode = SingleInstanceModeCheckbox.Checked;
 
 			Global.Config.BackupSaveram = BackupSRamCheckbox.Checked;
+			Global.Config.AutosaveSaveRAM = AutosaveSRAMCheckbox.Checked;
+			Global.Config.FlushSaveRamFrames = AutosaveSaveRAMSeconds * 60;
 			Global.Config.SkipLagFrame = FrameAdvSkipLagCheckbox.Checked;
 			Global.Config.WIN32_CONSOLE = LogWindowAsConsoleCheckbox.Checked;
 			Global.Config.RunLuaDuringTurbo = LuaDuringTurboCheckbox.Checked;
@@ -76,6 +109,16 @@ namespace BizHawk.Client.EmuHawk
 			Close();
 			DialogResult = DialogResult.Cancel;
 			GlobalWin.OSD.AddMessage("Customizing aborted.");
+		}
+
+		private void AutosaveSRAMCheckbox_CheckedChanged(object sender, EventArgs e)
+		{
+			groupBox2.Enabled = AutosaveSRAMCheckbox.Checked;
+		}
+
+		private void AutosaveSRAMradioButton3_CheckedChanged(object sender, EventArgs e)
+		{
+			AutosaveSRAMtextBox.Enabled = AutosaveSRAMradioButton3.Checked;
 		}
 	}
 }


### PR DESCRIPTION
Following on the menu item and hotkey to save SaveRAM, I created a menu to choose how often you want your save to be saved during play.  Manually flushing SaveRAM resets the counter, automatic saving in the core frame loop is done after the movie is handled that frame.

Fun fact: a 1 frame flush timer is workable on a RAM disk, depending on the speed of various computer subsystems.  Writing 60 files per second to flash (SSD, SD, etc) lags the SNES core a little bit, and could be mildly abusive of the storage hardware.  Trying it on a hard drive was not fun.