### PR TITLE
MultiDiskBundler: Handle archive files properly

### DIFF
--- a/BizHawk.Client.Common/XmlGame.cs
+++ b/BizHawk.Client.Common/XmlGame.cs
@@ -82,11 +82,13 @@ namespace BizHawk.Client.Common
 								using (var hf = new HawkFile(fullpath))
 								{
 									if (hf.IsArchive)
-									{
-										var archiveItem = hf.ArchiveItems.First(ai => ai.Name == filename.Split('|').Skip(1).First());
+									{                                       
+                                        var archiveItem = hf.ArchiveItems.First(ai => ai.Name == filename.Split('|').Skip(1).First());
 										hf.Unbind();
 										hf.BindArchiveMember(archiveItem);
 										data = hf.GetStream().ReadAllBytes();
+
+                                        filename = filename.Split('|').Skip(1).First();
 									}
 									else
 									{

--- a/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.cs
+++ b/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.cs
@@ -114,7 +114,8 @@ namespace BizHawk.Client.EmuHawk
 				DialogResult = DialogResult.OK;
 				Close();
 
-				GlobalWin.MainForm.LoadRom(fileInfo.FullName, new MainForm.LoadRomArgs() { OpenAdvanced = new OpenAdvanced_OpenRom() });
+                var lra = new MainForm.LoadRomArgs { OpenAdvanced = new OpenAdvanced_OpenRom { Path = fileInfo.FullName } };
+                GlobalWin.MainForm.LoadRom(fileInfo.FullName, lra);
 			}
 		}
 
@@ -130,16 +131,18 @@ namespace BizHawk.Client.EmuHawk
 				Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top
 			};
 
-			var mdf = new MultiDiskFileSelector
-			{
-				Location = UIHelper.Scale(new Point(7, 12)),
-				Width = groupBox.ClientSize.Width - UIHelper.ScaleX(13),
-				Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top
+            var mdf = new MultiDiskFileSelector
+            {
+                Location = UIHelper.Scale(new Point(7, 12)),
+                Width = groupBox.ClientSize.Width - UIHelper.ScaleX(13),
+                Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top                
 			};
 
 			mdf.NameChanged += FileSelector_NameChanged;
+            mdf.SystemString = SystemDropDown.SelectedText;
 
-			groupBox.Controls.Add(mdf);
+
+            groupBox.Controls.Add(mdf);
 
 			FileSelectorPanel.Controls.Add(groupBox);
 		}

--- a/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskFileSelector.cs
+++ b/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskFileSelector.cs
@@ -3,11 +3,14 @@ using System.Windows.Forms;
 
 using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.WinFormExtensions;
+using System.IO;
 
 namespace BizHawk.Client.EmuHawk
 {
 	public partial class MultiDiskFileSelector : UserControl
 	{
+        public string SystemString = "";
+
 		public string GetName()
 		{
 			return PathBox.Text;
@@ -74,11 +77,56 @@ namespace BizHawk.Client.EmuHawk
 				RestoreDirectory = true
 			})
 			{
+                string _path = "";
+
 				var result = ofd.ShowHawkDialog();
 				if (result == DialogResult.OK)
 				{
-					PathBox.Text = ofd.FileName;
+					_path = ofd.FileName;
 				}
+                else
+                {
+                    return;
+                }
+
+                try
+                {
+                    var file = new FileInfo(ofd.FileName);
+                    var path = BizHawk.Common.HawkFile.Util_ResolveLink(file.FullName);
+
+                    using (var hf = new BizHawk.Common.HawkFile(path))
+                    {
+                        if (hf.IsArchive)
+                        {
+                            // archive - run the archive chooser
+                            if (SystemString == "PSX" || SystemString == "PCFX" || SystemString == "SAT")
+                            {
+                                MessageBox.Show("Using archives with PSX, PCFX or SATURN is not currently recommended/supported.");
+                                return;
+                            }
+
+                            var ac = new ArchiveChooser(new BizHawk.Common.HawkFile(_path));
+                            int memIdx = -1;
+
+                            if (ac.ShowDialog(this) == DialogResult.OK)
+                            {
+                                memIdx = ac.SelectedMemberIndex;
+                            }
+
+                            var intName = hf.ArchiveItems[memIdx];
+                            PathBox.Text = _path + "|" + intName.Name;
+                        }
+                        else
+                        {
+                            // file is not an archive
+                            PathBox.Text = _path;
+                        }
+                    }                        
+                }
+                catch
+                {
+                    return;
+                }
 			}
 		}
 


### PR DESCRIPTION
This has been bugging me for a while now.

Open ticket from 2016 - #764

This pull request does the following:

* Allows BizHawk-XMLGame files to include references to ROMs/Tapes/Disks within archives (using the same format that Bizhawk uses elsewhere). Importantly, this is parsed correctly before being sent to RomLoader further down the line (the code was kind of there, but not complete). 

XML example:

![image](https://user-images.githubusercontent.com/7911038/44155954-999af086-a0a6-11e8-9b09-3d8940fba2ad.png)

* MultiDiskFileSelector and MultiDiskBundler have been modified to call ArchiveChooser when an archive is selected through the browse dialog. There is certain conditional logic here. It will basically tell the user to FO if the selected system is PSX, PCFX or SAT (basically systems that will probably die if you try to load files from within an archive).

* The 'SaveAndRun' button on the multidiskbundler form now actually RUNS, rather than just SAVES (the issue was the LoadRomArgs passed in to LoadRom were infact empty before).


I havent managed to break it yet, so looking good so far.

Thanks,

-Asni


