### PR TITLE
Lua: fix client.openrom

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
@@ -189,7 +189,8 @@ namespace BizHawk.Client.EmuHawk
 		[LuaMethod("openrom", "opens the Open ROM dialog")]
 		public static void OpenRom(string path)
 		{
-			GlobalWin.MainForm.LoadRom(path, new MainForm.LoadRomArgs { OpenAdvanced = new OpenAdvanced_OpenRom() });
+			var ioa = OpenAdvancedSerializer.ParseWithLegacy(path);
+			GlobalWin.MainForm.LoadRom(path, new MainForm.LoadRomArgs { OpenAdvanced = ioa });
 		}
 
 		[LuaMethod("opentasstudio", "opens the TAStudio dialog")]


### PR DESCRIPTION
The Lua function `client.openrom` did not work ever since 74d1eba3689d118f4359a37fde2489ebe6267b24.