### PR TITLE
State manager decay

### DIFF
--- a/BizHawk.Client.Common/BizHawk.Client.Common.csproj
+++ b/BizHawk.Client.Common/BizHawk.Client.Common.csproj
@@ -184,6 +184,7 @@
     </Compile>
     <Compile Include="movie\bk2\StringLogs.cs" />
     <Compile Include="movie\import\PXMImport.cs" />
+    <Compile Include="movie\tasproj\StateManagerDecay.cs" />
     <Compile Include="movie\tasproj\StateManagerState.cs" />
     <Compile Include="movie\tasproj\TasBranch.cs" />
     <Compile Include="movie\tasproj\TasMovie.History.cs" />

--- a/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
+++ b/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
@@ -66,7 +66,7 @@ namespace BizHawk.Client.Common
 
 		public void Trigger(int decayStates)
 		{
-			if (_tsm.StateCount <= 1 || decayStates <= 1)
+			if (_tsm.StateCount <= 1 || decayStates < 1)
 				return;
 
 			DecayDirection direction = DecayDirection.Forward;
@@ -137,7 +137,6 @@ namespace BizHawk.Client.Common
 				}
 				else
 				{
-					// todo: this should never happen!!!
 					_tsm.RemoveState(_tsm.GetStateFrameByIndex(1));
 					decayStates--;
 				}

--- a/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
+++ b/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
@@ -1,0 +1,149 @@
+﻿/****************************************************************************************
+	
+	algo by r57shell & feos
+
+	_zeros is the key to GREENZONE DECAY PATTERN
+
+	in a 16 element example, we evaluate these bitwise numbers to count zeros on the right.
+	first element is always assumed to be 16, which has all 4 bits set to 0.
+	each right zero means that we lower the priority of a state that goes at that index.
+	priority changes depending on current frame and amount of states.
+	states with biggest priority get erased first.
+	with a 4-bit battern and no initial gap between states, total frame coverage is about 5 times state count.
+
+	_zeros values are essentialy the values of rshiftby here:
+	bitwise view     frame    rshiftby priority
+	  00010000         0         4         1
+	  00000001         1         0        15
+	  00000010         2         1         7
+	  00000011         3         0        13
+	  00000100         4         2         3
+	  00000101         5         0        11
+	  00000110         6         1         5
+	  00000111         7         0         9
+	  00001000         8         3         1
+	  00001001         9         0         7
+	  00001010        10         1         3
+	  00001011        11         0         5
+	  00001100        12         2         1
+	  00001101        13         0         3
+	  00001110        14         1         1
+	  00001111        15         0         1
+
+*****************************************************************************************/
+using System.Collections.Generic;
+
+namespace BizHawk.Client.Common
+{
+	internal class StateManagerDecay
+	{
+		private TasStateManager _tsm;
+		private List<int> _zeros; // amount of least significant zeros in bitwise view (also max step)
+		private int _bits; // size of _zeros = 2 raised to the power of _bits
+		private int _mask; // for remainder calculation using bitwise instead of division
+		private int _base; // repeat count (like fceux's capacity). only used by aligned spread
+		private int _capacity; // total amount of savestates
+
+		private enum DecayDirection
+		{
+			Forward,    // from 0 to current frame
+			Backward,   // from last frame to current frame
+			Bothway     // both in one call
+		}
+
+		private enum PriorityFormula
+		{
+			Spread,
+			AlignedSpread
+		}
+
+		public StateManagerDecay(TasStateManager tsm, int capacity, int bits)
+		{
+			_tsm = tsm;
+			_zeros = new List<int>();
+
+			UpdateSettings(capacity, bits);
+		}
+
+		public void Trigger(int decayStates)
+		{
+			if (_tsm.StateCount <= 1)
+				return;
+
+			DecayDirection direction = DecayDirection.Forward;
+			PriorityFormula formula = PriorityFormula.Spread;
+			int baseStateIndex = _tsm.GetStateIndexByFrame(Global.Emulator.Frame);
+			int bestForwardPriority = -1;
+			int bestForwardFrame = -1;
+			int bestBackwardPriority = -1;
+			int bestBackwardFrame = -1;
+
+			for (; decayStates > 0; decayStates--)
+			{
+				if (direction == DecayDirection.Forward || direction == DecayDirection.Bothway)
+				{
+					for (int currentStateIndex = 0; currentStateIndex < baseStateIndex; currentStateIndex++)
+					{
+						int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex);
+						int zeroCount = _zeros[currentFrame & _mask];
+						int priority = ((baseStateIndex - currentFrame) >> zeroCount);
+
+						if (formula == PriorityFormula.AlignedSpread)
+							priority -= ((_base * ((1 << zeroCount) * 2 - 1)) >> zeroCount);
+
+						if (priority > bestForwardPriority)
+						{
+							bestForwardPriority = priority;
+							bestForwardFrame = currentFrame;
+						}
+					}
+
+					if (bestForwardFrame != -1)
+						_tsm.RemoveState(bestForwardFrame);
+				}
+
+				if (direction == DecayDirection.Backward || direction == DecayDirection.Bothway)
+				{
+					for (int currentStateIndex = _tsm.StateCount - 1; currentStateIndex > baseStateIndex; currentStateIndex--)
+					{
+						int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex);
+						int zeroCount = _zeros[currentFrame & _mask];
+						int priority = ((baseStateIndex - currentFrame) >> zeroCount);
+
+						if (formula == PriorityFormula.AlignedSpread)
+							priority -= ((_base * ((1 << zeroCount) * 2 - 1)) >> zeroCount);
+
+						if (priority > bestBackwardPriority)
+						{
+							bestBackwardPriority = priority;
+							bestBackwardFrame = currentFrame;
+						}
+					}
+
+					if (bestBackwardFrame != -1)
+						_tsm.RemoveState(bestBackwardFrame);
+				}
+			}
+		}
+
+		public void UpdateSettings(int capacity, int bits)
+		{
+			_bits = bits;
+			_capacity = capacity;
+			_mask = (1 << _bits) - 1;
+			_base = (_capacity + _bits / 2) / (_bits + 1);
+			_zeros[0] = _bits;
+
+			for (int i = 1; i < (1 << _bits); i++)
+			{
+				for (int j = i; j > 0; j >>= 1)
+				{
+					if ((j & 1) > 0)
+						break;
+
+					_zeros[i]++;
+				}
+			}
+		}
+	}
+}

--- a/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
+++ b/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
@@ -67,6 +67,10 @@ namespace BizHawk.Client.Common
 				for (int currentStateIndex = 1; currentStateIndex < baseStateIndex; currentStateIndex++)
 				{
 					int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex) / _step;
+
+					if (_tsm.StateIsMarker(currentFrame * _step))
+						continue;
+
 					int zeroCount = _zeros[currentFrame & _mask];
 					int priority = ((baseStateFrame - currentFrame) >> zeroCount);
 
@@ -83,6 +87,10 @@ namespace BizHawk.Client.Common
 				for (int currentStateIndex = _tsm.StateCount - 1; currentStateIndex > baseStateIndex; currentStateIndex--)
 				{
 					int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex) / _step;
+
+					if (_tsm.StateIsMarker(currentFrame * _step))
+						continue;
+
 					int zeroCount = _zeros[currentFrame & _mask];
 					int priority = ((currentFrame - baseStateFrame) >> zeroCount);
 

--- a/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
+++ b/BizHawk.Client.Common/movie/tasproj/StateManagerDecay.cs
@@ -1,15 +1,16 @@
 ﻿/****************************************************************************************
 	
-	algo by r57shell & feos
+	Algorithm by r57shell & feos, 2018
 
-	_zeros is the key to GREENZONE DECAY PATTERN
+	_zeros is the key to GREENZONE DECAY PATTERN.
 
-	in a 16 element example, we evaluate these bitwise numbers to count zeros on the right.
-	first element is always assumed to be 16, which has all 4 bits set to 0.
-	each right zero means that we lower the priority of a state that goes at that index.
-	priority changes depending on current frame and amount of states.
-	states with biggest priority get erased first.
-	with a 4-bit battern and no initial gap between states, total frame coverage is about 5 times state count.
+	In a 16 element example, we evaluate these bitwise numbers to count zeros on the right.
+	First element is always assumed to be 16, which has all 4 bits set to 0. Each right zero
+	means that we lower the priority of a state that goes at that index. Priority changes
+	depending on current frame and amount of states. States with biggest priority get erased
+	first. With a 4-bit battern and no initial gap between states, total frame coverage is
+	about 5 times state count. Initial state gap can screw up our patterns, so do all
+	calculations like gap isn't there, and take it back into account afterwards.
 
 	_zeros values are essentialy the values of rshiftby here:
 	bitwise view     frame    rshiftby priority
@@ -32,20 +33,19 @@
 
 *****************************************************************************************/
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BizHawk.Client.Common
 {
 	internal class StateManagerDecay
 	{
-		private TasStateManager _tsm;
-		private List<int> _zeros;	// amount of least significant zeros in bitwise view (also max step)
-		private int _bits;			// size of _zeros = 2 raised to the power of _bits
-		private int _mask;			// for remainder calculation using bitwise instead of division
-		private int _base;			// repeat count (like fceux's capacity). only used by aligned algo
-		private int _capacity;		// total amount of savestates
-		private int _step;			// initial memory state gap
-		private bool _align;
+		private TasStateManager _tsm;	// access tsm methods to make life easier
+		private List<int> _zeros;		// amount of least significant zeros in bitwise view (also max pattern step)
+		private int _bits;				// size of _zeros is 2 raised to the power of _bits
+		private int _mask;				// for remainder calculation using bitwise instead of division
+		private int _base;				// repeat count (like fceux's capacity). only used by aligned formula
+		private int _capacity;			// total amount of savestates
+		private int _step;				// initial memory state gap
+		private bool _align;			// extra care about fine alignment. TODO: do we want it?
 
 		public StateManagerDecay(TasStateManager tsm)
 		{
@@ -69,13 +69,17 @@ namespace BizHawk.Client.Common
 					int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex) / _step;
 
 					if (_tsm.StateIsMarker(currentFrame * _step))
+					{
 						continue;
+					}
 
 					int zeroCount = _zeros[currentFrame & _mask];
 					int priority = ((baseStateFrame - currentFrame) >> zeroCount);
 
 					if (_align)
+					{
 						priority -= ((_base * ((1 << zeroCount) * 2 - 1)) >> zeroCount);
+					}
 
 					if (priority > forwardPriority)
 					{
@@ -89,13 +93,17 @@ namespace BizHawk.Client.Common
 					int currentFrame = _tsm.GetStateFrameByIndex(currentStateIndex) / _step;
 
 					if (_tsm.StateIsMarker(currentFrame * _step))
+					{
 						continue;
+					}
 
 					int zeroCount = _zeros[currentFrame & _mask];
 					int priority = ((currentFrame - baseStateFrame) >> zeroCount);
 
 					if (_align)
+					{
 						priority -= ((_base * ((1 << zeroCount) * 2 - 1)) >> zeroCount);
+					}
 
 					if (priority > backwardPriority)
 					{
@@ -107,9 +115,13 @@ namespace BizHawk.Client.Common
 				if (forwardFrame > -1 && backwardFrame > -1)
 				{
 					if (baseStateFrame - forwardFrame > backwardFrame - baseStateFrame)
+					{
 						_tsm.RemoveState(forwardFrame * _step);
+					}
 					else
+					{
 						_tsm.RemoveState(backwardFrame * _step);
+					}
 
 					decayStates--;
 				}
@@ -143,7 +155,9 @@ namespace BizHawk.Client.Common
 				for (int j = i; j > 0; j >>= 1)
 				{
 					if ((j & 1) > 0)
+					{
 						break;
+					}
 
 					_zeros[i]++;
 				}

--- a/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
@@ -292,9 +292,9 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public void LimitStateCount()
 		{
-			if (StateCount > _maxStates || DiskUsed > (ulong)Settings.DiskCapacitymb * 1024 * 1024)
+			if (StateCount + 1 > _maxStates || DiskUsed > (ulong)Settings.DiskCapacitymb * 1024 * 1024)
 			{
-				_decay.Trigger(StateCount - _maxStates);
+				_decay.Trigger(StateCount + 1 - _maxStates);
 			}
 		}
 

--- a/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
@@ -63,7 +63,7 @@ namespace BizHawk.Client.Common
 				SetState(0, _movie.BinarySavestate);
 			}
 
-			_decay = new StateManagerDecay(_movie.TasStateManager, _maxStates, 4);
+			_decay = new StateManagerDecay(this);
 		}
 
 		public void Dispose()
@@ -78,7 +78,7 @@ namespace BizHawk.Client.Common
 					((int)_expectedStateSize / Settings.MemStateGapDivider / 1024),
 					_minFrequency, _maxFrequency);
 
-			//_decay.UpdateSettings(_maxStates, 4);
+			_decay.UpdateSettings(_maxStates, 4);
 		}
 
 		/// <summary>
@@ -292,9 +292,9 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		public void LimitStateCount()
 		{
-			while (Used + _expectedStateSize > Settings.Cap || DiskUsed > (ulong)Settings.DiskCapacitymb * 1024 * 1024)
+			if (StateCount > _maxStates || DiskUsed > (ulong)Settings.DiskCapacitymb * 1024 * 1024)
 			{
-				//_decay.Trigger(1);
+				_decay.Trigger(StateCount - _maxStates);
 			}
 		}
 

--- a/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
@@ -78,7 +78,7 @@ namespace BizHawk.Client.Common
 					((int)_expectedStateSize / Settings.MemStateGapDivider / 1024),
 					_minFrequency, _maxFrequency);
 
-			_decay.UpdateSettings(_maxStates, 4);
+			_decay.UpdateSettings(_maxStates, _stateFrequency, 4);
 		}
 
 		/// <summary>
@@ -374,7 +374,7 @@ namespace BizHawk.Client.Common
 				if (direction > 0)
 					leftoverStates = _states.Where(s => s.Key > 0 && s.Key < lastStateFrame).ToList();
 				else
-					leftoverStates = _states.Where(s => s.Key > lastStateFrame && s.Key < LastEmulatedFrame).ToList();
+					leftoverStates = _states.Where(s => s.Key > lastStateFrame && s.Key < LastStatedFrame).ToList();
 
 				foreach (var state in leftoverStates)
 				{
@@ -613,7 +613,7 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public int LastEmulatedFrame
+		public int LastStatedFrame
 		{
 			get
 			{

--- a/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs
@@ -548,7 +548,9 @@ namespace BizHawk.Client.Common
 		/// <returns></returns>
 		public int GetStateFrameByIndex(int index)
 		{
-			return _states.ElementAt(index).Key;
+			// feos: this is called super often by decay
+			// this method is hundred times faster than _states.ElementAt(index).Key
+			return _states.Keys[index];
 		}
 
 		private ulong _used;

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -764,7 +764,7 @@ namespace BizHawk.Client.EmuHawk
 
 			GoToFrame(0);
 			int lastState = 0;
-			int goToFrame = CurrentTasMovie.TasStateManager.LastEmulatedFrame;
+			int goToFrame = CurrentTasMovie.TasStateManager.LastStatedFrame;
 			do
 			{
 				Mainform.FrameAdvance();

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -807,6 +807,7 @@ namespace BizHawk.Client.EmuHawk
 
 			TasView.Refresh();
 
+			//SetSplicer();
 			CurrentTasMovie.FlushInputCache();
 			CurrentTasMovie.UseInputCache = false;
 
@@ -939,6 +940,7 @@ namespace BizHawk.Client.EmuHawk
 			SplicerStatusLabel.Text =
 				"Selected: " + TasView.SelectedRows.Count() + " frame" +
 				(TasView.SelectedRows.Count() == 1 ? "" : "s") +
+				//", State count: " + CurrentTasMovie.TasStateManager.StateCount.ToString();
 				", Clipboard: " + (_tasClipboard.Any() ? _tasClipboard.Count + " frame" +
 				(_tasClipboard.Count == 1 ? "" : "s") : "empty");
 		}

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -940,7 +940,7 @@ namespace BizHawk.Client.EmuHawk
 			SplicerStatusLabel.Text =
 				"Selected: " + TasView.SelectedRows.Count() + " frame" +
 				(TasView.SelectedRows.Count() == 1 ? "" : "s") +
-				//", State count: " + CurrentTasMovie.TasStateManager.StateCount.ToString();
+				//", State count: " + CurrentTasMovie.TasStateManager.StateCount.ToString() +
 				", Clipboard: " + (_tasClipboard.Any() ? _tasClipboard.Count + " frame" +
 				(_tasClipboard.Count == 1 ? "" : "s") : "empty");
 		}


### PR DESCRIPTION
* Finally use exponential decay algorithm for greenzone
  * Works in both directions (unlike fceux taseditor)
* Stop using last accesses states for anything
* When dropping states per project save, account for state gap better
* Use _states.Keys[i] instead of _states.ElementAt{i).Key in speedy parts, because it's apparently tons faster
* Use StateIsMarker() where it's supposed to be used
* Markers are still left untouched
* Branch states are still dead (probably forever)