### PR TITLE
Filter out forward slashes in FileSystemSafeName. Fixes #1088

### DIFF
--- a/BizHawk.Client.Common/PathManager.cs
+++ b/BizHawk.Client.Common/PathManager.cs
@@ -231,7 +231,8 @@ namespace BizHawk.Client.Common
 			var filesystemSafeName = game.Name
 				.Replace("|", "+")
 				.Replace(":", " -") // adelikat - Path.GetFileName scraps everything to the left of a colon unfortunately, so we need this hack here
-				.Replace("\"", ""); // adelikat - Ivan Ironman Stewart's Super Off-Road has quotes in game name
+				.Replace("\"", "")  // adelikat - Ivan Ironman Stewart's Super Off-Road has quotes in game name
+				.Replace("/", "+"); // Narry - Mario Bros / Duck hunt has a slash in the name which GetDirectoryName and GetFileName treat as if it were a folder
 
 			// zero 06-nov-2015 - regarding the below, i changed my mind. for libretro i want subdirectories here.
 			var filesystemDir = Path.GetDirectoryName(filesystemSafeName);


### PR DESCRIPTION
FileSystemSafeName always takes in a GameInfo and some games have forward slashes in their name, resulting in the name being mishandled by FilesystemSafeName.

Currently, FileSystemSafeName does a check for the DirectoryName and the FileName as the behavior for Libretro cores is to include the name of the core as a directory. e.g. (desmume_libretro\Super Mario 64 DS).  
As Libretro cores use a backslash rather than a forward slash, this change does not break that behavior.

Fixes #1088 
