### PR TITLE
SMS Light Phaser support

### DIFF
--- a/Assets/defctrl.json
+++ b/Assets/defctrl.json
@@ -748,7 +748,12 @@
       "P1 Right": "RightArrow, J1 POV1R",
       "P1 B1": "Z, J1 B1, X1 X",
       "Reset": "J1 B9, X1 Back",
-      "Pause": "J1 B10, X1 Start",
+      "Pause": "J1 B10, X1 Start"
+    },
+    "SMS Light Phaser Controller": {
+      "P1 Trigger": "Z, J1 B1, X1 X, WMouse L",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start"
     },
     "GG Controller": {
       "P1 Up": "UpArrow, J1 POV1U, X1 DpadUp, X1 LStickUp",
@@ -1580,6 +1585,18 @@
         "Value": "X1 LeftThumbX",
         "Mult": 1.0,
         "Deadzone": 0.1
+      }
+    },
+    "SMS Light Phaser Controller": {
+      "P1 X": {
+        "Value": "WMouse X",
+        "Mult": 1.0,
+        "Deadzone": 0.0
+      },
+      "P1 Y": {
+        "Value": "WMouse Y",
+        "Mult": 1.0,
+        "Deadzone": 0.0
       }
     }
   }

--- a/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -445,6 +445,7 @@
             this.SMSControllerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SMSControllerStandardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SMSControllerPaddleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.SMSControllerLightPhaserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.MainformMenu.SuspendLayout();
             this.MainStatusBar.SuspendLayout();
             this.MainFormContextMenu.SuspendLayout();
@@ -2552,7 +2553,8 @@
             this.SMSControllerToolStripMenuItem.Text = "&Controller Type";
             this.SMSControllerToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SMSControllerStandardToolStripMenuItem,
-            this.SMSControllerPaddleToolStripMenuItem});
+            this.SMSControllerPaddleToolStripMenuItem,
+            this.SMSControllerLightPhaserToolStripMenuItem});
             // 
             // SMSControllerStandardToolStripMenuItem
             // 
@@ -2565,6 +2567,12 @@
             this.SMSControllerPaddleToolStripMenuItem.Name = "SMSControllerPaddleToolStripMenuItem";
             this.SMSControllerPaddleToolStripMenuItem.Text = "Paddle";
             this.SMSControllerPaddleToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerPaddleToolStripMenuItem_Click);
+            // 
+            // SMSControllerLightPhaserToolStripMenuItem
+            // 
+            this.SMSControllerLightPhaserToolStripMenuItem.Name = "SMSControllerLightPhaserToolStripMenuItem";
+            this.SMSControllerLightPhaserToolStripMenuItem.Text = "Light Phaser";
+            this.SMSControllerLightPhaserToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerLightPhaserToolStripMenuItem_Click);
             // 
             // SMSdisplayPalToolStripMenuItem
             // 
@@ -4395,5 +4403,6 @@
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerStandardToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerPaddleToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem SMSControllerLightPhaserToolStripMenuItem;
 	}
 }

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1747,6 +1747,7 @@ namespace BizHawk.Client.EmuHawk
 			SMSdisplayAutoToolStripMenuItem.Checked = ss.DisplayType == "Auto";
 			SMSControllerStandardToolStripMenuItem.Checked = s.ControllerType == "Standard";
 			SMSControllerPaddleToolStripMenuItem.Checked = s.ControllerType == "Paddle";
+			SMSControllerLightPhaserToolStripMenuItem.Checked = s.ControllerType == "Light Phaser";
 			SMSenableBIOSToolStripMenuItem.Checked = ss.UseBIOS;
 			SMSEnableFMChipMenuItem.Checked = ss.EnableFM;
 			SMSOverclockMenuItem.Checked = ss.AllowOverlock;
@@ -1912,6 +1913,13 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var s = ((SMS)Emulator).GetSettings();
 			s.ControllerType = "Paddle";
+			PutCoreSettings(s);
+		}
+
+		private void SMSControllerLightPhaserToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var s = ((SMS)Emulator).GetSettings();
+			s.ControllerType = "Light Phaser";
 			PutCoreSettings(s);
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -19,6 +19,11 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				{
 					case "Paddle":
 						return SMSPaddleController;
+					case "Light Phaser":
+						// scale the vertical to the display mode
+						SMSLightPhaserController.FloatRanges[1] = new ControllerDefinition.FloatRange(0, Vdp.FrameHeight / 2, Vdp.FrameHeight - 1);
+
+						return SMSLightPhaserController;
 					default:
 						return SmsController;
 				}

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
@@ -73,6 +73,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			ser.Sync("Port3F", ref Port3F);
 			ser.Sync("Paddle1High", ref Paddle1High);
 			ser.Sync("Paddle2High", ref Paddle2High);
+			ser.Sync("LatchLightPhaser", ref LatchLightPhaser);
 
 			if (SaveRAM != null)
 			{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
@@ -8,9 +8,9 @@ using BizHawk.Emulation.Cores.Components.Z80;
 
 /*****************************************************
   TODO: 
-  + HCounter
+  + HCounter (Manually set for light phaser emulation... should be only case it's polled)
   + Try to clean up the organization of the source code. 
-  + Lightgun/Paddle/etc if I get really bored  
+  + Lightgun/Paddle/etc if I get really bored  (first 2 done!)
   + Mode 1 not implemented in VDP TMS modes. (I dont have a test case in SG1000 or Coleco)
  
 **********************************************************/
@@ -281,7 +281,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				if ((port & 1) == 0)
 					return Vdp.ReadVLineCounter();
 				else
-					return 0x50; // TODO Vdp.ReadHLineCounter();
+					return Vdp.ReadHLineCounter();
 			}
 			if (port < 0xC0) // VDP data/control ports
 			{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/VDP.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/VDP.cs
@@ -47,6 +47,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		public int FrameHeight = 192;
 		public int ScanLine;
+		public byte HCounter = 0x90;
 		public int[] FrameBuffer = new int[256 * 192];
 		public int[] GameGearFrameBuffer = new int[160 * 144];
 		public int[] OverscanFrameBuffer = null;
@@ -134,6 +135,11 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 					return VLineCounterTablePAL224[ScanLine];
 				return VLineCounterTablePAL240[ScanLine];
 			}
+		}
+
+		public byte ReadHLineCounter()
+		{
+			return HCounter;
 		}
 
 		public void WriteVdpControl(byte value)
@@ -375,6 +381,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 				ProcessFrameInterrupt();
 				ProcessLineInterrupt();
+				Sms.ProcessLineControls();
 
 				Cpu.ExecuteCycles(IPeriod);
 
@@ -428,6 +435,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			ser.Sync("Registers", ref Registers, false);
 			ser.Sync("CRAM", ref CRAM, false);
 			ser.Sync("VRAM", ref VRAM, false);
+			ser.Sync("HCounter", ref HCounter);
 			ser.EndSection();
 
 			if (ser.IsReader)


### PR DESCRIPTION
Adds support for the light phaser (light gun) for the Sega Master System.
It technically works in both regions despite it being impossible for the light phaser work on Japanese hardware (Seemed pointless to add code that would just hard/softlock games).
If anyone asks, yes, the VDP has a register and latches it on controller VH, essentially for the sake of only the light phaser, as far as I can tell in developer documentation.

Select via _SMS_ -> _Controller Type_ -> _Light Phaser_.
Use your mouse to aim and shoot; there's no indicator other than the mouse cursor as to where you'd fire on-screen so remapping that is probably not a great idea.

## Tested on:
* Rescue Mission
* Shooting Gallery
* Rambo III
* Space Gun (shoots up and to the right, I have no idea if the game had alignment problems on real hardware)