### PR TITLE
Keyboard support for SG-1000/Mark III

### DIFF
--- a/Assets/defctrl.json
+++ b/Assets/defctrl.json
@@ -833,8 +833,8 @@
       "Key PI": "RightShift",
       "Key Down Arrow": "DownArrow",
       
-      "Key Graph": "LeftControl",
-      "Key Kana": "LeftAlt",
+      "Key Graph": "PageUp",
+      "Key Kana": "PageDown",
       "Key Space": "Space",
       "Key Home/Clear": "Home",
       "Key Insert/Delete": "Insert",

--- a/Assets/defctrl.json
+++ b/Assets/defctrl.json
@@ -755,13 +755,96 @@
       "Reset": "J1 B9, X1 Back",
       "Pause": "J1 B10, X1 Start"
     },
-	"SMS Sports Pad Controller": {
+    "SMS Sports Pad Controller": {
       "P1 Up": "UpArrow, J1 POV1U",
       "P1 Down": "DownArrow, J1 POV1D",
       "P1 Left": "LeftArrow, J1 POV1L",
       "P1 Right": "RightArrow, J1 POV1R",
       "P1 B1": "Z, J1 B1, X1 X",
       "P1 B2": "X, J1 B2, X1 A",
+      "Reset": "J1 B9, X1 Back",
+      "Pause": "J1 B10, X1 Start",
+      "P2 Up": "",
+      "P2 Down": "",
+      "P2 Left": "",
+      "P2 Right": "",
+      "P2 B1": "",
+      "P2 B2": ""
+    },
+    "SMS Keyboard Controller": {
+      "Key 1": "D1",
+      "Key 2": "D2",
+      "Key 3": "D3",
+      "Key 4": "D4",
+      "Key 5": "D5",
+      "Key 6": "D6",
+      "Key 7": "D7",
+      "Key 8": "D8",
+      "Key 9": "D9",
+      "Key 0": "D0",
+      "Key Minus": "Minus",
+      "Key Caret": "Equals",
+      "Key Yen": "Backspace",
+      "Key Break": "Delete",
+      
+      "Key Function": "Tab",
+      "Key Q": "Q",
+      "Key W": "W",
+      "Key E": "E",
+      "Key R": "R",
+      "Key T": "T",
+      "Key Y": "Y",
+      "Key U": "U",
+      "Key I": "I",
+      "Key O": "O",
+      "Key P": "P",
+      "Key At": "LeftBracket",
+      "Key Left Bracket": "RightBracket",
+      "Key Return": "Return",
+      "Key Up Arrow": "UpArrow",
+      
+      "Key Control": "CapsLock",
+      "Key A": "A",
+      "Key S": "S",
+      "Key D": "D",
+      "Key F": "F",
+      "Key G": "G",
+      "Key H": "H",
+      "Key J": "J",
+      "Key K": "K",
+      "Key L": "L",
+      "Key Semicolon": "Semicolon",
+      "Key Colon": "Apostrophe",
+      "Key Right Bracket": "Backslash",
+      "Key Left Arrow": "LeftArrow",
+      "Key Right Arrow": "RightArrow",
+      
+      "Key Shift": "LeftShift",
+      "Key Z": "Z",
+      "Key X": "X",
+      "Key C": "C",
+      "Key V": "V",
+      "Key B": "B",
+      "Key N": "N",
+      "Key M": "M",
+      "Key Comma": "Comma",
+      "Key Period": "Period",
+      "Key Slash": "Slash",
+      "Key PI": "RightShift",
+      "Key Down Arrow": "DownArrow",
+      
+      "Key Graph": "LeftControl",
+      "Key Kana": "LeftAlt",
+      "Key Space": "Space",
+      "Key Home/Clear": "Home",
+      "Key Insert/Delete": "Insert",
+      
+      "P1 Up": "J1 POV1U, X1 DpadUp, X1 LStickUp",
+      "P1 Down": "J1 POV1D, X1 DpadDown, X1 LStickDown",
+      "P1 Left": "J1 POV1L, X1 DpadLeft, X1 LStickLeft",
+      "P1 Right": "J1 POV1R, X1 DpadRight, X1 LStickRight",
+      "P1 B1": "J1 B1, X1 X",
+      "P1 B2": "J1 B2, X1 A",
       "Reset": "J1 B9, X1 Back",
       "Pause": "J1 B10, X1 Start",
       "P2 Up": "",
@@ -1615,23 +1698,23 @@
         "Deadzone": 0.0
       }
     },
-	"SMS Sports Pad Controller": {
+    "SMS Sports Pad Controller": {
       "P1 X": {
         "Value": "X1 LeftThumbX",
         "Mult": 1.0,
         "Deadzone": 0.1
       },
-	    "P1 Y": {
+        "P1 Y": {
         "Value": "X1 LeftThumbY",
         "Mult": -1.0,
         "Deadzone": 0.1
       },
-	    "P2 X": {
+        "P2 X": {
         "Value": "X2 LeftThumbX",
         "Mult": 1.0,
         "Deadzone": 0.1
       },
-	    "P2 Y": {
+        "P2 Y": {
         "Value": "X2 LeftThumbY",
         "Mult": -1.0,
         "Deadzone": 0.1

--- a/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -450,6 +450,7 @@
             this.SMSControllerPaddleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SMSControllerLightPhaserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.SMSControllerSportsPadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SMSControllerKeyboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.MainformMenu.SuspendLayout();
             this.MainStatusBar.SuspendLayout();
             this.MainFormContextMenu.SuspendLayout();
@@ -2584,7 +2585,8 @@
             this.SMSControllerStandardToolStripMenuItem,
             this.SMSControllerPaddleToolStripMenuItem,
             this.SMSControllerLightPhaserToolStripMenuItem,
-			this.SMSControllerSportsPadToolStripMenuItem});
+			this.SMSControllerSportsPadToolStripMenuItem,
+			this.SMSControllerKeyboardToolStripMenuItem});
             // 
             // SMSControllerStandardToolStripMenuItem
             // 
@@ -2609,6 +2611,12 @@
 			this.SMSControllerSportsPadToolStripMenuItem.Name = "SMSControllerSportsPadToolStripMenuItem";
 			this.SMSControllerSportsPadToolStripMenuItem.Text = "Sports Pad";
 			this.SMSControllerSportsPadToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerSportsPadToolStripMenuItem_Click);
+			// 
+			// SMSControllerKeyboardToolStripMenuItem
+			// 
+			this.SMSControllerKeyboardToolStripMenuItem.Name = "SMSControllerKeyboardToolStripMenuItem";
+			this.SMSControllerKeyboardToolStripMenuItem.Text = "Keyboard";
+			this.SMSControllerKeyboardToolStripMenuItem.Click += new System.EventHandler(this.SMSControllerKeyboardToolStripMenuItem_Click);
 
 			// 
 			// SMSdisplayPalToolStripMenuItem
@@ -4445,5 +4453,6 @@
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerPaddleToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerLightPhaserToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SMSControllerSportsPadToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem SMSControllerKeyboardToolStripMenuItem;
 	}
 }

--- a/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1765,6 +1765,7 @@ namespace BizHawk.Client.EmuHawk
 			SMSControllerPaddleToolStripMenuItem.Checked = ss.ControllerType == "Paddle";
 			SMSControllerLightPhaserToolStripMenuItem.Checked = ss.ControllerType == "Light Phaser";
 			SMSControllerSportsPadToolStripMenuItem.Checked = ss.ControllerType == "Sports Pad";
+			SMSControllerKeyboardToolStripMenuItem.Checked = ss.ControllerType == "Keyboard";
 			SMSenableBIOSToolStripMenuItem.Checked = ss.UseBIOS;
 			SMSEnableFMChipMenuItem.Checked = ss.EnableFM;
 			SMSOverclockMenuItem.Checked = ss.AllowOverlock;
@@ -1944,6 +1945,13 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var s = ((SMS)Emulator).GetSyncSettings();
 			s.ControllerType = "Sports Pad";
+			PutCoreSyncSettings(s);
+		}
+		
+		private void SMSControllerKeyboardToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			var s = ((SMS)Emulator).GetSyncSettings();
+			s.ControllerType = "Keyboard";
 			PutCoreSyncSettings(s);
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -15,6 +15,9 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 					return GGController;
 				}
 
+				// Sorta a hack but why not
+				PortDEEnabled = SyncSettings.ControllerType == "Keyboard";
+
 				switch(SyncSettings.ControllerType)
 				{
 					case "Paddle":
@@ -26,6 +29,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						return SMSLightPhaserController;
 					case "Sports Pad":
 						return SMSSportsPadController;
+					case "Keyboard":
+						return SMSKeyboardController;
 					default:
 						return SmsController;
 				}

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
@@ -90,6 +90,35 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			}
 		};
 
+		public static readonly ControllerDefinition SMSKeyboardController = new ControllerDefinition
+		{
+			Name = "SMS Keyboard Controller",
+			BoolButtons =
+			{
+				"Key 1", "Key 2", "Key 3", "Key 4", "Key 5", "Key 6", "Key 7", "Key 8", "Key 9", "Key 0", "Key Minus", "Key Caret", "Key Yen", "Key Break",
+				"Key Function", "Key Q", "Key W", "Key E", "Key R", "Key T", "Key Y", "Key U", "Key I", "Key O", "Key P", "Key At", "Key Left Bracket", "Key Return", "Key Up Arrow",
+				"Key Control", "Key A", "Key S", "Key D", "Key F", "Key G", "Key H", "Key J", "Key K", "Key L", "Key Semicolon", "Key Colon", "Key Right Bracket", "Key Left Arrow", "Key Right Arrow",
+				"Key Shift", "Key Z", "Key X", "Key C", "Key V", "Key B", "Key N", "Key M", "Key Comma", "Key Period", "Key Slash", "Key PI", "Key Down Arrow",
+				"Key Graph", "Key Kana", "Key Space", "Key Home/Clear", "Key Insert/Delete",
+
+				"Reset", "Pause",
+				"P1 Up", "P1 Down", "P1 Left", "P1 Right", "P1 B1", "P1 B2",
+				"P2 Up", "P2 Down", "P2 Left", "P2 Right", "P2 B1", "P2 B2"
+			}
+		};
+
+		private static readonly string[] KeyboardMap =
+		{
+			"Key 1", "Key Q", "Key A", "Key Z", "Key Kana", "Key Comma", "Key K", "Key I", "Key 8", null, null, null,
+			"Key 2", "Key W", "Key S", "Key X", "Key Space", "Key Period", "Key L", "Key O", "Key 9", null, null, null,
+			"Key 3", "Key E", "Key D", "Key C", "Key Home/Clear", "Key Slash", "Key Semicolon", "Key P", "Key 0", null, null, null,
+			"Key 4", "Key R", "Key F", "Key V", "Key Insert/Delete", "Key PI", "Key Colon", "Key At", "Key Minus", null, null, null,
+			"Key 5", "Key T", "Key G", "Key B", null, "Key Down Arrow", "Key Right Bracket", "Key Left Bracket", "Key Caret", null, null, null,
+			"Key 6", "Key Y", "Key H", "Key N", null, "Key Left Arrow", "Key Return", null, "Key Yen", null, null, "Key Function",
+			"Key 7", "Key U", "Key J", "Key M", null, "Key Right Arrow", "Key Up Arrow", null, "Key Break", "Key Graph", "Key Control", "Key Shift",
+			"P1 Up", "P1 Down", "P1 Left", "P1 Right", "P1 B1", "P1 B2", "P2 Up", "P2 Down", "P2 Left", "P2 Right", "P2 B1", "P2 B2"
+		};
+
 		const int PaddleMin = 0;
 		const int PaddleMax = 255;
 		const int SportsPadMin = -64;
@@ -209,13 +238,14 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						else
 							p2Y = (int)_controller.GetFloat("P2 Y");
 
-						if(_region == "Japan")
+						if (_region == "Japan")
 						{
 							p1X += 128;
 							p1Y += 128;
 							p2X += 128;
 							p2Y += 128;
-						} else
+						}
+						else
 						{
 							p1X *= -1;
 							p1Y *= -1;
@@ -320,6 +350,22 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						}
 
 						PostsetControllerState(1);
+					}
+					break;
+
+				case "Keyboard":
+					{
+						// use keyboard map to get each bit
+
+						for (int bit = 0; bit < 8; ++bit)
+						{
+							string key = KeyboardMap[(PortDE & 0x07) * 12 + bit];
+
+							if (key != null && _controller.IsPressed(key))
+							{
+								value &= (byte)~(1 << bit);
+							}
+						}
 					}
 					break;
 
@@ -461,6 +507,24 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						}
 
 						PostsetControllerState(2);
+					}
+					break;
+
+				case "Keyboard":
+					{
+						value &= 0x7F;
+
+						// use keyboard map to get each bit
+
+						for (int bit = 0; bit < 4; ++bit)
+						{
+							string key = KeyboardMap[(PortDE & 0x07) * 12 + bit + 8];
+
+							if (key != null && _controller.IsPressed(key))
+							{
+								value &= (byte)~(1 << bit);
+							}
+						}
 					}
 					break;
 

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
@@ -208,6 +208,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 		public bool IsSG1000 { get; set; }
 
 		private bool HasYM2413 = false;
+		private bool PortDEEnabled = false;
 		private IController _controller;
 
 		private int _frame = 0;
@@ -216,6 +217,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 		private byte Port02 = 0xFF;
 		private byte Port3E = 0xAF;
 		private byte Port3F = 0xFF;
+		private byte PortDE = 0x00;
 
 		private byte ForceStereoByte = 0xAD;
 		private bool IsGame3D = false;
@@ -330,6 +332,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				case 0xDC: return ReadControls1();
 				case 0xC1:
 				case 0xDD: return ReadControls2();
+				case 0xDE: return PortDEEnabled ? PortDE : (byte)0xFF;
 				case 0xF2: return HasYM2413 ? YM2413.DetectionValue : (byte)0xFF;
 				default: return 0xFF;
 			}
@@ -358,6 +361,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				else
 					Vdp.WriteVdpControl(value);
 			}
+			else if (port == 0xDE && PortDEEnabled) PortDE = value;
 			else if (port == 0xF0 && HasYM2413) YM2413.RegisterLatch = value;
 			else if (port == 0xF1 && HasYM2413) YM2413.Write(value);
 			else if (port == 0xF2 && HasYM2413) YM2413.DetectionValue = value;


### PR DESCRIPTION
I couldn't find a game that used more than 10 keys or so, since most just use _the arrow keys_, _Insert_, and _Home_, basically pretending they make up a controller, so I can't guarantee that all the keys actually work.

SG-1000 games tested:
- Girl's Garden
- Sega-Galaga
- Champion Boxing
  - Actually uses more keys if you select 2 player!

Mark III Games tested:
- F-16 Fighting Falcon
  - I barely have any clue what's happening in this game, but I managed to shoot at a plane so I assume it all works.
- Alex Kidd no Miracle World*
  - This one is weird, it detects the keyboard, and you can start the game with it, but once it launches into the first level, it zero-outs the flags byte that includes the detected controllers and just forcibly uses the basic controller in-game.

Resolves #1059 
