### PR TITLE
Fix movie header SystemID

### DIFF
--- a/BizHawk.Client.Common/Global.cs
+++ b/BizHawk.Client.Common/Global.cs
@@ -87,6 +87,8 @@ namespace BizHawk.Client.Common
 						return SystemInfo.Intellivision;
 					case "SG":
 						return SystemInfo.SG;
+                    case "GG":
+                        return SystemInfo.GG;
 					case "SMS":
 						if ((Emulator as SMS).IsGameGear)
 						{

--- a/BizHawk.Client.Common/movie/conversions/MovieConversionExtensions.cs
+++ b/BizHawk.Client.Common/movie/conversions/MovieConversionExtensions.cs
@@ -319,11 +319,13 @@ namespace BizHawk.Client.Common.MovieConversionExtensions
 			if (Global.Emulator is SMS && (Global.Emulator as SMS).IsSG1000)
 			{
 				movie.HeaderEntries.Add("IsSGMode", "1");
-			}
+                movie.SystemID = "SG";
+            }
 
 			if (Global.Emulator is SMS && (Global.Emulator as SMS).IsGameGear)
 			{
 				movie.HeaderEntries.Add("IsGGMode", "1");
+                movie.SystemID = "GG";
 			}
 
 			if (Global.Emulator is GPGX && (Global.Emulator as GPGX).IsMegaCD)


### PR DESCRIPTION
From ticket #1246 

Small change to MovieConversionExtensions.PopulateWithDefaultHeaderValues()

Just changes SystemID to "GG" or "SG" if Global.Emulator .IsGameGear or IsSG1000 is true.

Without this, the play movie dialog shows 'Platform' as SMS for game gear and SG1000 movies (and highlights this in RED as it is incorrect).