### PR TITLE
fixed possible upper case problem in command line arguments parser

### DIFF
--- a/BizHawk.Client.EmuHawk/ArgParser.cs
+++ b/BizHawk.Client.EmuHawk/ArgParser.cs
@@ -50,11 +50,11 @@ namespace BizHawk.Client.EmuHawk
 
 				if (arg.StartsWith("--load-state="))
 				{
-					cmdLoadState = arg.Substring(arg.IndexOf('=') + 1);
+					cmdLoadState = args[i].Substring(args[i].IndexOf('=') + 1);
 				}
 				else if (arg.StartsWith("--movie="))
 				{
-					cmdMovie = arg.Substring(arg.IndexOf('=') + 1);
+					cmdMovie = args[i].Substring(args[i].IndexOf('=') + 1);
 				}
 				else if (arg.StartsWith("--dump-type="))
 				{
@@ -75,7 +75,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else if (arg.StartsWith("--dump-name="))
 				{
-					cmdDumpName = arg.Substring(arg.IndexOf('=') + 1);
+					cmdDumpName = args[i].Substring(args[i].IndexOf('=') + 1);
 				}
 				else if (arg.StartsWith("--dump-length="))
 				{
@@ -95,7 +95,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else if (arg.StartsWith("--lua="))
 				{
-					luaScript = arg.Substring(arg.IndexOf('=') + 1);
+					luaScript = args[i].Substring(args[i].IndexOf('=') + 1);
 					luaConsole = true;
 				}
 				else if (arg.StartsWith("--luaconsole"))


### PR DESCRIPTION
the command line argument parser uses `args[i].ToLower()` to capture arguments which are not only lower case characters but this way also changes the passed argument.
The PR addresses this issue for parameters (load-state, movie, dump-name, lua) where upper case characters might be used by the user.