### PR TITLE
EmuHawk: Movies and DeterministicEmulation - ensure this is enforced …

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3555,9 +3555,29 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			try
-			{
-				// If deterministic emulation is passed in, respect that value regardless, else determine a good value (currently that simply means movies require deterministic emulaton)
-				bool deterministic = args.Deterministic ?? Global.MovieSession.QueuedMovie != null;
+			{                
+                bool deterministic;
+
+                if (args.Deterministic == null)
+                {
+                    // force deterministic in this case
+                    // this is usually null for most cores
+                    // previously this was getting set to false if a movie was not queued for recording - surely that can't be good..
+                    deterministic = true;
+                }
+                else
+                {
+                    // a value was actually supplied somehow - use this
+                    deterministic = args.Deterministic.Value;
+                }
+
+                if (Global.MovieSession.QueuedMovie != null)
+                {
+                    // movies should require deterministic emulation in ALL cases
+                    // if the core is managing its own DE through SyncSettings a 'deterministic' bool should be passed into the core's constructor
+                    // it is then up to the core itself to override its own local DeterministicEmulation setting
+                    deterministic = true;
+                }
 
 				if (!GlobalWin.Tools.AskSave())
 				{


### PR DESCRIPTION
…whenever a movie is queued - #1290 

See ticket #1290 for background.

Very simple update. Previously when LoadRom() was called, a deterministic bool was passed into RomLoader (then onto a core). This was set to TRUE if a movie session was queued, but ONLY if LoadRomArgs.Deterministic was NOT NULL.

This PR removes any potential edge cases that might come up in the future by:

* If LoadRomArgs.Deterministic is null (as in most cases at the moment) set *deterministic* to TRUE (**previously this was being set as FALSE if no movie was queued - I can't for the life of me figure out why this was the case**)
* Otherwise set *deterministic* based on args.Deterministic's value
* Finally, if a movie is queued, ensure *deterministic* is set to TRUE

