### PR TITLE
Adds Sega Master System paddle support

### DIFF
--- a/Assets/defctrl.json
+++ b/Assets/defctrl.json
@@ -743,6 +743,13 @@
       "P2 B1": "",
       "P2 B2": ""
     },
+    "SMS Paddle Controller": {
+      "P1 Left": "LeftArrow, J1 POV1L",
+      "P1 Right": "RightArrow, J1 POV1R",
+      "P1 B1": "Z, J1 B1, X1 X",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start",
+    },
     "GG Controller": {
       "P1 Up": "UpArrow, J1 POV1U, X1 DpadUp, X1 LStickUp",
       "P1 Down": "DownArrow, J1 POV1D, X1 DpadDown, X1 LStickDown",
@@ -1564,6 +1571,13 @@
       },
       "P1 Y": {
         "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.1
+      }
+    },
+    "SMS Paddle Controller": {
+      "P1 Paddle": {
+        "Value": "X1 LeftThumbX",
         "Mult": 1.0,
         "Deadzone": 0.1
       }

--- a/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -442,6 +442,9 @@
             this.ShowMenuContextMenuSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.ShowMenuContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+            this.SMSControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.SMSControllerStandardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.SMSControllerPaddleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.MainformMenu.SuspendLayout();
             this.MainStatusBar.SuspendLayout();
             this.MainFormContextMenu.SuspendLayout();
@@ -2475,6 +2478,7 @@
             this.SMSSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SMSregionToolStripMenuItem,
             this.SMSdisplayToolStripMenuItem,
+            this.SMSControllerToolStripMenuItem,
             this.SMStoolStripMenuItem2,
             this.SMSenableBIOSToolStripMenuItem,
             this.SMSEnableFMChipMenuItem,
@@ -2541,6 +2545,26 @@
             this.SMSdisplayNtscToolStripMenuItem.Size = new System.Drawing.Size(104, 22);
             this.SMSdisplayNtscToolStripMenuItem.Text = "NTSC";
             this.SMSdisplayNtscToolStripMenuItem.Click += new System.EventHandler(this.SMS_DisplayNTSC_Click);
+            // 
+            // SMSControllerToolStripMenuItem
+            // 
+            this.SMSControllerToolStripMenuItem.Name = "SMSControllerToolStripMenuItem";
+            this.SMSControllerToolStripMenuItem.Text = "&Controller Type";
+            this.SMSControllerToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SMSControllerStandardToolStripMenuItem,
+            this.SMSControllerPaddleToolStripMenuItem});
+            // 
+            // SMSControllerStandardToolStripMenuItem
+            // 
+            this.SMSControllerStandardToolStripMenuItem.Name = "SMSControllerStandardToolStripMenuItem";
+            this.SMSControllerStandardToolStripMenuItem.Text = "Standard";
+			this.SMSControllerStandardToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerStandardToolStripMenuItem_Click);
+            // 
+            // SMSControllerPaddleToolStripMenuItem
+            // 
+            this.SMSControllerPaddleToolStripMenuItem.Name = "SMSControllerPaddleToolStripMenuItem";
+            this.SMSControllerPaddleToolStripMenuItem.Text = "Paddle";
+            this.SMSControllerPaddleToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerPaddleToolStripMenuItem_Click);
             // 
             // SMSdisplayPalToolStripMenuItem
             // 
@@ -4368,5 +4392,8 @@
 		private System.Windows.Forms.ToolStripMenuItem SgbSameBoyMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem pCFXToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem3;
+		private System.Windows.Forms.ToolStripMenuItem SMSControllerToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem SMSControllerStandardToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem SMSControllerPaddleToolStripMenuItem;
 	}
 }

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1745,6 +1745,8 @@ namespace BizHawk.Client.EmuHawk
 			SMSdisplayNtscToolStripMenuItem.Checked = ss.DisplayType == "NTSC";
 			SMSdisplayPalToolStripMenuItem.Checked = ss.DisplayType == "PAL";
 			SMSdisplayAutoToolStripMenuItem.Checked = ss.DisplayType == "Auto";
+			SMSControllerStandardToolStripMenuItem.Checked = s.ControllerType == "Standard";
+			SMSControllerPaddleToolStripMenuItem.Checked = s.ControllerType == "Paddle";
 			SMSenableBIOSToolStripMenuItem.Checked = ss.UseBIOS;
 			SMSEnableFMChipMenuItem.Checked = ss.EnableFM;
 			SMSOverclockMenuItem.Checked = ss.AllowOverlock;
@@ -1897,6 +1899,20 @@ namespace BizHawk.Client.EmuHawk
 		private void SmsVdpViewerMenuItem_Click(object sender, EventArgs e)
 		{
 			GlobalWin.Tools.Load<SmsVDPViewer>();
+		}
+
+		private void SMSControllerStandardToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var s = ((SMS)Emulator).GetSettings();
+			s.ControllerType = "Standard";
+			PutCoreSettings(s);
+		}
+
+		private void SMSControllerPaddleToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var s = ((SMS)Emulator).GetSettings();
+			s.ControllerType = "Paddle";
+			PutCoreSettings(s);
 		}
 
 		#endregion

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -15,7 +15,13 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 					return GGController;
 				}
 
-				return SmsController;
+				switch(Settings.ControllerType)
+				{
+					case "Paddle":
+						return SMSPaddleController;
+					default:
+						return SmsController;
+				}
 			}
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ISettable.cs
@@ -38,6 +38,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			public bool SpriteLimit = false;
 			public bool Fix3D = true;
 			public bool DisplayOverscan = false;
+			public string ControllerType = "Standard";
 
 			// GG settings
 			public bool ShowClippedRegions = false;

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
@@ -71,6 +71,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			ser.Sync("Port02", ref Port02);
 			ser.Sync("Port3E", ref Port3E);
 			ser.Sync("Port3F", ref Port3F);
+			ser.Sync("Paddle1High", ref Paddle1High);
+			ser.Sync("Paddle2High", ref Paddle2High);
 
 			if (SaveRAM != null)
 			{


### PR DESCRIPTION
To switch controllers, go to _SMS_ -> _Controller Type_ -> _Paddle_.
Uses left analog stick on a game pad, by default; can be remapped of course.
I would not recommend the alternative digital left/right inputs, although they are technically usable in Alex Kidd. Afterall, the games are designed around fine-grained & quick analog control.

## Tested On
* Alex Kidd BMX Trial
* Galactic Protector
* Megumi Rescue

## Weird Notes
It works on both _Export_ and _Japan_ regions. Being noted because for some reason the game code for virtually every paddle game detects it and the controller is expected to have a different I/O interface, despite it only ever being sold in Japan.
Hopefully there isn't some weird game that throws a wrench in the works regarding that.

I wanted to also add light gun support too, but it appears the following frame is just solid gray instead on the light gun flash frame, so there's something odd happening with the video code there..

Resolves #950