### PR TITLE
Make Gambatte show link status for printer connection

### DIFF
--- a/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
+++ b/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
@@ -365,7 +365,7 @@
     </Compile>
     <Compile Include="Consoles\Atari\A7800Hawk\M6532.cs" />
     <Compile Include="Consoles\Atari\A7800Hawk\Maria.cs" />
-		<Compile Include="Consoles\Atari\A7800Hawk\Pokey.cs" />
+    <Compile Include="Consoles\Atari\A7800Hawk\Pokey.cs" />
     <Compile Include="Consoles\Atari\A7800Hawk\TIA_Sound\Tia.Audio.cs" />
     <Compile Include="Consoles\Atari\A7800Hawk\TIA_Sound\TIA.cs" />
     <Compile Include="Consoles\Atari\A7800Hawk\TIA_Sound\Tia.SyncState.cs" />
@@ -461,6 +461,9 @@
       <DependentUpon>Gambatte.cs</DependentUpon>
     </Compile>
     <Compile Include="Consoles\Nintendo\Gameboy\Gambatte.IEmulator.cs">
+      <DependentUpon>Gambatte.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Consoles\Nintendo\Gameboy\Gambatte.ILinkable.cs">
       <DependentUpon>Gambatte.cs</DependentUpon>
     </Compile>
     <Compile Include="Consoles\Nintendo\Gameboy\Gambatte.IMemoryDomains.cs">

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ILinkable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ILinkable.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BizHawk.Emulation.Common;
+
+namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
+{
+	public partial class Gameboy : ILinkable
+	{
+		public bool LinkConnected { get; private set; }
+	}
+}

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -19,7 +19,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 	[ServiceNotApplicable(typeof(IDriveLight), typeof(IDriveLight))]
 	public partial class Gameboy : IEmulator, IVideoProvider, ISoundProvider, ISaveRam, IStatable, IInputPollable, ICodeDataLogger,
 		IBoardInfo, IDebuggable, ISettable<Gameboy.GambatteSettings, Gameboy.GambatteSyncSettings>,
-		IGameboyCommon, ICycleTiming
+		IGameboyCommon, ICycleTiming, ILinkable
 	{
 		[CoreConstructor("GB", "GBC")]
 		public Gameboy(CoreComm comm, GameInfo game, byte[] file, object settings, object syncSettings, bool deterministic)
@@ -513,9 +513,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 			if (callback != null)
 			{
 				printer = new GambattePrinter(this, callback);
+				LinkConnected = true;
 			}
 			else
 			{
+				LinkConnected = false;
 				printer.Disconnect();
 				printer = null;
 			}


### PR DESCRIPTION
Might as well use ```ILinkable``` for the little status icon, didn't even realize it was a thing when making #982 since its only used one other time in BizHawk (in ```GambatteLink```)
