### PR TITLE
EmuHawk: ToolManager.IsAvailable<T>

### DIFF
--- a/BizHawk.Client.EmuHawk/ToolAttribute.cs
+++ b/BizHawk.Client.EmuHawk/ToolAttribute.cs
@@ -6,14 +6,17 @@ namespace BizHawk.Client.EmuHawk
 	[AttributeUsage(AttributeTargets.Class)]
 	public class ToolAttribute : Attribute
 	{
-		public ToolAttribute(bool released, string[] supportedSystems)
+		public ToolAttribute(bool released, string[] supportedSystems, string[] unsupportedCores = null)
 		{
 			Released = released;
 			SupportedSystems = supportedSystems;
+            UnsupportedCores = unsupportedCores;
 		}
 
 		public bool Released { get; private set; }
 
 		public IEnumerable<string> SupportedSystems { get; private set; }
+
+        public IEnumerable<string> UnsupportedCores { get; private set; }
 	}
 }

--- a/BizHawk.Client.EmuHawk/tools/GameShark.cs
+++ b/BizHawk.Client.EmuHawk/tools/GameShark.cs
@@ -20,7 +20,8 @@ namespace BizHawk.Client.EmuHawk
 	//Verify all wording in the error reports
 
 
-	[Tool(released: true, supportedSystems: new[] { "GB", "GBA", "GEN", "N64", "NES", "PSX", "SAT", "SMS", "SNES" })]
+	[Tool(released: true, supportedSystems: new[] { "GB", "GBA", "GEN", "N64", "NES", "PSX", "SAT", "SMS", "SNES" },
+        unsupportedCores: new[] { "Snes9x" })]
 	public partial class GameShark : Form, IToolForm, IToolFormAutoConfig
 	{
 		#region " Game Genie Dictionary "

--- a/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Common.ReflectionExtensions;
+using BizHawk.Client.EmuHawk.CoreExtensions;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -743,13 +744,30 @@ namespace BizHawk.Client.EmuHawk
 				.OfType<ToolAttribute>()
 				.FirstOrDefault();
 
-			// If no supported systems mentioned assume all
-			if (attr?.SupportedSystems != null && attr.SupportedSystems.Any())
+            // start with the assumption that if no supported systems are mentioned and no unsupported cores are mentioned
+            // then this is available for all
+            bool supported = true;
+            
+            if (attr?.SupportedSystems != null && attr.SupportedSystems.Any())
 			{
-				return attr.SupportedSystems.Contains(Global.Emulator.SystemId);
-			}
+                // supported systems are available
+                supported = attr.SupportedSystems.Contains(Global.Emulator.SystemId);
 
-			return true;
+                if (supported)
+                {
+                    // check for a core not supported override
+                    if (attr.UnsupportedCores.Contains(Global.Emulator.DisplayName()))
+                        supported = false; 
+                }
+			}
+            else if (attr?.UnsupportedCores != null && attr.UnsupportedCores.Any())
+            {
+                // no supported system specified, but unsupported cores are
+                if (attr.UnsupportedCores.Contains(Global.Emulator.DisplayName()))
+                    supported = false;
+            }
+
+			return supported;
 		}
 
 		// Note: Referencing these properties creates an instance of the tool and persists it.  They should be referenced by type if this is not desired
@@ -973,7 +991,7 @@ namespace BizHawk.Client.EmuHawk
 		public void LoadGameGenieEc()
 		{
 			if (GlobalWin.Tools.IsAvailable<GameShark>())
-			{
+			{                
 				GlobalWin.Tools.Load<GameShark>();
 			}
 		}


### PR DESCRIPTION
This is because of issue #1293 

Currently the gameshark Tool (called 'Cheat Code Converter' in the menus and dialogs) is made available to the user based on a _GlobalWin.Tools.IsAvailable`<GameShark`>()_ call. As this method only looks at the *supportedSystems* ToolAttribute, you have a situation where SNES IS supported (and the code converter dialog is made available) but the Snes9x core does not expose a 'System Bus' MemoryDomain - so exceptions are shown when the user attempts to convert a code.

This PR:

* Modifies the **ToolAttribute** class to make available an **UnsupportedCores** IEnumerable (which defaults to null)
* Modifies the **.IsAvailable(Type t)** method in **ToolManager.cs**. The logic is pretty much the same as before, except a second check is made to see whether there are any UnsupportedCore overrides for the current core. Similar to before it returns a TRUE if both SupportedSystems & UnsupportedCores are null
* Adds 'Snes9x' to the **GameShark.cs** **UnsupportedCores** ToolAttribute (in order to solve ticket #1293)

As far as I can see, it is only the Snes9x core that needs this within GameShark.cs (for now), but rather than implement an arbitrary kludge, I thought it might be worthwhile doing it in a way that can/will be useful elsewhere in the future.

Thanks,

-Asni