### PR TITLE
lua: forms.drawText() horizontal alignment "right" fix

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/LuaPictureBox.cs
@@ -346,7 +346,7 @@ namespace BizHawk.Client.EmuHawk
 						x -= sizeOfText.Width / 2;
 						break;
 					case "right":
-						x -= sizeOfText.Width / 2;
+						x -= sizeOfText.Width;
 						break;
 				}
 			}


### PR DESCRIPTION
The lua function forms.drawText() horizontal alignment "right" did the same as "center"