### PR TITLE
Revert "Resize unattended video if zoom factor >1"

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3184,12 +3184,6 @@ namespace BizHawk.Client.EmuHawk
 					aw = new AudioStretcher(aw);
 				}
 
-				if (unattended && Global.Config.TargetZoomFactor > 1)
-				{
-					_avwriterResizew = Global.Config.TargetZoomFactor * _currentVideoProvider.BufferWidth;
-					_avwriterResizeh = Global.Config.TargetZoomFactor * _currentVideoProvider.BufferHeight;
-				}
-
 				aw.SetMovieParameters(Emulator.VsyncNumerator(), Emulator.VsyncDenominator());
 				if (_avwriterResizew > 0 && _avwriterResizeh > 0)
 				{


### PR DESCRIPTION
Reverts TASVideos/BizHawk#1205

This is terrible. It uses a hardcoded magic value that's impossible for a user to change, and it's never used anywhere in the code, to rule that all the users from now on are obliged to get 2x dumps as long as they have figured out what settings they want to use.

fix #1244