### PR TITLE
Fixed SpeedThrottle()'s (relatively) high CPU usage

### DIFF
--- a/BizHawk.Client.EmuHawk/Throttle.cs
+++ b/BizHawk.Client.EmuHawk/Throttle.cs
@@ -338,28 +338,21 @@ namespace BizHawk.Client.EmuHawk
 				}
 
 				int sleepTime = (int)((timePerFrame - elapsedTime) * 1000 / afsfreq);
-				if (sleepTime >= 2 || paused)
-				{
-#if WINDOWS
-					// Assuming a timer period of 1 ms (i.e. timeBeginPeriod(1)): The actual sleep time
-					// on Windows XP is generally within a half millisecond either way of the requested
-					// time. The actual sleep time on Windows 8 is generally between the requested time
-					// and up to a millisecond over. So we'll subtract 1 ms from the time to avoid
-					// sleeping longer than desired.
-					sleepTime -= 1;
-#else
-					// The actual sleep time on OS X with Mono is generally between the request time
-					// and up to 25% over. So we'll scale the sleep time back to account for that.
-					sleepTime = sleepTime * 4 / 5;
-#endif
 
-					Thread.Sleep(Math.Max(sleepTime, 1));
-				}
-				else if (sleepTime > 0) // spin for <1 millisecond waits
-				{
-					Thread.Yield(); // limit to other threads on the same CPU core for other short waits
-				}
-			}
+#if WINDOWS
+				// Assuming a timer period of 1 ms (i.e. timeBeginPeriod(1)): The actual sleep time
+				// on Windows XP is generally within a half millisecond either way of the requested
+				// time. The actual sleep time on Windows 8 is generally between the requested time
+				// and up to a millisecond over. So we'll subtract 1 ms from the time to avoid
+				// sleeping longer than desired.
+				sleepTime -= 1;
+#else
+				// The actual sleep time on OS X with Mono is generally between the request time
+				// and up to 25% over. So we'll scale the sleep time back to account for that.
+				sleepTime = sleepTime * 4 / 5;
+#endif
+                Thread.Sleep(Math.Max(sleepTime, 1));
+            }
 		}
 	}
 }


### PR DESCRIPTION
SpeedThrottle() was using a large portion of computation (~10 -15% of the entire program). When the sleep time is less than zero, the while true loop tags over. For some reason this appears to be occuring for more than a single. The solution is to always sleep for at least 1 ms if throttling is needed.

(For future) Look into using Threading.Timer. Might provide a better overall architecture.