### PR TITLE
Fixes debugger tool for SMSHawk

### DIFF
--- a/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
@@ -393,7 +393,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 			"NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", "NOP", //0x100
 		};
 
-		public string Disassemble(ushort addr, Func<ushort, byte> read, out ushort size)
+		public string Disassemble(ushort addr, Func<ushort, byte> read, out int size)
 		{
 			ushort start_addr = addr;
 			ushort extra_inc = 0;
@@ -434,7 +434,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 
 			addr += extra_inc;
 
-			size = (ushort)(addr - start_addr);
+			size = addr - start_addr;
 			return temp;
 		}
 
@@ -458,10 +458,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 
 		public string Disassemble(MemoryDomain m, uint addr, out int length)
 		{
-			int loc = (int)addr;
-			ushort unused = 0;
-			string ret = Disassemble((ushort) addr, a => m.PeekByte(a), out unused);
-			length = loc - (int)addr;
+			string ret = Disassemble((ushort)addr, a => m.PeekByte(a), out length);
 			return ret;
 		}
 

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
@@ -609,7 +609,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 
 		public TraceInfo State(bool disassemble = true)
 		{
-			ushort bytes_read = 0;
+			int bytes_read = 0;
 
 			string disasm = disassemble ? Disassemble(RegPC, ReadMemory, out bytes_read) : "---";
 			string byte_code = null;

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.CodeMasters.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.CodeMasters.cs
@@ -40,8 +40,8 @@
 
 		void InitCodeMastersMapper()
 		{
-			ReadMemory = ReadMemoryCM;
-			WriteMemory = WriteMemoryCM;
+			ReadMemoryMapper = ReadMemoryCM;
+			WriteMemoryMapper = WriteMemoryCM;
 			MapMemory = MapMemoryCM;
 			WriteMemoryCM(0x0000, 0);
 			WriteMemoryCM(0x4000, 1);
@@ -113,8 +113,8 @@
 
 		void InitCodeMastersMapperRam()
 		{
-			ReadMemory = ReadMemoryCMRam;
-			WriteMemory = WriteMemoryCMRam;
+			ReadMemoryMapper = ReadMemoryCMRam;
+			WriteMemoryMapper = WriteMemoryCMRam;
 			MapMemory = MapMemoryCMRam;
 			WriteMemoryCM(0x0000, 0);
 			WriteMemoryCM(0x4000, 1);

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.EEPROM.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.EEPROM.cs
@@ -122,8 +122,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		void InitEEPROMMapper()
 		{
-			ReadMemory = ReadMemoryEEPROM;
-			WriteMemory = WriteMemoryEEPROM;
+			ReadMemoryMapper = ReadMemoryEEPROM;
+			WriteMemoryMapper = WriteMemoryEEPROM;
 			MapMemory = MapMemoryEEPROM;
 			WriteMemoryEEPROM(0xFFFC, 0);
 			WriteMemoryEEPROM(0xFFFD, 0);

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.ExtRam.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.ExtRam.cs
@@ -38,8 +38,8 @@
 		{
 			ExtRam = new byte[size];
 			ExtRamMask = size - 1;
-			ReadMemory = ReadMemoryExt;
-			WriteMemory = WriteMemoryExt;
+			ReadMemoryMapper = ReadMemoryExt;
+			WriteMemoryMapper = WriteMemoryExt;
 			MapMemory = MapMemoryExt;
 		}
 	}

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.Korea.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.Korea.cs
@@ -30,8 +30,8 @@
 
 		void InitKoreaMapper()
 		{
-			ReadMemory = ReadMemoryKR;
-			WriteMemory = WriteMemoryKR;
+			ReadMemoryMapper = ReadMemoryKR;
+			WriteMemoryMapper = WriteMemoryKR;
 			MapMemory = MapMemoryKR;
 			RomBank0 = 0;
 			RomBank1 = 1;
@@ -101,9 +101,9 @@
 
 		void InitMSXMapper()
 		{
-			ReadMemory = ReadMemoryMSX;
-			WriteMemory = WriteMemoryMSX;
-			ReadMemory = ReadMemoryMSX;
+			ReadMemoryMapper = ReadMemoryMSX;
+			WriteMemoryMapper = WriteMemoryMSX;
+			ReadMemoryMapper = ReadMemoryMSX;
 			RomBank0 = 0;
 			RomBank1 = 0;
 			RomBank2 = 0;
@@ -113,7 +113,7 @@
 		void InitNemesisMapper()
 		{
 			InitMSXMapper();
-			ReadMemory = ReadMemoryNemesis;
+			ReadMemoryMapper = ReadMemoryNemesis;
 			MapMemory = MapMemoryNemesis;
 		}
 	}

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.Sega.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/MemoryMap.Sega.cs
@@ -132,8 +132,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		void InitSegaMapper()
 		{
-			ReadMemory = ReadMemorySega;
-			WriteMemory = WriteMemorySega;
+			ReadMemoryMapper = ReadMemorySega;
+			WriteMemoryMapper = WriteMemorySega;
 			MapMemory = MapMemorySega;
 			WriteMemorySega(0xFFFC, 0);
 			WriteMemorySega(0xFFFD, 0);
@@ -176,8 +176,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 
 		void InitBiosMapper()
 		{
-			ReadMemory = ReadMemoryBIOS;
-			WriteMemory = WriteMemoryBIOS;
+			ReadMemoryMapper = ReadMemoryBIOS;
+			WriteMemoryMapper = WriteMemoryBIOS;
 			WriteMemorySega(0xFFFC, 0);
 			WriteMemorySega(0xFFFD, 0);
 			WriteMemorySega(0xFFFE, 1);

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ICodeDataLogger.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.ICodeDataLogger.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			{
 				Cpu.ReadMemory = ReadMemory;
 				Cpu.WriteMemory = WriteMemory;
-				Cpu.FetchMemory = FetchMemory_StubThunk;
+				Cpu.FetchMemory = FetchMemory;
 			}
 			else
 			{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IDebuggable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IDebuggable.cs
@@ -33,7 +33,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				["Shadow BC"] = Cpu.Regs[Cpu.C_s] + (Cpu.Regs[Cpu.B_s] << 8),
 				["Shadow DE"] = Cpu.Regs[Cpu.E_s] + (Cpu.Regs[Cpu.D_s] << 8),
 				["Shadow HL"] = Cpu.Regs[Cpu.L_s] + (Cpu.Regs[Cpu.H_s] << 8),
-				["SP"] = Cpu.Regs[Cpu.Iyl] + (Cpu.Regs[Cpu.Iyh] << 8),
+				["SP"] = Cpu.Regs[Cpu.SPl] + (Cpu.Regs[Cpu.SPh] << 8),
 				["Flag C"] = Cpu.FlagC,
 				["Flag N"] = Cpu.FlagN,
 				["Flag P/V"] = Cpu.FlagP,

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
@@ -78,10 +78,11 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			{
 				ReadHardware = ReadPort,
 				WriteHardware = WritePort,
-				FetchMemory = ReadMemory,
+				FetchMemory = FetchMemory,
 				ReadMemory = ReadMemory,
 				WriteMemory = WriteMemory,
-				MemoryCallbacks = MemoryCallbacks
+				MemoryCallbacks = MemoryCallbacks,
+				OnExecFetch = OnExecMemory
 			};
 
 			Vdp = new VDP(this, Cpu, IsGameGear ? VdpMode.GameGear : VdpMode.SMS, Region);
@@ -249,15 +250,39 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			return DisplayType.NTSC;
 		}
 
+		private byte ReadMemory(ushort addr)
+		{
+			MemoryCallbacks.CallReads(addr, "System Bus");
+
+			return ReadMemoryMapper(addr);
+		}
+
+		private void WriteMemory(ushort addr, byte value)
+		{
+			WriteMemoryMapper(addr, value);
+
+			MemoryCallbacks.CallWrites(addr, "System Bus");
+		}
+
+		private byte FetchMemory(ushort addr)
+		{
+			return ReadMemoryMapper(addr);
+		}
+
+		private void OnExecMemory(ushort addr)
+		{
+			MemoryCallbacks.CallExecutes(addr, "System Bus");
+		}
+
 		/// <summary>
 		/// The ReadMemory callback for the mapper
 		/// </summary>
-		private Func<ushort, byte> ReadMemory;
+		private Func<ushort, byte> ReadMemoryMapper;
 
 		/// <summary>
 		/// The WriteMemory callback for the wrapper
 		/// </summary>
-		private Action<ushort, byte> WriteMemory;
+		private Action<ushort, byte> WriteMemoryMapper;
 
 		/// <summary>
 		/// A dummy FetchMemory that simply reads the memory

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/TerebiOekaki.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/TerebiOekaki.cs
@@ -46,8 +46,8 @@
 
 		void InitTerebiOekaki()
 		{
-			ReadMemory = ReadMemoryTO;
-			WriteMemory = WriteMemoryTO;
+			ReadMemoryMapper = ReadMemoryTO;
+			WriteMemoryMapper = WriteMemoryTO;
 		}
 	}
 }


### PR DESCRIPTION
The Z80 disassembler reported all of the instructions as 0 bytes long so it would just print the first instruction down the entire window.

Also, breakpoints weren't setup to work at all in `SMSHawk`.