### PR TITLE
C64Hawk: Fix border issues - #1272

### DIFF
--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.ISettable.cs
@@ -104,7 +104,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 
 		public enum BorderType
 		{
-			SmallProportional, SmallFixed, Normal, Full
+			None, SmallProportional, SmallFixed, Normal, Full
 		}
 
 		public enum SidType

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.ISettable.cs
@@ -34,7 +34,12 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 		public class C64Settings
 		{
 			[DisplayName("Border type")]
-			[Description("Select how to show the border area")]
+			[Description("Select how to show the border area\n" +
+                "NORMAL:\t Horizontal and Vertical border both set to 32 pixels (although horizontal will appear narrower due to pixel density)\n" +
+                "SMALL PROPORTIONAL:\t Horizontal and Vertical border both set to 16 pixels (although horizontal will appear narrower due to pixel density)\n" +
+                "SMALL FIXED:\t Horizontal border is set to 16 pixels and vertical is made slightly smaller so as to appear horizontal and vertical are the same after pixel density has been applied\n" +
+                "NONE:\t Only the pixel buffer is rendered"
+                )]
 			[DefaultValue(BorderType.SmallProportional)]
 			public BorderType BorderType { get; set; }
 
@@ -104,7 +109,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 
 		public enum BorderType
 		{
-			None, SmallProportional, SmallFixed, Normal, Full
+			None, SmallProportional, SmallFixed, Normal
 		}
 
 		public enum SidType

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Vic.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Vic.cs
@@ -129,13 +129,27 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 					newVblankStart = 0xFA + hBorderSize;
 					newVblankEnd = 0x32 - hBorderSize;
 					break;
+                case C64.BorderType.None:
+                    newHblankStart = 0x158 + PixBufferSize;
+                    newHblankEnd = 0x018 + PixBufferSize;
+                    newVblankStart = 0xFA;
+                    newVblankEnd = 0x32;
+                    _vblank = true;
+                    _hblank = true;
+                    break;
 			}
 
 			// wrap values
-			newHblankStart = WrapValue(0, maxWidth, newHblankStart);
-			newHblankEnd = WrapValue(0, maxWidth, newHblankEnd);
-			newVblankStart = WrapValue(0, lines, newVblankStart);
-			newVblankEnd = WrapValue(0, lines, newVblankEnd);
+            if (_hblank)
+            {
+                newHblankStart = WrapValue(0, maxWidth, newHblankStart);
+                newHblankEnd = WrapValue(0, maxWidth, newHblankEnd);
+            }
+			if (_vblank)
+            {
+                newVblankStart = WrapValue(0, lines, newVblankStart);
+                newVblankEnd = WrapValue(0, lines, newVblankEnd);
+            }
 
 			// calculate output dimensions
 			_hblankStartCheckXRaster = newHblankStart & 0xFFC;

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Vic.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/MOS/Vic.cs
@@ -97,6 +97,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 
 			switch (borderType)
 			{
+                /*
 				case C64.BorderType.Full:
 					newHblankStart = -1;
 					newHblankEnd = -1;
@@ -105,6 +106,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64.MOS
 					newVblankEnd = -1;
 					_vblank = false;
 					break;
+                    */
 				case C64.BorderType.Normal:
 					newHblankStart = hblankStart;
 					newHblankEnd = hblankEnd;


### PR DESCRIPTION
This is in relation to ticket #1272

This PR:

* Adds a 'None' border option as requested:

![image](https://user-images.githubusercontent.com/7911038/44202964-6d197380-a145-11e8-8268-19fcb800ad66.png)

* Fixes the endless loop that happens in  Vic.TimingBuilder (timingbuilder is expecting -1 values for hblankStart and hblankEnd passed to it when the 'Full Border' option is selected. Without the new changes in this PR Vic.ConfigureBlanking ends up converting hblankStart and vblankStart to the same value (and actually an odd number - which is ultimately what is responsible for the infinite loop).

So basically the 'Full Border' option now works, but it actually is showing the screen including the horizontal and vertical flyback periods. I.E. : it looks weird:

![image](https://user-images.githubusercontent.com/7911038/44203168-106a8880-a146-11e8-9c8e-086d1cba7e5c.png)

Its probably safe to say that the person who raised the issue believed that FULL is what he/she wanted (but didnt know this because it never worked), when actually he/she *actually* just wants to stick with NORMAL.

The question is do we just remove the FULL border as an available option? Its really only a dev/debug thing as far as I can see.

Thanks,

-Asni