### PR TITLE
Fix for #1094 lua mainmemory.readbyterange() issue

### DIFF
--- a/BizHawk.Client.Common/lua/LuaMemoryBase.cs
+++ b/BizHawk.Client.Common/lua/LuaMemoryBase.cs
@@ -177,7 +177,7 @@ namespace BizHawk.Client.Common
 			var d = string.IsNullOrEmpty(domain) ? Domain : DomainList[VerifyMemoryDomain(domain)];
 			var lastAddr = length + addr;
 			var table = Lua.NewTable();
-			if (lastAddr < d.Size)
+			if (lastAddr <= d.Size)
 			{
 				for (var i = 0; i < length; i++)
 				{


### PR DESCRIPTION
After changing the range check this last remaining byte could be read successfully.

    local mem = mainmemory.readbyterange(0x0000,2048)
    console.log(mem)

Now produces the last entry (2047) for NES games as well:
[...]
"2040": "3"
"2041": "8"
"2042": "4"
"2043": "0"
"2044": "0"
"2045": "0"
"2046": "0"
"2047": "165"
"205": "0"
"206": "176"
[...]

