### PR TITLE
Use generic interface type on MOS 6052X for talking to the emulator core

### DIFF
--- a/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
+++ b/BizHawk.Emulation.Cores/BizHawk.Emulation.Cores.csproj
@@ -1299,6 +1299,7 @@
     <Compile Include="CPUs\LR35902\Registers.cs" />
     <Compile Include="CPUs\LR35902\Tables_Direct.cs" />
     <Compile Include="CPUs\LR35902\Tables_Indirect.cs" />
+    <Compile Include="CPUs\MOS 6502X\IMOS6502XLink.cs" />
     <Compile Include="CPUs\W65816\Disassembler.cs" />
     <Compile Include="CPUs\68000\Diassembler.cs" />
     <Compile Include="CPUs\68000\Instructions\BitArithemetic.cs" />
@@ -1439,6 +1440,7 @@
     <None Include="Consoles\Nintendo\NES\Docs\BoardTable.xlsx" />
     <None Include="Consoles\Nintendo\NES\Docs\MapperCompatibilityList.url" />
     <None Include="Consoles\Nintendo\NES\Docs\nesasm.pdf" />
+    <Compile Include="Consoles\Nintendo\NES\NES.CpuLink.cs" />
     <None Include="Resources\128.ROM.gz" />
     <None Include="Resources\48.ROM.gz" />
     <None Include="Resources\cgb_boot.bin.gz" />

--- a/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Disassembler.cs
+++ b/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Disassembler.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace BizHawk.Emulation.Cores.Components.M6502
 {
-	public partial class MOS6502X : IDisassemblable
+	public partial class MOS6502X<TLink> : IDisassemblable
 	{
 		private static ushort peeker_word(ushort address, Func<ushort, byte> peeker)
 		{
@@ -15,7 +15,43 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 		public string Disassemble(ushort pc, out int bytesToAdvance)
 		{
-			return Disassemble(pc, out bytesToAdvance, PeekMemory);
+			return MOS6502X.Disassemble(pc, out bytesToAdvance, _link.PeekMemory);
+		}
+
+		public string Cpu
+		{
+			get
+			{
+				return "6502";
+			}
+			set
+			{
+			}
+		}
+
+		public string PCRegisterName
+		{
+			get { return "PC"; }
+		}
+
+		public IEnumerable<string> AvailableCpus
+		{
+			get { yield return "6502"; }
+		}
+
+		public string Disassemble(MemoryDomain m, uint addr, out int length)
+		{
+			return MOS6502X.Disassemble((ushort)addr, out length, a => m.PeekByte((int)a));
+		}
+	}
+
+	public static class MOS6502X
+	{
+		private static ushort peeker_word(ushort address, Func<ushort, byte> peeker)
+		{
+			byte l = peeker(address);
+			byte h = peeker(++address);
+			return (ushort)((h << 8) | l);
 		}
 
 		/// <summary>
@@ -207,32 +243,6 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			}
 			bytesToAdvance = 1;
 			return "???";
-		}
-
-		public string Cpu
-		{
-			get
-			{
-				return "6502";
-			}
-			set
-			{
-			}
-		}
-
-		public string PCRegisterName
-		{
-			get { return "PC"; }
-		}
-
-		public IEnumerable<string> AvailableCpus
-		{
-			get { yield return "6502"; }
-		}
-
-		public string Disassemble(MemoryDomain m, uint addr, out int length)
-		{
-			return Disassemble((ushort)addr, out length, a => m.PeekByte((int)a));
 		}
 	}
 }

--- a/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
+++ b/BizHawk.Emulation.Cores/CPUs/MOS 6502X/Execute.cs
@@ -7,7 +7,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Components.M6502
 {
-	public partial class MOS6502X
+	public partial class MOS6502X<TLink>
 	{
 		//dont know whether this system is any faster. hard to get benchmarks someone else try it?
 		//static ShortBuffer CompiledMicrocode;
@@ -537,7 +537,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				DummyReadMemory(PC);
+				_link.DummyReadMemory(PC);
 			}
 		}
 
@@ -610,10 +610,10 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			{
 				if (debug) Console.WriteLine(State());
 				branch_irq_hack = false;
-				if (OnExecFetch != null) OnExecFetch(PC);
+				_link.OnExecFetch(PC);
 				if (TraceCallback != null)
 					TraceCallback(State());
-				opcode = ReadMemory(PC++);
+				opcode = _link.ReadMemory(PC++);
 				mi = -1;
 			}
 		}
@@ -622,7 +622,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				opcode2 = ReadMemory(PC++);
+				opcode2 = _link.ReadMemory(PC++);
 			}
 		}
 		void Fetch3()
@@ -630,21 +630,21 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				opcode3 = ReadMemory(PC++);
+				opcode3 = _link.ReadMemory(PC++);
 			}
 		}
 		void PushPCH()
 		{
-			WriteMemory((ushort)(S-- + 0x100), (byte)(PC >> 8));
+			_link.WriteMemory((ushort)(S-- + 0x100), (byte)(PC >> 8));
 		}
 		void PushPCL()
 		{
-			WriteMemory((ushort)(S-- + 0x100), (byte)PC);
+			_link.WriteMemory((ushort)(S-- + 0x100), (byte)PC);
 		}
 		void PushP_BRK()
 		{
 			FlagB = true;
-			WriteMemory((ushort)(S-- + 0x100), P);
+			_link.WriteMemory((ushort)(S-- + 0x100), P);
 			FlagI = true;
 			ea = BRKVector;
 
@@ -652,7 +652,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		void PushP_IRQ()
 		{
 			FlagB = false;
-			WriteMemory((ushort)(S-- + 0x100), P);
+			_link.WriteMemory((ushort)(S-- + 0x100), P);
 			FlagI = true;
 			ea = IRQVector;
 
@@ -660,7 +660,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		void PushP_NMI()
 		{
 			FlagB = false;
-			WriteMemory((ushort)(S-- + 0x100), P);
+			_link.WriteMemory((ushort)(S-- + 0x100), P);
 			FlagI = true; //is this right?
 			ea = NMIVector;
 
@@ -692,7 +692,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 					NMI = false;
 					ea = NMIVector;
 				}
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
@@ -701,7 +701,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp += ReadMemory((ushort)(ea + 1)) << 8;
+				alu_temp += _link.ReadMemory((ushort)(ea + 1)) << 8;
 				PC = (ushort)alu_temp;
 			}
 
@@ -859,36 +859,36 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_WRITE_STA()
 		{
-			WriteMemory((ushort)((opcode3 << 8) + opcode2), A);
+			_link.WriteMemory((ushort)((opcode3 << 8) + opcode2), A);
 		}
 		void Abs_WRITE_STX()
 		{
-			WriteMemory((ushort)((opcode3 << 8) + opcode2), X);
+			_link.WriteMemory((ushort)((opcode3 << 8) + opcode2), X);
 		}
 		void Abs_WRITE_STY()
 		{
-			WriteMemory((ushort)((opcode3 << 8) + opcode2), Y);
+			_link.WriteMemory((ushort)((opcode3 << 8) + opcode2), Y);
 		}
 		void Abs_WRITE_SAX()
 		{
-			WriteMemory((ushort)((opcode3 << 8) + opcode2), (byte)(X & A));
+			_link.WriteMemory((ushort)((opcode3 << 8) + opcode2), (byte)(X & A));
 
 		}
 		void ZP_WRITE_STA()
 		{
-			WriteMemory(opcode2, A);
+			_link.WriteMemory(opcode2, A);
 		}
 		void ZP_WRITE_STY()
 		{
-			WriteMemory(opcode2, Y);
+			_link.WriteMemory(opcode2, Y);
 		}
 		void ZP_WRITE_STX()
 		{
-			WriteMemory(opcode2, X);
+			_link.WriteMemory(opcode2, X);
 		}
 		void ZP_WRITE_SAX()
 		{
-			WriteMemory(opcode2, (byte)(X & A));
+			_link.WriteMemory(opcode2, (byte)(X & A));
 
 		}
 		void IndIdx_Stage3()
@@ -896,7 +896,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ea = ReadMemory(opcode2);
+				ea = _link.ReadMemory(opcode2);
 			}
 
 		}
@@ -906,7 +906,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				alu_temp = ea + Y;
-				ea = (ReadMemory((byte)(opcode2 + 1)) << 8)
+				ea = (_link.ReadMemory((byte)(opcode2 + 1)) << 8)
 					| ((alu_temp & 0xFF));
 			}
 
@@ -916,7 +916,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory((ushort)ea);
+				_link.ReadMemory((ushort)ea);
 				ea += (alu_temp >> 8) << 8;
 			}
 
@@ -934,7 +934,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 				}
 				else
 				{
-					ReadMemory((ushort)ea);
+					_link.ReadMemory((ushort)ea);
 					ea = (ushort)(ea + 0x100);
 				}
 			}
@@ -944,7 +944,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory((ushort)ea);
+				_link.ReadMemory((ushort)ea);
 				if (alu_temp.Bit(8))
 					ea = (ushort)(ea + 0x100);
 				
@@ -953,12 +953,12 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_WRITE_Stage6_STA()
 		{
-			WriteMemory((ushort)ea, A);
+			_link.WriteMemory((ushort)ea, A);
 
 		}
 		void IndIdx_WRITE_Stage6_SHA()
 		{
-			WriteMemory((ushort)ea, (byte)(A & X & 7));
+			_link.WriteMemory((ushort)ea, (byte)(A & X & 7));
 
 		}
 		void IndIdx_READ_Stage6_LDA()
@@ -966,7 +966,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory((ushort)ea);
+				A = _link.ReadMemory((ushort)ea);
 				NZ_A();
 			}
 		}
@@ -975,7 +975,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Cmp();
 			}
 		}
@@ -984,7 +984,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_And();
 			}
 		}
@@ -993,7 +993,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Eor();
 			}
 		}
@@ -1002,7 +1002,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = X = ReadMemory((ushort)ea);
+				A = X = _link.ReadMemory((ushort)ea);
 				NZ_A();
 			}
 		}
@@ -1011,7 +1011,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Adc();
 			}
 		}
@@ -1020,7 +1020,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Sbc();
 			}
 		}
@@ -1029,7 +1029,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Ora();
 			}
 		}
@@ -1038,13 +1038,13 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
 		void IndIdx_RMW_Stage7_SLO()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)((value8 << 1));
@@ -1053,7 +1053,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_RMW_Stage7_SRE()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -1062,7 +1062,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_RMW_Stage7_RRA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -1070,14 +1070,14 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_RMW_Stage7_ISC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 + 1);
 			_Sbc();
 		}
 		void IndIdx_RMW_Stage7_DCP()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 - 1);
 			FlagC = (temp8 & 1) != 0;
@@ -1085,7 +1085,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_RMW_Stage7_RLA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -1094,7 +1094,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IndIdx_RMW_Stage8()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 		}
 		void RelBranch_Stage2_BVS()
 		{
@@ -1142,7 +1142,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				opcode2 = ReadMemory(PC++);
+				opcode2 = _link.ReadMemory(PC++);
 				if (branch_taken)
 				{
 					branch_taken = false;
@@ -1213,7 +1213,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				PC = (ushort)((ReadMemory((ushort)(PC)) << 8) + opcode2);
+				PC = (ushort)((_link.ReadMemory((ushort)(PC)) << 8) + opcode2);
 			}
 		}
 		void PullP()
@@ -1221,7 +1221,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				P = ReadMemory((ushort)(S++ + 0x100));
+				P = _link.ReadMemory((ushort)(S++ + 0x100));
 				FlagT = true; //force T always to remain true
 			}
 
@@ -1232,7 +1232,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				PC &= 0xFF00;
-				PC |= ReadMemory((ushort)(S++ + 0x100));
+				PC |= _link.ReadMemory((ushort)(S++ + 0x100));
 			}
 
 		}
@@ -1242,7 +1242,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				PC &= 0xFF;
-				PC |= (ushort)(ReadMemory((ushort)(S + 0x100)) << 8);
+				PC |= (ushort)(_link.ReadMemory((ushort)(S + 0x100)) << 8);
 			}
 
 		}
@@ -1251,7 +1251,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				A = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				NZ_A();
 			}
 		}
@@ -1260,7 +1260,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				Y = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				Y = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				NZ_Y();
 			}
 		}
@@ -1269,7 +1269,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				X = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				X = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				NZ_X();
 			}
 		}
@@ -1278,7 +1278,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Bit();
 			}
 		}
@@ -1287,8 +1287,8 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
-				A = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				A = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				X = A;
 				NZ_A();
 			}
@@ -1298,7 +1298,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_And();
 			}
 		}
@@ -1307,7 +1307,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Eor();
 			}
 		}
@@ -1316,7 +1316,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Ora();
 			}
 		}
@@ -1325,7 +1325,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Adc();
 			}
 		}
@@ -1334,7 +1334,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Cmp();
 			}
 		}
@@ -1343,7 +1343,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Cpy();
 			}
 		}
@@ -1352,7 +1352,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 			}
 
 		}
@@ -1361,7 +1361,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Cpx();
 			}
 		}
@@ -1370,7 +1370,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)((opcode3 << 8) + opcode2));
+				alu_temp = _link.ReadMemory((ushort)((opcode3 << 8) + opcode2));
 				_Sbc();
 			}
 
@@ -1380,7 +1380,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(opcode2);
+				_link.ReadMemory(opcode2);
 				opcode2 = (byte)(opcode2 + X); //a bit sneaky to shove this into opcode2... but we can reuse all the zero page uops if we do that
 			}
 
@@ -1390,7 +1390,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(opcode2);
+				_link.ReadMemory(opcode2);
 				opcode2 = (byte)(opcode2 + Y); //a bit sneaky to shove this into opcode2... but we can reuse all the zero page uops if we do that
 			}
 
@@ -1400,13 +1400,13 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 			}
 
 		}
 		void ZpIdx_RMW_Stage6()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 
 
 		}
@@ -1415,7 +1415,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Eor();
 			}
 		}
@@ -1424,7 +1424,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Bit();
 			}
 		}
@@ -1433,7 +1433,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory(opcode2);
+				A = _link.ReadMemory(opcode2);
 				NZ_A();
 			}
 		}
@@ -1442,7 +1442,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				Y = ReadMemory(opcode2);
+				Y = _link.ReadMemory(opcode2);
 				NZ_Y();
 			}
 		}
@@ -1451,7 +1451,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				X = ReadMemory(opcode2);
+				X = _link.ReadMemory(opcode2);
 				NZ_X();
 			}
 		}
@@ -1461,7 +1461,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				//?? is this right??
-				X = ReadMemory(opcode2);
+				X = _link.ReadMemory(opcode2);
 				A = X;
 				NZ_A();
 			}
@@ -1471,7 +1471,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Cpy();
 			}
 		}
@@ -1480,7 +1480,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Cmp();
 			}
 		}
@@ -1489,7 +1489,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Cpx();
 			}
 		}
@@ -1498,7 +1498,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Ora();
 			}
 		}
@@ -1507,7 +1507,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(opcode2); //just a dummy
+				_link.ReadMemory(opcode2); //just a dummy
 			}
 
 		}
@@ -1516,7 +1516,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Sbc();
 			}
 		}
@@ -1525,7 +1525,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_Adc();
 			}
 		}
@@ -1534,7 +1534,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 				_And();
 			}
 
@@ -1696,7 +1696,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Eor();
 			}
 		}
@@ -1705,7 +1705,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Anc();
 			}
 		}
@@ -1714,7 +1714,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Asr();
 			}
 		}
@@ -1723,7 +1723,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Axs();
 			}
 		}
@@ -1732,7 +1732,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Arr();
 			}
 		}
@@ -1741,7 +1741,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Lxa();
 			}
 		}
@@ -1750,7 +1750,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Ora();
 			}
 		}
@@ -1759,7 +1759,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Cpy();
 			}
 		}
@@ -1768,7 +1768,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Cpx();
 			}
 		}
@@ -1777,7 +1777,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Cmp();
 			}
 		}
@@ -1786,7 +1786,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Sbc();
 			}
 		}
@@ -1795,7 +1795,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_And();
 			}
 		}
@@ -1804,7 +1804,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(PC++);
+				alu_temp = _link.ReadMemory(PC++);
 				_Adc();
 			}
 		}
@@ -1813,7 +1813,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory(PC++);
+				A = _link.ReadMemory(PC++);
 				NZ_A();
 			}
 		}
@@ -1822,7 +1822,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				X = ReadMemory(PC++);
+				X = _link.ReadMemory(PC++);
 				NZ_X();
 			}
 		}
@@ -1831,7 +1831,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				Y = ReadMemory(PC++);
+				Y = _link.ReadMemory(PC++);
 				NZ_Y();
 			}
 		}
@@ -1840,7 +1840,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(PC++);
+				_link.ReadMemory(PC++);
 			}
 
 		}
@@ -1849,7 +1849,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(opcode2); //dummy?
+				_link.ReadMemory(opcode2); //dummy?
 				alu_temp = (opcode2 + X) & 0xFF;
 			}
 
@@ -1859,7 +1859,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ea = ReadMemory((ushort)alu_temp);
+				ea = _link.ReadMemory((ushort)alu_temp);
 			}
 
 		}
@@ -1868,7 +1868,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ea += (ReadMemory((byte)(alu_temp + 1)) << 8);
+				ea += (_link.ReadMemory((byte)(alu_temp + 1)) << 8);
 			}
 
 		}
@@ -1878,7 +1878,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				//TODO make uniform with others
-				A = ReadMemory((ushort)ea);
+				A = _link.ReadMemory((ushort)ea);
 				NZ_A();
 			}
 		}
@@ -1887,7 +1887,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Ora();
 			}
 		}
@@ -1896,7 +1896,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = X = ReadMemory((ushort)ea);
+				A = X = _link.ReadMemory((ushort)ea);
 				NZ_A();
 			}
 		}
@@ -1905,7 +1905,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Cmp();
 			}
 		}
@@ -1914,7 +1914,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Adc();
 			}
 		}
@@ -1923,7 +1923,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_And();
 			}
 		}
@@ -1932,7 +1932,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Eor();
 			}
 		}
@@ -1941,19 +1941,19 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Sbc();
 			}
 		}
 		void IdxInd_Stage6_WRITE_STA()
 		{
-			WriteMemory((ushort)ea, A);
+			_link.WriteMemory((ushort)ea, A);
 
 		}
 		void IdxInd_Stage6_WRITE_SAX()
 		{
 			alu_temp = A & X;
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			//flag writing skipped on purpose
 
 		}
@@ -1962,13 +1962,13 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
 		void IdxInd_Stage7_RMW_SLO()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)((value8 << 1));
@@ -1977,14 +1977,14 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IdxInd_Stage7_RMW_ISC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 + 1);
 			_Sbc();
 		}
 		void IdxInd_Stage7_RMW_DCP()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 - 1);
 			FlagC = (temp8 & 1) != 0;
@@ -1992,7 +1992,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IdxInd_Stage7_RMW_SRE()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2001,7 +2001,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IdxInd_Stage7_RMW_RRA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
@@ -2010,7 +2010,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IdxInd_Stage7_RMW_RLA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2019,26 +2019,26 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void IdxInd_Stage8_RMW()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 
 
 		}
 		void PushP()
 		{
 			FlagB = true;
-			WriteMemory((ushort)(S-- + 0x100), P);
+			_link.WriteMemory((ushort)(S-- + 0x100), P);
 
 		}
 		void PushA()
 		{
-			WriteMemory((ushort)(S-- + 0x100), A);
+			_link.WriteMemory((ushort)(S-- + 0x100), A);
 		}
 		void PullA_NoInc()
 		{
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory((ushort)(S + 0x100));
+				A = _link.ReadMemory((ushort)(S + 0x100));
 				NZ_A();
 			}
 		}
@@ -2048,7 +2048,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				my_iflag = FlagI;
-				P = ReadMemory((ushort)(S + 0x100));
+				P = _link.ReadMemory((ushort)(S + 0x100));
 				iflag_pending = FlagI;
 				FlagI = my_iflag;
 				FlagT = true; //force T always to remain true
@@ -2107,7 +2107,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				PC = (ushort)((ReadMemory(PC) << 8) + opcode2);
+				PC = (ushort)((_link.ReadMemory(PC) << 8) + opcode2);
 			}
 
 		}
@@ -2116,7 +2116,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				ReadMemory(PC);
+				_link.ReadMemory(PC);
 				PC++;
 			}
 		}	
@@ -2125,29 +2125,29 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory(opcode2);
+				alu_temp = _link.ReadMemory(opcode2);
 			}
 
 		}
 		void ZP_RMW_Stage5()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 		}
 		void ZP_RMW_INC()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			alu_temp = (byte)((alu_temp + 1) & 0xFF);
 			P = (byte)((P & 0x7D) | TableNZ[alu_temp]);
 		}
 		void ZP_RMW_DEC()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			alu_temp = (byte)((alu_temp - 1) & 0xFF);
 			P = (byte)((P & 0x7D) | TableNZ[alu_temp]);
 		}
 		void ZP_RMW_ASL()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)(value8 << 1);
@@ -2155,7 +2155,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_SRE()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2164,7 +2164,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_RRA()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2172,7 +2172,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_DCP()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 - 1);
 			FlagC = (temp8 & 1) != 0;
@@ -2180,7 +2180,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_LSR()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2189,7 +2189,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_ROR()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2197,7 +2197,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_ROL()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2205,7 +2205,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_SLO()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)((value8 << 1));
@@ -2214,14 +2214,14 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void ZP_RMW_ISC()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)(value8 + 1);
 			_Sbc();
 		}
 		void ZP_RMW_RLA()
 		{
-			WriteMemory(opcode2, (byte)alu_temp);
+			_link.WriteMemory(opcode2, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2233,7 +2233,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				opcode3 = ReadMemory(PC++);
+				opcode3 = _link.ReadMemory(PC++);
 				alu_temp = opcode2 + Y;
 				ea = (opcode3 << 8) + (alu_temp & 0xFF);
 
@@ -2245,7 +2245,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				opcode3 = ReadMemory(PC++);
+				opcode3 = _link.ReadMemory(PC++);
 				alu_temp = opcode2 + X;
 				ea = (opcode3 << 8) + (alu_temp & 0xFF);
 			}
@@ -2264,7 +2264,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 				}
 				else
 				{
-					alu_temp = ReadMemory((ushort)ea);
+					alu_temp = _link.ReadMemory((ushort)ea);
 					ea = (ushort)(ea + 0x100);
 				}
 			}
@@ -2279,36 +2279,36 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 				if (alu_temp.Bit(8))
 				{
-					alu_temp = ReadMemory((ushort)ea);
+					alu_temp = _link.ReadMemory((ushort)ea);
 					ea = (ushort)(ea + 0x100);
 				}
-				else alu_temp = ReadMemory((ushort)ea);
+				else alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
 		void AbsIdx_WRITE_Stage5_STA()
 		{
-			WriteMemory((ushort)ea, A);
+			_link.WriteMemory((ushort)ea, A);
 
 		}
 		void AbsIdx_WRITE_Stage5_SHY()
 		{
 			alu_temp = Y & (ea >> 8);
 			ea = (ea & 0xFF) | (alu_temp << 8); //"(the bank where the value is stored may be equal to the value stored)" -- more like IS.
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 
 		}
 		void AbsIdx_WRITE_Stage5_SHX()
 		{
 			alu_temp = X & (ea >> 8);
 			ea = (ea & 0xFF) | (alu_temp << 8); //"(the bank where the value is stored may be equal to the value stored)" -- more like IS.
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 
 		}
 		void AbsIdx_WRITE_Stage5_ERROR()
 		{
 			S = (byte)(X & A);
-			WriteMemory((ushort)ea, (byte)(S & (opcode3+1)));
+			_link.WriteMemory((ushort)ea, (byte)(S & (opcode3+1)));
 
 		}
 		void AbsIdx_RMW_Stage5()
@@ -2316,44 +2316,44 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
 		void AbsIdx_RMW_Stage7()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 
 		}
 		void AbsIdx_RMW_Stage6_DEC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			alu_temp = value8 = (byte)(alu_temp - 1);
 			P = (byte)((P & 0x7D) | TableNZ[value8]);
 
 		}
 		void AbsIdx_RMW_Stage6_DCP()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			alu_temp = value8 = (byte)(alu_temp - 1);
 			_Cmp();
 		}
 		void AbsIdx_RMW_Stage6_ISC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			alu_temp = value8 = (byte)(alu_temp + 1);
 			_Sbc();
 		}
 		void AbsIdx_RMW_Stage6_INC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			alu_temp = value8 = (byte)(alu_temp + 1);
 			P = (byte)((P & 0x7D) | TableNZ[value8]);
 
 		}
 		void AbsIdx_RMW_Stage6_ROL()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2362,7 +2362,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_LSR()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2371,7 +2371,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_SLO()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)(value8 << 1);
@@ -2380,7 +2380,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_SRE()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2389,7 +2389,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_RRA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2397,7 +2397,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_RLA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2406,7 +2406,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_ASL()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)(value8 << 1);
@@ -2415,7 +2415,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void AbsIdx_RMW_Stage6_ROR()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2428,7 +2428,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory((ushort)ea);
+				A = _link.ReadMemory((ushort)ea);
 				NZ_A();
 			}
 		}
@@ -2437,7 +2437,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				X = ReadMemory((ushort)ea);
+				X = _link.ReadMemory((ushort)ea);
 				NZ_X();
 			}
 		}
@@ -2446,7 +2446,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				A = ReadMemory((ushort)ea);
+				A = _link.ReadMemory((ushort)ea);
 				X = A;
 				NZ_A();
 			}
@@ -2456,7 +2456,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				Y = ReadMemory((ushort)ea);
+				Y = _link.ReadMemory((ushort)ea);
 				NZ_Y();
 			}
 		}
@@ -2465,7 +2465,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Ora();
 			}
 		}
@@ -2474,7 +2474,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
@@ -2483,7 +2483,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Cmp();
 			}
 		}
@@ -2492,7 +2492,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Sbc();
 			}
 		}
@@ -2501,7 +2501,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Adc();
 			}
 		}
@@ -2510,7 +2510,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_Eor();
 			}
 		}
@@ -2519,7 +2519,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				_And();
 			}
 		}
@@ -2528,7 +2528,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			rdy_freeze = !RDY;
 			if (RDY)
 			{
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 				S &= (byte)alu_temp;
 				X = S;
 				A = S;
@@ -2542,7 +2542,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				ea = (opcode3 << 8) + opcode2;
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 		}
 		void AbsInd_JMP_Stage5()
@@ -2551,7 +2551,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				ea = (opcode3 << 8) + (byte)(opcode2 + 1);
-				alu_temp += ReadMemory((ushort)ea) << 8;
+				alu_temp += _link.ReadMemory((ushort)ea) << 8;
 				PC = (ushort)alu_temp;
 			}
 
@@ -2562,13 +2562,13 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 			if (RDY)
 			{
 				ea = (opcode3 << 8) + opcode2;
-				alu_temp = ReadMemory((ushort)ea);
+				alu_temp = _link.ReadMemory((ushort)ea);
 			}
 
 		}
 		void Abs_RMW_Stage5_INC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)(alu_temp + 1);
 			alu_temp = value8;
 			P = (byte)((P & 0x7D) | TableNZ[value8]);
@@ -2576,7 +2576,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_DEC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)(alu_temp - 1);
 			alu_temp = value8;
 			P = (byte)((P & 0x7D) | TableNZ[value8]);
@@ -2584,21 +2584,21 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_DCP()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)(alu_temp - 1);
 			alu_temp = value8;
 			_Cmp();
 		}
 		void Abs_RMW_Stage5_ISC()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)(alu_temp + 1);
 			alu_temp = value8;
 			_Sbc();
 		}
 		void Abs_RMW_Stage5_ASL()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)(value8 << 1);
@@ -2607,7 +2607,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_ROR()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2616,7 +2616,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_SLO()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 0x80) != 0;
 			alu_temp = value8 = (byte)(value8 << 1);
@@ -2625,7 +2625,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_RLA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2634,7 +2634,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_SRE()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2643,7 +2643,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_RRA()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 >> 1) | ((P & 1) << 7));
 			FlagC = (temp8 & 1) != 0;
@@ -2651,7 +2651,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_ROL()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = temp8 = (byte)alu_temp;
 			alu_temp = value8 = (byte)((value8 << 1) | (P & 1));
 			FlagC = (temp8 & 0x80) != 0;
@@ -2660,7 +2660,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage5_LSR()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 			value8 = (byte)alu_temp;
 			FlagC = (value8 & 1) != 0;
 			alu_temp = value8 = (byte)(value8 >> 1);
@@ -2670,7 +2670,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		}
 		void Abs_RMW_Stage6()
 		{
-			WriteMemory((ushort)ea, (byte)alu_temp);
+			_link.WriteMemory((ushort)ea, (byte)alu_temp);
 
 
 		}

--- a/BizHawk.Emulation.Cores/CPUs/MOS 6502X/IMOS6502XLink.cs
+++ b/BizHawk.Emulation.Cores/CPUs/MOS 6502X/IMOS6502XLink.cs
@@ -1,5 +1,10 @@
 ﻿namespace BizHawk.Emulation.Cores.Components.M6502
 {
+	// Interface that has all the methods required by the MOS 6502X to talk to
+	// the emulator core.
+	// Should only be used as a generic type argument for the MOS 6502X, and
+	// implementations should be structs where possible. This combination allows
+	// the JITer to generate much faster code than calling a Func<> or Action<>.
 	public interface IMOS6502XLink
 	{
 		byte ReadMemory(ushort address);

--- a/BizHawk.Emulation.Cores/CPUs/MOS 6502X/IMOS6502XLink.cs
+++ b/BizHawk.Emulation.Cores/CPUs/MOS 6502X/IMOS6502XLink.cs
@@ -1,0 +1,13 @@
+﻿namespace BizHawk.Emulation.Cores.Components.M6502
+{
+	public interface IMOS6502XLink
+	{
+		byte ReadMemory(ushort address);
+		byte DummyReadMemory(ushort address);
+		byte PeekMemory(ushort address);
+		void WriteMemory(ushort address, byte value);
+
+		// This only calls when the first byte of an instruction is fetched.
+		void OnExecFetch(ushort address);
+	}
+}

--- a/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
+++ b/BizHawk.Emulation.Cores/CPUs/MOS 6502X/MOS6502X.cs
@@ -6,10 +6,13 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Components.M6502
 {
-	public sealed partial class MOS6502X
+	public sealed partial class MOS6502X<TLink> where TLink : IMOS6502XLink
 	{
-		public MOS6502X()
+		private readonly TLink _link;
+
+		public MOS6502X(TLink link)
 		{
+			_link = link;
 			InitOpcodeHandlers();
 			Reset();
 		}
@@ -62,7 +65,7 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 			for (int i = 0; i < length; i++)
 			{
-				rawbytes += string.Format(" {0:X2}", PeekMemory((ushort)(PC + i)));
+				rawbytes += string.Format(" {0:X2}", _link.PeekMemory((ushort)(PC + i)));
 			}
 
 			return new TraceInfo
@@ -206,39 +209,17 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 
 		public int TotalExecutedCycles;
 
-		public Func<ushort, byte> ReadMemory;
-		public Func<ushort, byte> DummyReadMemory;
-		public Func<ushort, byte> PeekMemory;
-		public Action<ushort, byte> WriteMemory;
-
-		//this only calls when the first byte of an instruction is fetched.
-		public Action<ushort> OnExecFetch;
-
-		public void SetCallbacks
-		(
-			Func<ushort, byte> ReadMemory,
-			Func<ushort, byte> DummyReadMemory,
-			Func<ushort, byte> PeekMemory,
-			Action<ushort, byte> WriteMemory
-		)
-		{
-			this.ReadMemory = ReadMemory;
-			this.DummyReadMemory = DummyReadMemory;
-			this.PeekMemory = PeekMemory;
-			this.WriteMemory = WriteMemory;
-		}
-
 		public ushort ReadWord(ushort address)
 		{
-			byte l = ReadMemory(address);
-			byte h = ReadMemory(++address);
+			byte l = _link.ReadMemory(address);
+			byte h = _link.ReadMemory(++address);
 			return (ushort)((h << 8) | l);
 		}
 
 		public ushort PeekWord(ushort address)
 		{
-			byte l = PeekMemory(address);
-			byte h = PeekMemory(++address);
+			byte l = _link.PeekMemory(address);
+			byte h = _link.PeekMemory(++address);
 			return (ushort)((h << 8) | l);
 		}
 
@@ -246,14 +227,14 @@ namespace BizHawk.Emulation.Cores.Components.M6502
 		{
 			byte l = (byte)(value & 0xFF);
 			byte h = (byte)(value >> 8);
-			WriteMemory(address, l);
-			WriteMemory(++address, h);
+			_link.WriteMemory(address, l);
+			_link.WriteMemory(++address, h);
 		}
 
 		private ushort ReadWordPageWrap(ushort address)
 		{
 			ushort highAddress = (ushort)((address & 0xFF00) + ((address + 1) & 0xFF));
-			return (ushort)(ReadMemory(address) | (ReadMemory(highAddress) << 8));
+			return (ushort)(_link.ReadMemory(address) | (_link.ReadMemory(highAddress) << 8));
 		}
 
 		// SO pin

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
@@ -10,10 +10,27 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 	public sealed partial class Chip6510
 	{
 		// ------------------------------------
-		private readonly MOS6502X _cpu;
+		private readonly MOS6502X<CpuLink> _cpu;
 		private bool _pinNmiLast;
 		private LatchedPort _port;
 		private bool _thisNmi;
+
+		private struct CpuLink : IMOS6502XLink
+		{
+			private readonly Chip6510 _chip;
+
+			public CpuLink(Chip6510 chip) => _chip = chip;
+
+			public byte DummyReadMemory(ushort address) => unchecked((byte)_chip.Read(address));
+
+			public void OnExecFetch(ushort address) { }
+
+			public byte PeekMemory(ushort address) => unchecked((byte)_chip.Peek(address));
+
+			public byte ReadMemory(ushort address) => unchecked((byte)_chip.Read(address));
+
+			public void WriteMemory(ushort address, byte value) => _chip.Write(address, value);
+		}
 
 		public Func<int, int> PeekMemory;
 		public Action<int, int> PokeMemory;
@@ -33,13 +50,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 		public Chip6510()
 		{
 			// configure cpu r/w
-			_cpu = new MOS6502X
-			{
-				DummyReadMemory = CpuRead,
-				ReadMemory = CpuRead,
-				WriteMemory = CpuWrite,
-				PeekMemory = CpuPeek
-			};
+			_cpu = new MOS6502X<CpuLink>(new CpuLink(this));
 
 			// perform hard reset
 			HardReset();

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Chip6510.cs
@@ -19,7 +19,10 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 		{
 			private readonly Chip6510 _chip;
 
-			public CpuLink(Chip6510 chip) => _chip = chip;
+			public CpuLink(Chip6510 chip)
+			{
+				_chip = chip;
+			}
 
 			public byte DummyReadMemory(ushort address) => unchecked((byte)_chip.Read(address));
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
@@ -19,7 +19,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 		private bool _motorEnabled;
 		private bool _ledEnabled;
 		private int _motorStep;
-		private readonly MOS6502X _cpu;
+		private readonly MOS6502X<CpuLink> _cpu;
 		private int[] _ram;
 		public readonly Via Via0;
 		public readonly Via Via1;
@@ -31,15 +31,28 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 		public Action DebuggerStep;
 		public readonly Chip23128 DriveRom;
 
+		private struct CpuLink : IMOS6502XLink
+		{
+			private readonly Drive1541 _drive;
+
+			public CpuLink(Drive1541 drive) => _drive = drive;
+
+			public byte DummyReadMemory(ushort address) => unchecked((byte)_drive.Read(address));
+
+			public void OnExecFetch(ushort address) { }
+
+			public byte PeekMemory(ushort address) => unchecked((byte)_drive.Peek(address));
+
+			public byte ReadMemory(ushort address) => unchecked((byte)_drive.Read(address));
+
+			public void WriteMemory(ushort address, byte value) => _drive.Write(address, value);
+		}
+
 		public Drive1541(int clockNum, int clockDen)
 		{
 			DriveRom = new Chip23128();
-			_cpu = new MOS6502X
+			_cpu = new MOS6502X<CpuLink>(new CpuLink(this))
 			{
-				ReadMemory = CpuRead,
-				WriteMemory = CpuWrite,
-				DummyReadMemory = CpuRead,
-				PeekMemory = CpuPeek,
 				NMI = false
 			};
 

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/Serial/Drive1541.cs
@@ -35,7 +35,10 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.Serial
 		{
 			private readonly Drive1541 _drive;
 
-			public CpuLink(Drive1541 drive) => _drive = drive;
+			public CpuLink(Drive1541 drive)
+			{
+				_drive = drive;
+			}
 
 			public byte DummyReadMemory(ushort address) => unchecked((byte)_drive.Read(address));
 

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
@@ -37,7 +37,10 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		{
 			private readonly Atari2600 _atari2600;
 
-			public CpuLink(Atari2600 atari2600) => _atari2600 = atari2600;
+			public CpuLink(Atari2600 atari2600)
+			{
+				_atari2600 = atari2600;
+			}
 
 			public byte DummyReadMemory(ushort address) => _atari2600.ReadMemory(address);
 

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.Core.cs
@@ -28,10 +28,27 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		private bool _leftDifficultySwitchHeld;
 		private bool _rightDifficultySwitchHeld;
 
-		internal MOS6502X Cpu { get; private set; }
+		internal MOS6502X<CpuLink> Cpu { get; private set; }
 		internal byte[] Ram => _ram;
 		internal byte[] Rom { get; }
 		internal int DistinctAccessCount { get; private set; }
+
+		internal struct CpuLink : IMOS6502XLink
+		{
+			private readonly Atari2600 _atari2600;
+
+			public CpuLink(Atari2600 atari2600) => _atari2600 = atari2600;
+
+			public byte DummyReadMemory(ushort address) => _atari2600.ReadMemory(address);
+
+			public void OnExecFetch(ushort address) => _atari2600.ExecFetch(address);
+
+			public byte PeekMemory(ushort address) => _atari2600.ReadMemory(address);
+
+			public byte ReadMemory(ushort address) => _atari2600.ReadMemory(address);
+
+			public void WriteMemory(ushort address, byte value) => _atari2600.WriteMemory(address, value);
+		}
 
 		// keeps track of tia cycles, 3 cycles per CPU cycle
 		private int cyc_counter;
@@ -292,14 +309,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			_mapper.Core = this;
 
 			_lagcount = 0;
-			Cpu = new MOS6502X
-			{
-				ReadMemory = ReadMemory,
-				WriteMemory = WriteMemory,
-				PeekMemory = PeekMemory,
-				DummyReadMemory = ReadMemory,
-				OnExecFetch = ExecFetch
-			};
+			Cpu = new MOS6502X<CpuLink>(new CpuLink(this));
 
 			if (_game["PAL"])
 			{
@@ -334,14 +344,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			_ram = new byte[128];
 			_mapper.HardReset();
 
-			Cpu = new MOS6502X
-			{
-				ReadMemory = ReadMemory,
-				WriteMemory = WriteMemory,
-				PeekMemory = PeekMemory,
-				DummyReadMemory = ReadMemory,
-				OnExecFetch = ExecFetch
-			};
+			Cpu = new MOS6502X<CpuLink>(new CpuLink(this));
 
 			_tia.Reset();
 			_m6532 = new M6532(this);

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
@@ -55,7 +55,10 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 		{
 			private readonly A7800Hawk _a7800;
 
-			public CpuLink(A7800Hawk a7800) => _a7800 = a7800;
+			public CpuLink(A7800Hawk a7800)
+			{
+				_a7800 = a7800;
+			}
 
 			public byte DummyReadMemory(ushort address) => _a7800.ReadMemory(address);
 

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
@@ -44,12 +44,29 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 		private readonly ITraceable _tracer;
 
-		public MOS6502X cpu;
+		public MOS6502X<CpuLink> cpu;
 		public Maria maria;
 		public bool _isPAL;
 		public M6532 m6532;
 		public TIA tia;
 		public Pokey pokey;
+
+		public struct CpuLink : IMOS6502XLink
+		{
+			private readonly A7800Hawk _a7800;
+
+			public CpuLink(A7800Hawk a7800) => _a7800 = a7800;
+
+			public byte DummyReadMemory(ushort address) => _a7800.ReadMemory(address);
+
+			public void OnExecFetch(ushort address) => _a7800.ExecFetch(address);
+
+			public byte PeekMemory(ushort address) => _a7800.ReadMemory(address);
+
+			public byte ReadMemory(ushort address) => _a7800.ReadMemory(address);
+
+			public void WriteMemory(ushort address, byte value) => _a7800.WriteMemory(address, value);
+		}
 
 		public A7800Hawk(CoreComm comm, GameInfo game, byte[] rom, string gameDbFn, object settings, object syncSettings)
 		{
@@ -60,14 +77,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 			m6532 = new M6532();
 			pokey = new Pokey();
 
-			cpu = new MOS6502X
-			{
-				ReadMemory = ReadMemory,
-				WriteMemory = WriteMemory,
-				PeekMemory = ReadMemory,
-				DummyReadMemory = ReadMemory,
-				OnExecFetch = ExecFetch
-			};
+			cpu = new MOS6502X<CpuLink>(new CpuLink(this));
 
 			maria = new Maria
 			{
@@ -255,7 +265,6 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 			tia.Reset();
 			cpu.Reset();
-			cpu.SetCallbacks(ReadMemory, ReadMemory, ReadMemory, WriteMemory);
 
 			maria.Reset();
 			m6532.Reset();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	public partial class NES : IEmulator, ICycleTiming
 	{
 		//hardware/state
-		public MOS6502X cpu;
+		public MOS6502X<CpuLink> cpu;
 		public PPU ppu;
 		public APU apu;
 		public byte[] ram;
@@ -159,11 +159,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		public void HardReset()
 		{
-			cpu = new MOS6502X();
-			cpu.SetCallbacks(ReadMemory, ReadMemory, PeekMemory, WriteMemory);
+			cpu = new MOS6502X<CpuLink>(new CpuLink(this))
+			{
+				BCD_Enabled = false
+			};
 
-			cpu.BCD_Enabled = false;
-			cpu.OnExecFetch = ExecFetch;
 			ppu = new PPU(this);
 			ram = new byte[0x800];
 			CIRAM = new byte[0x800];

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.CpuLink.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.CpuLink.cs
@@ -8,7 +8,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		{
 			private readonly NES _nes;
 
-			public CpuLink(NES nes) => _nes = nes;
+			public CpuLink(NES nes)
+			{
+				_nes = nes;
+			}
 
 			public byte DummyReadMemory(ushort address) => _nes.ReadMemory(address);
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.CpuLink.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.CpuLink.cs
@@ -1,0 +1,24 @@
+﻿using BizHawk.Emulation.Cores.Components.M6502;
+
+namespace BizHawk.Emulation.Cores.Nintendo.NES
+{
+    public partial class NES
+    {
+		public struct CpuLink : IMOS6502XLink
+		{
+			private readonly NES _nes;
+
+			public CpuLink(NES nes) => _nes = nes;
+
+			public byte DummyReadMemory(ushort address) => _nes.ReadMemory(address);
+
+			public void OnExecFetch(ushort address) => _nes.ExecFetch(address);
+
+			public byte PeekMemory(ushort address) => _nes.CDL == null ? _nes.PeekMemory(address) : _nes.FetchMemory_CDL(address);
+
+			public byte ReadMemory(ushort address) => _nes.CDL == null ? _nes.ReadMemory(address) : _nes.ReadMemory_CDL(address);
+
+			public void WriteMemory(ushort address, byte value) => _nes.WriteMemory(address, value);
+		}
+	}
+}

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.ICodeDataLogger.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.ICodeDataLogger.cs
@@ -9,18 +9,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		public void SetCDL(ICodeDataLog cdl)
 		{
 			CDL = cdl;
-			if (cdl == null)
-			{
-				cpu.ReadMemory = ReadMemory;
-				cpu.WriteMemory = WriteMemory;
-				cpu.PeekMemory = PeekMemory;
-			}
-			else
-			{
-				cpu.ReadMemory = ReadMemory_CDL;
-				cpu.WriteMemory = WriteMemory;
-				cpu.PeekMemory = FetchMemory_CDL;
-			}
 		}
 
 		public void NewCDL(ICodeDataLog cdl)


### PR DESCRIPTION
This PR creates an interface (`IMOS6052XLink`) that has all the methods required for the CPU to talk to the emulator core. The `MOS6052X` then takes a type implementing this interface as a generic type parameter.

The `MOS6052X` constructor takes a link as a parameter, and uses this to talk to the emulator core, instead of the `Func`/`Action` delegates currently used. This means that the compiler knows the exact methods being called at compile time.

By making all implementations of this link interface `struct`s, the compiler can subsequently eliminate pointer chasing (the delegates live on the heap) and virtual calls (`Func.Invoke`/`Action.Invoke`).

For example, on my machine, this leads to a speedup of ~1-2 fps for NESHawk and ~7-9 fps for A2600.

This change needs some more testing across all cores utilising the MOS 6502X implementation (Commodore 64, NES, A2600 and A7800) and by more people, to ensure the JITer consistently applies the optimization across frameworks, or at the very least it's not detrimental to some people's performance.

If effective, a similar construct could be used in the other CPU implementations (or perhaps elsewhere) for similar performance gains.

