### PR TITLE
Fixes SMS Galactic Defender's Player 2 paddle

### DIFF
--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
@@ -89,6 +89,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						if ((Port3F & 0x02) == 0x00)
 						{
 							Paddle1High = (Port3F & 0x20) != 0;
+							Paddle2High = Paddle1High;
 						}
 						if ((Port3F & 0x08) == 0x00)
 						{


### PR DESCRIPTION
Are the TH output connections for the 2 controllers bridged? Might have been a bug in the actual game where it only clocks P1's TH and nobody noticed since it doesn't matter in the Japan region. Works now either way.

Follow up to #987 