### PR TITLE
Lua: Add optional position parameters to `DrawPolygon`

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
@@ -1043,7 +1043,7 @@ namespace BizHawk.Client.EmuHawk
 					{
 						if (control is LuaPictureBox)
 						{
-							(control as LuaPictureBox).DrawPolygon(points, line, x, y, background);
+							(control as LuaPictureBox).DrawPolygon(points, x, y, line, background);
 						}
 					}
 				}

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
@@ -1026,7 +1026,7 @@ namespace BizHawk.Client.EmuHawk
 		[LuaMethod(
 			"drawPolygon",
 			"Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). If x or y is passed, the polygon will be translated by the passed coordinate pair. Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(int componentHandle, LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
+		public void DrawPolygon(int componentHandle, LuaTable points, int? x = null, int? y = null, Color? line = null, Color? background = null)
 		{
 			try
 			{

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Forms.cs
@@ -1022,11 +1022,11 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("forms.drawPolygon( 334, { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 0x007F00FF, 0x7F7F7FFF );")]
+		[LuaMethodExample("forms.drawPolygon( 334, { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 10, 30, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod(
 			"drawPolygon",
-			"Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(int componentHandle, LuaTable points, Color? line = null, Color? background = null)
+			"Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). If x or y is passed, the polygon will be translated by the passed coordinate pair. Line is the color of the polygon. Background is the optional fill color")]
+		public void DrawPolygon(int componentHandle, LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
 		{
 			try
 			{
@@ -1043,7 +1043,7 @@ namespace BizHawk.Client.EmuHawk
 					{
 						if (control is LuaPictureBox)
 						{
-							(control as LuaPictureBox).DrawPolygon(points, line, background);
+							(control as LuaPictureBox).DrawPolygon(points, line, x, y, background);
 						}
 					}
 				}

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Gui.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Gui.cs
@@ -450,7 +450,7 @@ namespace BizHawk.Client.EmuHawk
 
 		[LuaMethodExample("gui.drawPolygon( { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 10, 30, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawPolygon", "Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). If x or y is passed, the polygon will be translated by the passed coordinate pair. Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int? x = null, int? y = null, Color? line = null, Color? background = null)
 		{
 			using (var g = GetGraphics())
 			{
@@ -460,7 +460,7 @@ namespace BizHawk.Client.EmuHawk
 					var i = 0;
 					foreach (LuaTable point in points.Values)
 					{
-						pointsArr[i] = new Point(LuaInt(point[1]) + x, LuaInt(point[2]) + y);
+						pointsArr[i] = new Point(LuaInt(point[1]) + x ?? 0, LuaInt(point[2]) + y ?? 0);
 						i++;
 					}
 

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Gui.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Gui.cs
@@ -448,9 +448,9 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		[LuaMethodExample("gui.drawPolygon( { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 0x007F00FF, 0x7F7F7FFF );")]
-		[LuaMethod("drawPolygon", "Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(LuaTable points, Color? line = null, Color? background = null)
+		[LuaMethodExample("gui.drawPolygon( { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 10, 30, 0x007F00FF, 0x7F7F7FFF );")]
+		[LuaMethod("drawPolygon", "Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). If x or y is passed, the polygon will be translated by the passed coordinate pair. Line is the color of the polygon. Background is the optional fill color")]
+		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
 		{
 			using (var g = GetGraphics())
 			{
@@ -460,7 +460,7 @@ namespace BizHawk.Client.EmuHawk
 					var i = 0;
 					foreach (LuaTable point in points.Values)
 					{
-						pointsArr[i] = new Point(LuaInt(point[1]), LuaInt(point[2]));
+						pointsArr[i] = new Point(LuaInt(point[1]) + x, LuaInt(point[2]) + y);
 						i++;
 					}
 

--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
@@ -291,7 +291,7 @@ namespace BizHawk.Client.EmuHawk
 		[LuaMethod(
 			"drawPolygon",
 			"Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int? x = null, int? y = null, Color? line = null, Color? background = null)
 		{
 			try
 			{

--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
@@ -291,11 +291,11 @@ namespace BizHawk.Client.EmuHawk
 		[LuaMethod(
 			"drawPolygon",
 			"Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(LuaTable points, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
 		{
 			try
 			{
-				luaPictureBox.DrawPolygon(points, line, background);
+				luaPictureBox.DrawPolygon(points, line, x, y, background);
 			}
 			catch (Exception ex)
 			{

--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaCanvas.cs
@@ -295,7 +295,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			try
 			{
-				luaPictureBox.DrawPolygon(points, line, x, y, background);
+				luaPictureBox.DrawPolygon(points, x, y, line, background);
 			}
 			catch (Exception ex)
 			{

--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
@@ -255,13 +255,13 @@ namespace BizHawk.Client.EmuHawk
 			boxBackground.DrawLine(GetPen(color ?? _defaultForeground), x, y, x + 0.1F, y);
 		}
 
-		public void DrawPolygon(LuaTable points, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
 		{
 			var pointsArr = new Point[points.Values.Count];
 			var i = 0;
 			foreach (LuaTable point in points.Values)
 			{
-				pointsArr[i] = new Point((int)(double)(point[1]), (int)(double)(point[2]));
+				pointsArr[i] = new Point((int)(double)(point[1]) + x, (int)(double)(point[2]) + y);
 				i++;
 			}
 

--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
@@ -255,13 +255,13 @@ namespace BizHawk.Client.EmuHawk
 			boxBackground.DrawLine(GetPen(color ?? _defaultForeground), x, y, x + 0.1F, y);
 		}
 
-		public void DrawPolygon(LuaTable points, int x = 0, int y = 0, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int? x = null, int? y = null, Color? line = null, Color? background = null)
 		{
 			var pointsArr = new Point[points.Values.Count];
 			var i = 0;
 			foreach (LuaTable point in points.Values)
 			{
-				pointsArr[i] = new Point((int)(double)(point[1]) + x, (int)(double)(point[2]) + y);
+				pointsArr[i] = new Point((int)(double)(point[1]) + x ?? 0, (int)(double)(point[2]) + y ?? 0);
 				i++;
 			}
 


### PR DESCRIPTION
In some cases, a user may want to draw a polygon at a different position without needing to update every point. The proposed changes optimize this task by applying the translation while populating the array of points.

Note that this change breaks backwards compatibility of `gui.drawPolygon`, `forms.drawPolygon`, and `LuaCanvas.DrawPolygon` by placing the new `x` and `y` parameters before `line` and `background`. This was done to maintain the convention of color arguments going last.