### PR TITLE
Lua: client.getversion() - #1271

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
@@ -391,6 +391,13 @@ namespace BizHawk.Client.EmuHawk
 			return GlobalWin.MainForm.DesktopLocation.Y;
 		}
 
+        [LuaMethodExample("local incbhver = client.getversion( );")]
+        [LuaMethod("getversion", "Returns the current (non-dev) BizHawk version")]
+        public static string GetVersion()
+        {
+            return VersionInfo.GetEmuVersionNonDev();            
+        }
+
 		[LuaMethodExample("local nlcliget = client.getavailabletools( );")]
 		[LuaMethod("getavailabletools", "Returns a list of the tools currently open")]
 		public LuaTable GetAvailableTools()

--- a/Version/VersionInfo.cs
+++ b/Version/VersionInfo.cs
@@ -2,8 +2,9 @@ using System.IO;
 
 internal static class VersionInfo
 {
-	public const string Mainversion = "2.0.0"; // Use numbers only or the new version notification won't work
-	public static readonly string RELEASEDATE = "June 25, 2017";
+    // keep this updated at every major release
+	public const string Mainversion = "2.3.0"; // Use numbers only or the new version notification won't work
+	public static readonly string RELEASEDATE = "June 24, 2018";
 	public static readonly bool DeveloperBuild = true;
 	public static readonly string HomePage = "http://tasvideos.org/BizHawk.html";
 
@@ -13,6 +14,11 @@ internal static class VersionInfo
 	{
 		return DeveloperBuild ? ("GIT " + SubWCRev.GIT_BRANCH + "#" + SubWCRev.GIT_SHORTHASH) : ("Version " + Mainversion);
 	}
+
+    public static string GetEmuVersionNonDev()
+    {
+        return Mainversion;
+    }
 
 	static VersionInfo()
 	{


### PR DESCRIPTION
see ticket #1271 

Adds lua method:

`client.getversion()`

This returns the _Mainversion_ string from _VersionInfo_ regardless of whether this is a DeveloperBuild or not. 

We just need to keep _VersionInfo.Mainversion_ updated at every release.