### PR TITLE
FirmwaresConfig: Stop indiscriminate importing (and some other things…

### DIFF
--- a/BizHawk.Client.Common/FirmwareManager.cs
+++ b/BizHawk.Client.Common/FirmwareManager.cs
@@ -128,7 +128,6 @@ namespace BizHawk.Client.Common
 
         /// <summary>
         /// Test to determine whether the supplied firmware file matches something in the firmware database
-        /// For customization overrides then perhaps the user can copy into the firmware directory manually?
         /// </summary>
         /// <param name="f"></param>
         /// <returns></returns>

--- a/BizHawk.Client.Common/FirmwareManager.cs
+++ b/BizHawk.Client.Common/FirmwareManager.cs
@@ -126,7 +126,38 @@ namespace BizHawk.Client.Common
 			public Dictionary<string, RealFirmwareFile> Dict { get; } = new Dictionary<string, RealFirmwareFile>();
 		}
 
-		public void DoScanAndResolve()
+        /// <summary>
+        /// Test to determine whether the supplied firmware file matches something in the firmware database
+        /// For customization overrides then perhaps the user can copy into the firmware directory manually?
+        /// </summary>
+        /// <param name="f"></param>
+        /// <returns></returns>
+        public bool CanFileBeImported(string f)
+        {
+            try
+            {
+                var fi = new FileInfo(f);
+                if (!fi.Exists)
+                    return false;
+
+                // weed out filesizes first to reduce the unnecessary overhead of a hashing operation
+                if (FirmwareDatabase.FirmwareFiles.Where(a => a.Size == fi.Length).FirstOrDefault() == null)
+                    return false;
+
+                // check the hash
+                using (var reader = new RealFirmwareReader())
+                {
+                    reader.Read(fi);
+                    if (FirmwareDatabase.FirmwareFiles.Where(a => a.Hash == reader.Dict.FirstOrDefault().Value.Hash).FirstOrDefault() != null)
+                        return true;
+                }
+            }
+            catch { }
+
+            return false;
+        }
+
+        public void DoScanAndResolve()
 		{
 			// build a list of file sizes. Only those will be checked during scanning
 			HashSet<long> sizes = new HashSet<long>();

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
@@ -28,56 +28,57 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FirmwaresConfig));
-			this.imageList1 = new System.Windows.Forms.ImageList(this.components);
-			this.lvFirmwares = new System.Windows.Forms.ListView();
-			this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-			this.lvFirmwaresContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.tsmiSetCustomization = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiClearCustomization = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiInfo = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiCopy = new System.Windows.Forms.ToolStripMenuItem();
-			this.panel1 = new System.Windows.Forms.Panel();
-			this.toolStrip1 = new ToolStripEx();
-			this.tbbGroup = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.tbbScan = new System.Windows.Forms.ToolStripButton();
-			this.tbbOrganize = new System.Windows.Forms.ToolStripButton();
-			this.tbbImport = new System.Windows.Forms.ToolStripButton();
-			this.tbbClose = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.tbbCloseReload = new System.Windows.Forms.ToolStripButton();
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.panel2 = new System.Windows.Forms.Panel();
-			this.linkBasePath = new System.Windows.Forms.LinkLabel();
-			this.label1 = new System.Windows.Forms.Label();
-			this.label2 = new System.Windows.Forms.Label();
-			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-			this.lvFirmwaresContextMenuStrip.SuspendLayout();
-			this.panel1.SuspendLayout();
-			this.toolStrip1.SuspendLayout();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.panel2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// imageList1
-			// 
-			this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
-			this.imageList1.ImageSize = new System.Drawing.Size(16, 16);
-			this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
-			// 
-			// lvFirmwares
-			// 
-			this.lvFirmwares.AllowDrop = true;
-			this.lvFirmwares.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FirmwaresConfig));
+            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+            this.lvFirmwares = new System.Windows.Forms.ListView();
+            this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvFirmwaresContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.tsmiSetCustomization = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiClearCustomization = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiInfo = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiCopy = new System.Windows.Forms.ToolStripMenuItem();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.toolStrip1 = new ToolStripEx();
+            this.tbbGroup = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.tbbScan = new System.Windows.Forms.ToolStripButton();
+            this.tbbOrganize = new System.Windows.Forms.ToolStripButton();
+            this.tbbImport = new System.Windows.Forms.ToolStripButton();
+            this.tbbClose = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tbbCloseReload = new System.Windows.Forms.ToolStripButton();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.linkBasePath = new System.Windows.Forms.LinkLabel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.tbbOpenFolder = new System.Windows.Forms.ToolStripButton();
+            this.lvFirmwaresContextMenuStrip.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.toolStrip1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.panel2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // imageList1
+            // 
+            this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+            this.imageList1.ImageSize = new System.Drawing.Size(16, 16);
+            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+            // 
+            // lvFirmwares
+            // 
+            this.lvFirmwares.AllowDrop = true;
+            this.lvFirmwares.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader5,
             this.columnHeader1,
             this.columnHeader6,
@@ -86,114 +87,114 @@
             this.columnHeader3,
             this.columnHeader8,
             this.columnHeader7});
-			this.lvFirmwares.ContextMenuStrip = this.lvFirmwaresContextMenuStrip;
-			this.lvFirmwares.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.lvFirmwares.FullRowSelect = true;
-			this.lvFirmwares.GridLines = true;
-			this.lvFirmwares.Location = new System.Drawing.Point(0, 25);
-			this.lvFirmwares.Name = "lvFirmwares";
-			this.lvFirmwares.ShowItemToolTips = true;
-			this.lvFirmwares.Size = new System.Drawing.Size(824, 404);
-			this.lvFirmwares.SmallImageList = this.imageList1;
-			this.lvFirmwares.TabIndex = 24;
-			this.lvFirmwares.UseCompatibleStateImageBehavior = false;
-			this.lvFirmwares.View = System.Windows.Forms.View.Details;
-			this.lvFirmwares.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lvFirmwares_ColumnClick);
-			this.lvFirmwares.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragDrop);
-			this.lvFirmwares.DragEnter += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragEnter);
-			this.lvFirmwares.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvFirmwares_KeyDown);
-			this.lvFirmwares.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvFirmwares_MouseClick);
-			// 
-			// columnHeader5
-			// 
-			this.columnHeader5.Text = "";
-			this.columnHeader5.Width = 31;
-			// 
-			// columnHeader1
-			// 
-			this.columnHeader1.Text = "System";
-			// 
-			// columnHeader6
-			// 
-			this.columnHeader6.Text = "Id";
-			// 
-			// columnHeader4
-			// 
-			this.columnHeader4.Text = "Description";
-			this.columnHeader4.Width = 165;
-			// 
-			// columnHeader2
-			// 
-			this.columnHeader2.Text = "Resolved With";
-			this.columnHeader2.Width = 116;
-			// 
-			// columnHeader3
-			// 
-			this.columnHeader3.Text = "Location";
-			this.columnHeader3.Width = 252;
-			// 
-			// columnHeader8
-			// 
-			this.columnHeader8.Text = "Size";
-			// 
-			// columnHeader7
-			// 
-			this.columnHeader7.Text = "Hash";
-			this.columnHeader7.Width = 250;
-			// 
-			// lvFirmwaresContextMenuStrip
-			// 
-			this.lvFirmwaresContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lvFirmwares.ContextMenuStrip = this.lvFirmwaresContextMenuStrip;
+            this.lvFirmwares.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvFirmwares.FullRowSelect = true;
+            this.lvFirmwares.GridLines = true;
+            this.lvFirmwares.Location = new System.Drawing.Point(0, 25);
+            this.lvFirmwares.Name = "lvFirmwares";
+            this.lvFirmwares.ShowItemToolTips = true;
+            this.lvFirmwares.Size = new System.Drawing.Size(824, 404);
+            this.lvFirmwares.SmallImageList = this.imageList1;
+            this.lvFirmwares.TabIndex = 24;
+            this.lvFirmwares.UseCompatibleStateImageBehavior = false;
+            this.lvFirmwares.View = System.Windows.Forms.View.Details;
+            this.lvFirmwares.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lvFirmwares_ColumnClick);
+            this.lvFirmwares.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragDrop);
+            this.lvFirmwares.DragEnter += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragEnter);
+            this.lvFirmwares.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvFirmwares_KeyDown);
+            this.lvFirmwares.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvFirmwares_MouseClick);
+            // 
+            // columnHeader5
+            // 
+            this.columnHeader5.Text = "";
+            this.columnHeader5.Width = 31;
+            // 
+            // columnHeader1
+            // 
+            this.columnHeader1.Text = "System";
+            // 
+            // columnHeader6
+            // 
+            this.columnHeader6.Text = "Id";
+            // 
+            // columnHeader4
+            // 
+            this.columnHeader4.Text = "Description";
+            this.columnHeader4.Width = 165;
+            // 
+            // columnHeader2
+            // 
+            this.columnHeader2.Text = "Resolved With";
+            this.columnHeader2.Width = 116;
+            // 
+            // columnHeader3
+            // 
+            this.columnHeader3.Text = "Location";
+            this.columnHeader3.Width = 252;
+            // 
+            // columnHeader8
+            // 
+            this.columnHeader8.Text = "Size";
+            // 
+            // columnHeader7
+            // 
+            this.columnHeader7.Text = "Hash";
+            this.columnHeader7.Width = 250;
+            // 
+            // lvFirmwaresContextMenuStrip
+            // 
+            this.lvFirmwaresContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsmiSetCustomization,
             this.tsmiClearCustomization,
             this.tsmiInfo,
             this.tsmiCopy});
-			this.lvFirmwaresContextMenuStrip.Name = "lvFirmwaresContextMenuStrip";
-			this.lvFirmwaresContextMenuStrip.Size = new System.Drawing.Size(182, 92);
-			this.lvFirmwaresContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.lvFirmwaresContextMenuStrip_Opening);
-			// 
-			// tsmiSetCustomization
-			// 
-			this.tsmiSetCustomization.Name = "tsmiSetCustomization";
-			this.tsmiSetCustomization.Size = new System.Drawing.Size(181, 22);
-			this.tsmiSetCustomization.Text = "&Set Customization";
-			this.tsmiSetCustomization.Click += new System.EventHandler(this.tsmiSetCustomization_Click);
-			// 
-			// tsmiClearCustomization
-			// 
-			this.tsmiClearCustomization.Name = "tsmiClearCustomization";
-			this.tsmiClearCustomization.Size = new System.Drawing.Size(181, 22);
-			this.tsmiClearCustomization.Text = "C&lear Customization";
-			this.tsmiClearCustomization.Click += new System.EventHandler(this.tsmiClearCustomization_Click);
-			// 
-			// tsmiInfo
-			// 
-			this.tsmiInfo.Name = "tsmiInfo";
-			this.tsmiInfo.Size = new System.Drawing.Size(181, 22);
-			this.tsmiInfo.Text = "&Info";
-			this.tsmiInfo.Click += new System.EventHandler(this.tsmiInfo_Click);
-			// 
-			// tsmiCopy
-			// 
-			this.tsmiCopy.Name = "tsmiCopy";
-			this.tsmiCopy.Size = new System.Drawing.Size(181, 22);
-			this.tsmiCopy.Text = "&Copy";
-			this.tsmiCopy.Click += new System.EventHandler(this.tsmiCopy_Click);
-			// 
-			// panel1
-			// 
-			this.panel1.Controls.Add(this.lvFirmwares);
-			this.panel1.Controls.Add(this.toolStrip1);
-			this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.panel1.Location = new System.Drawing.Point(3, 23);
-			this.panel1.Name = "panel1";
-			this.panel1.Size = new System.Drawing.Size(824, 429);
-			this.panel1.TabIndex = 24;
-			// 
-			// toolStrip1
-			// 
-			this.toolStrip1.ClickThrough = true;
-			this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.lvFirmwaresContextMenuStrip.Name = "lvFirmwaresContextMenuStrip";
+            this.lvFirmwaresContextMenuStrip.Size = new System.Drawing.Size(182, 92);
+            this.lvFirmwaresContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.lvFirmwaresContextMenuStrip_Opening);
+            // 
+            // tsmiSetCustomization
+            // 
+            this.tsmiSetCustomization.Name = "tsmiSetCustomization";
+            this.tsmiSetCustomization.Size = new System.Drawing.Size(181, 22);
+            this.tsmiSetCustomization.Text = "&Set Customization";
+            this.tsmiSetCustomization.Click += new System.EventHandler(this.tsmiSetCustomization_Click);
+            // 
+            // tsmiClearCustomization
+            // 
+            this.tsmiClearCustomization.Name = "tsmiClearCustomization";
+            this.tsmiClearCustomization.Size = new System.Drawing.Size(181, 22);
+            this.tsmiClearCustomization.Text = "C&lear Customization";
+            this.tsmiClearCustomization.Click += new System.EventHandler(this.tsmiClearCustomization_Click);
+            // 
+            // tsmiInfo
+            // 
+            this.tsmiInfo.Name = "tsmiInfo";
+            this.tsmiInfo.Size = new System.Drawing.Size(181, 22);
+            this.tsmiInfo.Text = "&Info";
+            this.tsmiInfo.Click += new System.EventHandler(this.tsmiInfo_Click);
+            // 
+            // tsmiCopy
+            // 
+            this.tsmiCopy.Name = "tsmiCopy";
+            this.tsmiCopy.Size = new System.Drawing.Size(181, 22);
+            this.tsmiCopy.Text = "&Copy";
+            this.tsmiCopy.Click += new System.EventHandler(this.tsmiCopy_Click);
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.lvFirmwares);
+            this.panel1.Controls.Add(this.toolStrip1);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(3, 23);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(824, 429);
+            this.panel1.TabIndex = 24;
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.ClickThrough = true;
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tbbGroup,
             this.toolStripSeparator2,
             this.tbbScan,
@@ -201,176 +202,187 @@
             this.tbbImport,
             this.tbbClose,
             this.toolStripSeparator1,
-            this.tbbCloseReload});
-			this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-			this.toolStrip1.Name = "toolStrip1";
-			this.toolStrip1.Size = new System.Drawing.Size(824, 25);
-			this.toolStrip1.TabIndex = 23;
-			this.toolStrip1.Text = "toolStrip1";
-			// 
-			// tbbGroup
-			// 
-			this.tbbGroup.Checked = true;
-			this.tbbGroup.CheckOnClick = true;
-			this.tbbGroup.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.tbbGroup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbGroup.Image = ((System.Drawing.Image)(resources.GetObject("tbbGroup.Image")));
-			this.tbbGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbGroup.Name = "tbbGroup";
-			this.tbbGroup.Size = new System.Drawing.Size(44, 22);
-			this.tbbGroup.Text = "Group";
-			this.tbbGroup.Click += new System.EventHandler(this.tbbGroup_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			// 
-			// tbbScan
-			// 
-			this.tbbScan.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbScan.Image = ((System.Drawing.Image)(resources.GetObject("tbbScan.Image")));
-			this.tbbScan.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbScan.Name = "tbbScan";
-			this.tbbScan.Size = new System.Drawing.Size(36, 22);
-			this.tbbScan.Text = "Scan";
-			this.tbbScan.Click += new System.EventHandler(this.tbbScan_Click);
-			// 
-			// tbbOrganize
-			// 
-			this.tbbOrganize.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbOrganize.Image = ((System.Drawing.Image)(resources.GetObject("tbbOrganize.Image")));
-			this.tbbOrganize.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbOrganize.Name = "tbbOrganize";
-			this.tbbOrganize.Size = new System.Drawing.Size(58, 22);
-			this.tbbOrganize.Text = "Organize";
-			this.tbbOrganize.Click += new System.EventHandler(this.tbbOrganize_Click);
-			// 
-			// tbbImport
-			// 
-			this.tbbImport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbImport.Image = ((System.Drawing.Image)(resources.GetObject("tbbImport.Image")));
-			this.tbbImport.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbImport.Name = "tbbImport";
-			this.tbbImport.Size = new System.Drawing.Size(47, 22);
-			this.tbbImport.Text = "Import";
-			this.tbbImport.Click += new System.EventHandler(this.tbbImport_Click);
-			// 
-			// tbbClose
-			// 
-			this.tbbClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.tbbClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbClose.Image = ((System.Drawing.Image)(resources.GetObject("tbbClose.Image")));
-			this.tbbClose.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbClose.Margin = new System.Windows.Forms.Padding(0, 1, 2, 2);
-			this.tbbClose.Name = "tbbClose";
-			this.tbbClose.Size = new System.Drawing.Size(40, 22);
-			this.tbbClose.Text = "Close";
-			this.tbbClose.Click += new System.EventHandler(this.tbbClose_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-			this.toolStripSeparator1.Visible = false;
-			// 
-			// tbbCloseReload
-			// 
-			this.tbbCloseReload.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.tbbCloseReload.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-			this.tbbCloseReload.Enabled = false;
-			this.tbbCloseReload.Image = ((System.Drawing.Image)(resources.GetObject("tbbCloseReload.Image")));
-			this.tbbCloseReload.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.tbbCloseReload.Name = "tbbCloseReload";
-			this.tbbCloseReload.Size = new System.Drawing.Size(129, 22);
-			this.tbbCloseReload.Text = "Close and reload ROM";
-			this.tbbCloseReload.ToolTipText = "Close and reload ROM";
-			this.tbbCloseReload.Visible = false;
-			this.tbbCloseReload.Click += new System.EventHandler(this.tbbCloseReload_Click);
-			// 
-			// tableLayoutPanel1
-			// 
-			this.tableLayoutPanel1.ColumnCount = 1;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
-			this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 2);
-			this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
-			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 3;
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(830, 478);
-			this.tableLayoutPanel1.TabIndex = 25;
-			// 
-			// panel2
-			// 
-			this.panel2.AutoSize = true;
-			this.panel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.panel2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-			this.panel2.Controls.Add(this.linkBasePath);
-			this.panel2.Controls.Add(this.label1);
-			this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.panel2.Location = new System.Drawing.Point(3, 458);
-			this.panel2.Name = "panel2";
-			this.panel2.Size = new System.Drawing.Size(824, 17);
-			this.panel2.TabIndex = 26;
-			// 
-			// linkBasePath
-			// 
-			this.linkBasePath.AutoSize = true;
-			this.linkBasePath.Location = new System.Drawing.Point(125, 0);
-			this.linkBasePath.Name = "linkBasePath";
-			this.linkBasePath.Size = new System.Drawing.Size(55, 13);
-			this.linkBasePath.TabIndex = 27;
-			this.linkBasePath.TabStop = true;
-			this.linkBasePath.Text = "linkLabel1";
-			this.linkBasePath.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkBasePath_LinkClicked);
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(3, 0);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(119, 13);
-			this.label1.TabIndex = 25;
-			this.label1.Text = "Firmwares Search Path:";
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(5, 5);
-			this.label2.Margin = new System.Windows.Forms.Padding(5, 5, 3, 0);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(383, 13);
-			this.label2.TabIndex = 27;
-			this.label2.Text = "Firmware such as BIOS files are copyrighted material and not provided by BizHawk";
-			// 
-			// FirmwaresConfig
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(830, 478);
-			this.Controls.Add(this.tableLayoutPanel1);
-			this.Name = "FirmwaresConfig";
-			this.ShowIcon = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Firmwares";
-			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FirmwaresConfig_FormClosed);
-			this.Load += new System.EventHandler(this.FirmwaresConfig_Load);
-			this.lvFirmwaresContextMenuStrip.ResumeLayout(false);
-			this.panel1.ResumeLayout(false);
-			this.panel1.PerformLayout();
-			this.toolStrip1.ResumeLayout(false);
-			this.toolStrip1.PerformLayout();
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel1.PerformLayout();
-			this.panel2.ResumeLayout(false);
-			this.panel2.PerformLayout();
-			this.ResumeLayout(false);
+            this.tbbCloseReload,
+            this.tbbOpenFolder});
+            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(824, 25);
+            this.toolStrip1.TabIndex = 23;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // tbbGroup
+            // 
+            this.tbbGroup.Checked = true;
+            this.tbbGroup.CheckOnClick = true;
+            this.tbbGroup.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.tbbGroup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbGroup.Image = ((System.Drawing.Image)(resources.GetObject("tbbGroup.Image")));
+            this.tbbGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbGroup.Name = "tbbGroup";
+            this.tbbGroup.Size = new System.Drawing.Size(44, 22);
+            this.tbbGroup.Text = "Group";
+            this.tbbGroup.Click += new System.EventHandler(this.tbbGroup_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // tbbScan
+            // 
+            this.tbbScan.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbScan.Image = ((System.Drawing.Image)(resources.GetObject("tbbScan.Image")));
+            this.tbbScan.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbScan.Name = "tbbScan";
+            this.tbbScan.Size = new System.Drawing.Size(36, 22);
+            this.tbbScan.Text = "Scan";
+            this.tbbScan.Click += new System.EventHandler(this.tbbScan_Click);
+            // 
+            // tbbOrganize
+            // 
+            this.tbbOrganize.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbOrganize.Image = ((System.Drawing.Image)(resources.GetObject("tbbOrganize.Image")));
+            this.tbbOrganize.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbOrganize.Name = "tbbOrganize";
+            this.tbbOrganize.Size = new System.Drawing.Size(58, 22);
+            this.tbbOrganize.Text = "Organize";
+            this.tbbOrganize.Click += new System.EventHandler(this.tbbOrganize_Click);
+            // 
+            // tbbImport
+            // 
+            this.tbbImport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbImport.Image = ((System.Drawing.Image)(resources.GetObject("tbbImport.Image")));
+            this.tbbImport.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbImport.Name = "tbbImport";
+            this.tbbImport.Size = new System.Drawing.Size(47, 22);
+            this.tbbImport.Text = "Import";
+            this.tbbImport.Click += new System.EventHandler(this.tbbImport_Click);
+            // 
+            // tbbClose
+            // 
+            this.tbbClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.tbbClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbClose.Image = ((System.Drawing.Image)(resources.GetObject("tbbClose.Image")));
+            this.tbbClose.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbClose.Margin = new System.Windows.Forms.Padding(0, 1, 2, 2);
+            this.tbbClose.Name = "tbbClose";
+            this.tbbClose.Size = new System.Drawing.Size(40, 22);
+            this.tbbClose.Text = "Close";
+            this.tbbClose.Click += new System.EventHandler(this.tbbClose_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator1.Visible = false;
+            // 
+            // tbbCloseReload
+            // 
+            this.tbbCloseReload.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.tbbCloseReload.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbCloseReload.Enabled = false;
+            this.tbbCloseReload.Image = ((System.Drawing.Image)(resources.GetObject("tbbCloseReload.Image")));
+            this.tbbCloseReload.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbCloseReload.Name = "tbbCloseReload";
+            this.tbbCloseReload.Size = new System.Drawing.Size(129, 22);
+            this.tbbCloseReload.Text = "Close and reload ROM";
+            this.tbbCloseReload.ToolTipText = "Close and reload ROM";
+            this.tbbCloseReload.Visible = false;
+            this.tbbCloseReload.Click += new System.EventHandler(this.tbbCloseReload_Click);
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(830, 478);
+            this.tableLayoutPanel1.TabIndex = 25;
+            // 
+            // panel2
+            // 
+            this.panel2.AutoSize = true;
+            this.panel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panel2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.panel2.Controls.Add(this.linkBasePath);
+            this.panel2.Controls.Add(this.label1);
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel2.Location = new System.Drawing.Point(3, 458);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(824, 17);
+            this.panel2.TabIndex = 26;
+            // 
+            // linkBasePath
+            // 
+            this.linkBasePath.AutoSize = true;
+            this.linkBasePath.Location = new System.Drawing.Point(125, 0);
+            this.linkBasePath.Name = "linkBasePath";
+            this.linkBasePath.Size = new System.Drawing.Size(55, 13);
+            this.linkBasePath.TabIndex = 27;
+            this.linkBasePath.TabStop = true;
+            this.linkBasePath.Text = "linkLabel1";
+            this.linkBasePath.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkBasePath_LinkClicked);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(119, 13);
+            this.label1.TabIndex = 25;
+            this.label1.Text = "Firmwares Search Path:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(5, 5);
+            this.label2.Margin = new System.Windows.Forms.Padding(5, 5, 3, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(395, 13);
+            this.label2.TabIndex = 27;
+            this.label2.Text = "Firmware such as BIOS files are copyrighted material and not provided by BizHawk";
+            // 
+            // tbbOpenFolder
+            // 
+            this.tbbOpenFolder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tbbOpenFolder.Image = ((System.Drawing.Image)(resources.GetObject("tbbOpenFolder.Image")));
+            this.tbbOpenFolder.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tbbOpenFolder.Name = "tbbOpenFolder";
+            this.tbbOpenFolder.Size = new System.Drawing.Size(128, 22);
+            this.tbbOpenFolder.Text = "Open Firmware Folder";
+            this.tbbOpenFolder.Click += new System.EventHandler(this.tbbOpenFolder_Click);
+            // 
+            // FirmwaresConfig
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(830, 478);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Name = "FirmwaresConfig";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Firmwares";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FirmwaresConfig_FormClosed);
+            this.Load += new System.EventHandler(this.FirmwaresConfig_Load);
+            this.lvFirmwaresContextMenuStrip.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 
@@ -407,5 +419,6 @@
 				private System.Windows.Forms.ToolStripButton tbbCloseReload;
 				private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 		private System.Windows.Forms.Label label2;
-	}
+        private System.Windows.Forms.ToolStripButton tbbOpenFolder;
+    }
 }

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
@@ -28,57 +28,57 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FirmwaresConfig));
-            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
-            this.lvFirmwares = new System.Windows.Forms.ListView();
-            this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvFirmwaresContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.tsmiSetCustomization = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiClearCustomization = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiInfo = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiCopy = new System.Windows.Forms.ToolStripMenuItem();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.toolStrip1 = new ToolStripEx();
-            this.tbbGroup = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.tbbScan = new System.Windows.Forms.ToolStripButton();
-            this.tbbOrganize = new System.Windows.Forms.ToolStripButton();
-            this.tbbImport = new System.Windows.Forms.ToolStripButton();
-            this.tbbClose = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.tbbCloseReload = new System.Windows.Forms.ToolStripButton();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.linkBasePath = new System.Windows.Forms.LinkLabel();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.tbbOpenFolder = new System.Windows.Forms.ToolStripButton();
-            this.lvFirmwaresContextMenuStrip.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.toolStrip1.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.panel2.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // imageList1
-            // 
-            this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
-            this.imageList1.ImageSize = new System.Drawing.Size(16, 16);
-            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
-            // 
-            // lvFirmwares
-            // 
-            this.lvFirmwares.AllowDrop = true;
-            this.lvFirmwares.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FirmwaresConfig));
+			this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+			this.lvFirmwares = new System.Windows.Forms.ListView();
+			this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.lvFirmwaresContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.tsmiSetCustomization = new System.Windows.Forms.ToolStripMenuItem();
+			this.tsmiClearCustomization = new System.Windows.Forms.ToolStripMenuItem();
+			this.tsmiInfo = new System.Windows.Forms.ToolStripMenuItem();
+			this.tsmiCopy = new System.Windows.Forms.ToolStripMenuItem();
+			this.panel1 = new System.Windows.Forms.Panel();
+			this.toolStrip1 = new ToolStripEx();
+			this.tbbGroup = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.tbbScan = new System.Windows.Forms.ToolStripButton();
+			this.tbbOrganize = new System.Windows.Forms.ToolStripButton();
+			this.tbbImport = new System.Windows.Forms.ToolStripButton();
+			this.tbbClose = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.tbbCloseReload = new System.Windows.Forms.ToolStripButton();
+			this.tbbOpenFolder = new System.Windows.Forms.ToolStripButton();
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.panel2 = new System.Windows.Forms.Panel();
+			this.linkBasePath = new System.Windows.Forms.LinkLabel();
+			this.label1 = new System.Windows.Forms.Label();
+			this.label2 = new System.Windows.Forms.Label();
+			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+			this.lvFirmwaresContextMenuStrip.SuspendLayout();
+			this.panel1.SuspendLayout();
+			this.toolStrip1.SuspendLayout();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.panel2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// imageList1
+			// 
+			this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+			this.imageList1.ImageSize = new System.Drawing.Size(16, 16);
+			this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+			// 
+			// lvFirmwares
+			// 
+			this.lvFirmwares.AllowDrop = true;
+			this.lvFirmwares.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader5,
             this.columnHeader1,
             this.columnHeader6,
@@ -87,114 +87,114 @@
             this.columnHeader3,
             this.columnHeader8,
             this.columnHeader7});
-            this.lvFirmwares.ContextMenuStrip = this.lvFirmwaresContextMenuStrip;
-            this.lvFirmwares.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lvFirmwares.FullRowSelect = true;
-            this.lvFirmwares.GridLines = true;
-            this.lvFirmwares.Location = new System.Drawing.Point(0, 25);
-            this.lvFirmwares.Name = "lvFirmwares";
-            this.lvFirmwares.ShowItemToolTips = true;
-            this.lvFirmwares.Size = new System.Drawing.Size(824, 404);
-            this.lvFirmwares.SmallImageList = this.imageList1;
-            this.lvFirmwares.TabIndex = 24;
-            this.lvFirmwares.UseCompatibleStateImageBehavior = false;
-            this.lvFirmwares.View = System.Windows.Forms.View.Details;
-            this.lvFirmwares.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lvFirmwares_ColumnClick);
-            this.lvFirmwares.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragDrop);
-            this.lvFirmwares.DragEnter += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragEnter);
-            this.lvFirmwares.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvFirmwares_KeyDown);
-            this.lvFirmwares.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvFirmwares_MouseClick);
-            // 
-            // columnHeader5
-            // 
-            this.columnHeader5.Text = "";
-            this.columnHeader5.Width = 31;
-            // 
-            // columnHeader1
-            // 
-            this.columnHeader1.Text = "System";
-            // 
-            // columnHeader6
-            // 
-            this.columnHeader6.Text = "Id";
-            // 
-            // columnHeader4
-            // 
-            this.columnHeader4.Text = "Description";
-            this.columnHeader4.Width = 165;
-            // 
-            // columnHeader2
-            // 
-            this.columnHeader2.Text = "Resolved With";
-            this.columnHeader2.Width = 116;
-            // 
-            // columnHeader3
-            // 
-            this.columnHeader3.Text = "Location";
-            this.columnHeader3.Width = 252;
-            // 
-            // columnHeader8
-            // 
-            this.columnHeader8.Text = "Size";
-            // 
-            // columnHeader7
-            // 
-            this.columnHeader7.Text = "Hash";
-            this.columnHeader7.Width = 250;
-            // 
-            // lvFirmwaresContextMenuStrip
-            // 
-            this.lvFirmwaresContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.lvFirmwares.ContextMenuStrip = this.lvFirmwaresContextMenuStrip;
+			this.lvFirmwares.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.lvFirmwares.FullRowSelect = true;
+			this.lvFirmwares.GridLines = true;
+			this.lvFirmwares.Location = new System.Drawing.Point(0, 25);
+			this.lvFirmwares.Name = "lvFirmwares";
+			this.lvFirmwares.ShowItemToolTips = true;
+			this.lvFirmwares.Size = new System.Drawing.Size(824, 404);
+			this.lvFirmwares.SmallImageList = this.imageList1;
+			this.lvFirmwares.TabIndex = 24;
+			this.lvFirmwares.UseCompatibleStateImageBehavior = false;
+			this.lvFirmwares.View = System.Windows.Forms.View.Details;
+			this.lvFirmwares.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lvFirmwares_ColumnClick);
+			this.lvFirmwares.DragDrop += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragDrop);
+			this.lvFirmwares.DragEnter += new System.Windows.Forms.DragEventHandler(this.lvFirmwares_DragEnter);
+			this.lvFirmwares.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvFirmwares_KeyDown);
+			this.lvFirmwares.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lvFirmwares_MouseClick);
+			// 
+			// columnHeader5
+			// 
+			this.columnHeader5.Text = "";
+			this.columnHeader5.Width = 31;
+			// 
+			// columnHeader1
+			// 
+			this.columnHeader1.Text = "System";
+			// 
+			// columnHeader6
+			// 
+			this.columnHeader6.Text = "Id";
+			// 
+			// columnHeader4
+			// 
+			this.columnHeader4.Text = "Description";
+			this.columnHeader4.Width = 165;
+			// 
+			// columnHeader2
+			// 
+			this.columnHeader2.Text = "Resolved With";
+			this.columnHeader2.Width = 116;
+			// 
+			// columnHeader3
+			// 
+			this.columnHeader3.Text = "Location";
+			this.columnHeader3.Width = 252;
+			// 
+			// columnHeader8
+			// 
+			this.columnHeader8.Text = "Size";
+			// 
+			// columnHeader7
+			// 
+			this.columnHeader7.Text = "Hash";
+			this.columnHeader7.Width = 250;
+			// 
+			// lvFirmwaresContextMenuStrip
+			// 
+			this.lvFirmwaresContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsmiSetCustomization,
             this.tsmiClearCustomization,
             this.tsmiInfo,
             this.tsmiCopy});
-            this.lvFirmwaresContextMenuStrip.Name = "lvFirmwaresContextMenuStrip";
-            this.lvFirmwaresContextMenuStrip.Size = new System.Drawing.Size(182, 92);
-            this.lvFirmwaresContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.lvFirmwaresContextMenuStrip_Opening);
-            // 
-            // tsmiSetCustomization
-            // 
-            this.tsmiSetCustomization.Name = "tsmiSetCustomization";
-            this.tsmiSetCustomization.Size = new System.Drawing.Size(181, 22);
-            this.tsmiSetCustomization.Text = "&Set Customization";
-            this.tsmiSetCustomization.Click += new System.EventHandler(this.tsmiSetCustomization_Click);
-            // 
-            // tsmiClearCustomization
-            // 
-            this.tsmiClearCustomization.Name = "tsmiClearCustomization";
-            this.tsmiClearCustomization.Size = new System.Drawing.Size(181, 22);
-            this.tsmiClearCustomization.Text = "C&lear Customization";
-            this.tsmiClearCustomization.Click += new System.EventHandler(this.tsmiClearCustomization_Click);
-            // 
-            // tsmiInfo
-            // 
-            this.tsmiInfo.Name = "tsmiInfo";
-            this.tsmiInfo.Size = new System.Drawing.Size(181, 22);
-            this.tsmiInfo.Text = "&Info";
-            this.tsmiInfo.Click += new System.EventHandler(this.tsmiInfo_Click);
-            // 
-            // tsmiCopy
-            // 
-            this.tsmiCopy.Name = "tsmiCopy";
-            this.tsmiCopy.Size = new System.Drawing.Size(181, 22);
-            this.tsmiCopy.Text = "&Copy";
-            this.tsmiCopy.Click += new System.EventHandler(this.tsmiCopy_Click);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.lvFirmwares);
-            this.panel1.Controls.Add(this.toolStrip1);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(3, 23);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(824, 429);
-            this.panel1.TabIndex = 24;
-            // 
-            // toolStrip1
-            // 
-            this.toolStrip1.ClickThrough = true;
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.lvFirmwaresContextMenuStrip.Name = "lvFirmwaresContextMenuStrip";
+			this.lvFirmwaresContextMenuStrip.Size = new System.Drawing.Size(182, 92);
+			this.lvFirmwaresContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.lvFirmwaresContextMenuStrip_Opening);
+			// 
+			// tsmiSetCustomization
+			// 
+			this.tsmiSetCustomization.Name = "tsmiSetCustomization";
+			this.tsmiSetCustomization.Size = new System.Drawing.Size(181, 22);
+			this.tsmiSetCustomization.Text = "&Set Customization";
+			this.tsmiSetCustomization.Click += new System.EventHandler(this.tsmiSetCustomization_Click);
+			// 
+			// tsmiClearCustomization
+			// 
+			this.tsmiClearCustomization.Name = "tsmiClearCustomization";
+			this.tsmiClearCustomization.Size = new System.Drawing.Size(181, 22);
+			this.tsmiClearCustomization.Text = "C&lear Customization";
+			this.tsmiClearCustomization.Click += new System.EventHandler(this.tsmiClearCustomization_Click);
+			// 
+			// tsmiInfo
+			// 
+			this.tsmiInfo.Name = "tsmiInfo";
+			this.tsmiInfo.Size = new System.Drawing.Size(181, 22);
+			this.tsmiInfo.Text = "&Info";
+			this.tsmiInfo.Click += new System.EventHandler(this.tsmiInfo_Click);
+			// 
+			// tsmiCopy
+			// 
+			this.tsmiCopy.Name = "tsmiCopy";
+			this.tsmiCopy.Size = new System.Drawing.Size(181, 22);
+			this.tsmiCopy.Text = "&Copy";
+			this.tsmiCopy.Click += new System.EventHandler(this.tsmiCopy_Click);
+			// 
+			// panel1
+			// 
+			this.panel1.Controls.Add(this.lvFirmwares);
+			this.panel1.Controls.Add(this.toolStrip1);
+			this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.panel1.Location = new System.Drawing.Point(3, 23);
+			this.panel1.Name = "panel1";
+			this.panel1.Size = new System.Drawing.Size(824, 429);
+			this.panel1.TabIndex = 24;
+			// 
+			// toolStrip1
+			// 
+			this.toolStrip1.ClickThrough = true;
+			this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tbbGroup,
             this.toolStripSeparator2,
             this.tbbScan,
@@ -204,185 +204,185 @@
             this.toolStripSeparator1,
             this.tbbCloseReload,
             this.tbbOpenFolder});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(824, 25);
-            this.toolStrip1.TabIndex = 23;
-            this.toolStrip1.Text = "toolStrip1";
-            // 
-            // tbbGroup
-            // 
-            this.tbbGroup.Checked = true;
-            this.tbbGroup.CheckOnClick = true;
-            this.tbbGroup.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.tbbGroup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbGroup.Image = ((System.Drawing.Image)(resources.GetObject("tbbGroup.Image")));
-            this.tbbGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbGroup.Name = "tbbGroup";
-            this.tbbGroup.Size = new System.Drawing.Size(44, 22);
-            this.tbbGroup.Text = "Group";
-            this.tbbGroup.Click += new System.EventHandler(this.tbbGroup_Click);
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-            // 
-            // tbbScan
-            // 
-            this.tbbScan.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbScan.Image = ((System.Drawing.Image)(resources.GetObject("tbbScan.Image")));
-            this.tbbScan.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbScan.Name = "tbbScan";
-            this.tbbScan.Size = new System.Drawing.Size(36, 22);
-            this.tbbScan.Text = "Scan";
-            this.tbbScan.Click += new System.EventHandler(this.tbbScan_Click);
-            // 
-            // tbbOrganize
-            // 
-            this.tbbOrganize.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbOrganize.Image = ((System.Drawing.Image)(resources.GetObject("tbbOrganize.Image")));
-            this.tbbOrganize.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbOrganize.Name = "tbbOrganize";
-            this.tbbOrganize.Size = new System.Drawing.Size(58, 22);
-            this.tbbOrganize.Text = "Organize";
-            this.tbbOrganize.Click += new System.EventHandler(this.tbbOrganize_Click);
-            // 
-            // tbbImport
-            // 
-            this.tbbImport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbImport.Image = ((System.Drawing.Image)(resources.GetObject("tbbImport.Image")));
-            this.tbbImport.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbImport.Name = "tbbImport";
-            this.tbbImport.Size = new System.Drawing.Size(47, 22);
-            this.tbbImport.Text = "Import";
-            this.tbbImport.Click += new System.EventHandler(this.tbbImport_Click);
-            // 
-            // tbbClose
-            // 
-            this.tbbClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.tbbClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbClose.Image = ((System.Drawing.Image)(resources.GetObject("tbbClose.Image")));
-            this.tbbClose.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbClose.Margin = new System.Windows.Forms.Padding(0, 1, 2, 2);
-            this.tbbClose.Name = "tbbClose";
-            this.tbbClose.Size = new System.Drawing.Size(40, 22);
-            this.tbbClose.Text = "Close";
-            this.tbbClose.Click += new System.EventHandler(this.tbbClose_Click);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-            this.toolStripSeparator1.Visible = false;
-            // 
-            // tbbCloseReload
-            // 
-            this.tbbCloseReload.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.tbbCloseReload.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbCloseReload.Enabled = false;
-            this.tbbCloseReload.Image = ((System.Drawing.Image)(resources.GetObject("tbbCloseReload.Image")));
-            this.tbbCloseReload.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbCloseReload.Name = "tbbCloseReload";
-            this.tbbCloseReload.Size = new System.Drawing.Size(129, 22);
-            this.tbbCloseReload.Text = "Close and reload ROM";
-            this.tbbCloseReload.ToolTipText = "Close and reload ROM";
-            this.tbbCloseReload.Visible = false;
-            this.tbbCloseReload.Click += new System.EventHandler(this.tbbCloseReload_Click);
-            // 
-            // tableLayoutPanel1
-            // 
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(830, 478);
-            this.tableLayoutPanel1.TabIndex = 25;
-            // 
-            // panel2
-            // 
-            this.panel2.AutoSize = true;
-            this.panel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.panel2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.panel2.Controls.Add(this.linkBasePath);
-            this.panel2.Controls.Add(this.label1);
-            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(3, 458);
-            this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(824, 17);
-            this.panel2.TabIndex = 26;
-            // 
-            // linkBasePath
-            // 
-            this.linkBasePath.AutoSize = true;
-            this.linkBasePath.Location = new System.Drawing.Point(125, 0);
-            this.linkBasePath.Name = "linkBasePath";
-            this.linkBasePath.Size = new System.Drawing.Size(55, 13);
-            this.linkBasePath.TabIndex = 27;
-            this.linkBasePath.TabStop = true;
-            this.linkBasePath.Text = "linkLabel1";
-            this.linkBasePath.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkBasePath_LinkClicked);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(119, 13);
-            this.label1.TabIndex = 25;
-            this.label1.Text = "Firmwares Search Path:";
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(5, 5);
-            this.label2.Margin = new System.Windows.Forms.Padding(5, 5, 3, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(395, 13);
-            this.label2.TabIndex = 27;
-            this.label2.Text = "Firmware such as BIOS files are copyrighted material and not provided by BizHawk";
-            // 
-            // tbbOpenFolder
-            // 
-            this.tbbOpenFolder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tbbOpenFolder.Image = ((System.Drawing.Image)(resources.GetObject("tbbOpenFolder.Image")));
-            this.tbbOpenFolder.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tbbOpenFolder.Name = "tbbOpenFolder";
-            this.tbbOpenFolder.Size = new System.Drawing.Size(128, 22);
-            this.tbbOpenFolder.Text = "Open Firmware Folder";
-            this.tbbOpenFolder.Click += new System.EventHandler(this.tbbOpenFolder_Click);
-            // 
-            // FirmwaresConfig
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(830, 478);
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Name = "FirmwaresConfig";
-            this.ShowIcon = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Firmwares";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FirmwaresConfig_FormClosed);
-            this.Load += new System.EventHandler(this.FirmwaresConfig_Load);
-            this.lvFirmwaresContextMenuStrip.ResumeLayout(false);
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
-            this.ResumeLayout(false);
+			this.toolStrip1.Location = new System.Drawing.Point(0, 0);
+			this.toolStrip1.Name = "toolStrip1";
+			this.toolStrip1.Size = new System.Drawing.Size(824, 25);
+			this.toolStrip1.TabIndex = 23;
+			this.toolStrip1.Text = "toolStrip1";
+			// 
+			// tbbGroup
+			// 
+			this.tbbGroup.Checked = true;
+			this.tbbGroup.CheckOnClick = true;
+			this.tbbGroup.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.tbbGroup.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbGroup.Image = ((System.Drawing.Image)(resources.GetObject("tbbGroup.Image")));
+			this.tbbGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbGroup.Name = "tbbGroup";
+			this.tbbGroup.Size = new System.Drawing.Size(44, 22);
+			this.tbbGroup.Text = "Group";
+			this.tbbGroup.Click += new System.EventHandler(this.tbbGroup_Click);
+			// 
+			// toolStripSeparator2
+			// 
+			this.toolStripSeparator2.Name = "toolStripSeparator2";
+			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+			// 
+			// tbbScan
+			// 
+			this.tbbScan.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbScan.Image = ((System.Drawing.Image)(resources.GetObject("tbbScan.Image")));
+			this.tbbScan.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbScan.Name = "tbbScan";
+			this.tbbScan.Size = new System.Drawing.Size(36, 22);
+			this.tbbScan.Text = "Scan";
+			this.tbbScan.Click += new System.EventHandler(this.tbbScan_Click);
+			// 
+			// tbbOrganize
+			// 
+			this.tbbOrganize.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbOrganize.Image = ((System.Drawing.Image)(resources.GetObject("tbbOrganize.Image")));
+			this.tbbOrganize.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbOrganize.Name = "tbbOrganize";
+			this.tbbOrganize.Size = new System.Drawing.Size(58, 22);
+			this.tbbOrganize.Text = "Organize";
+			this.tbbOrganize.Click += new System.EventHandler(this.tbbOrganize_Click);
+			// 
+			// tbbImport
+			// 
+			this.tbbImport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbImport.Image = ((System.Drawing.Image)(resources.GetObject("tbbImport.Image")));
+			this.tbbImport.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbImport.Name = "tbbImport";
+			this.tbbImport.Size = new System.Drawing.Size(47, 22);
+			this.tbbImport.Text = "Import";
+			this.tbbImport.Click += new System.EventHandler(this.tbbImport_Click);
+			// 
+			// tbbClose
+			// 
+			this.tbbClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.tbbClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbClose.Image = ((System.Drawing.Image)(resources.GetObject("tbbClose.Image")));
+			this.tbbClose.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbClose.Margin = new System.Windows.Forms.Padding(0, 1, 2, 2);
+			this.tbbClose.Name = "tbbClose";
+			this.tbbClose.Size = new System.Drawing.Size(40, 22);
+			this.tbbClose.Text = "Close";
+			this.tbbClose.Click += new System.EventHandler(this.tbbClose_Click);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+			this.toolStripSeparator1.Visible = false;
+			// 
+			// tbbCloseReload
+			// 
+			this.tbbCloseReload.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+			this.tbbCloseReload.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbCloseReload.Enabled = false;
+			this.tbbCloseReload.Image = ((System.Drawing.Image)(resources.GetObject("tbbCloseReload.Image")));
+			this.tbbCloseReload.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbCloseReload.Name = "tbbCloseReload";
+			this.tbbCloseReload.Size = new System.Drawing.Size(129, 22);
+			this.tbbCloseReload.Text = "Close and reload ROM";
+			this.tbbCloseReload.ToolTipText = "Close and reload ROM";
+			this.tbbCloseReload.Visible = false;
+			this.tbbCloseReload.Click += new System.EventHandler(this.tbbCloseReload_Click);
+			// 
+			// tbbOpenFolder
+			// 
+			this.tbbOpenFolder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+			this.tbbOpenFolder.Image = ((System.Drawing.Image)(resources.GetObject("tbbOpenFolder.Image")));
+			this.tbbOpenFolder.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.tbbOpenFolder.Name = "tbbOpenFolder";
+			this.tbbOpenFolder.Size = new System.Drawing.Size(128, 22);
+			this.tbbOpenFolder.Text = "Open Firmware Folder";
+			this.tbbOpenFolder.Click += new System.EventHandler(this.tbbOpenFolder_Click);
+			// 
+			// tableLayoutPanel1
+			// 
+			this.tableLayoutPanel1.ColumnCount = 1;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 2);
+			this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
+			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 3;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(830, 478);
+			this.tableLayoutPanel1.TabIndex = 25;
+			// 
+			// panel2
+			// 
+			this.panel2.AutoSize = true;
+			this.panel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.panel2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.panel2.Controls.Add(this.linkBasePath);
+			this.panel2.Controls.Add(this.label1);
+			this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.panel2.Location = new System.Drawing.Point(3, 458);
+			this.panel2.Name = "panel2";
+			this.panel2.Size = new System.Drawing.Size(824, 17);
+			this.panel2.TabIndex = 26;
+			// 
+			// linkBasePath
+			// 
+			this.linkBasePath.AutoSize = true;
+			this.linkBasePath.Location = new System.Drawing.Point(125, 0);
+			this.linkBasePath.Name = "linkBasePath";
+			this.linkBasePath.Size = new System.Drawing.Size(55, 13);
+			this.linkBasePath.TabIndex = 27;
+			this.linkBasePath.TabStop = true;
+			this.linkBasePath.Text = "linkLabel1";
+			this.linkBasePath.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkBasePath_LinkClicked);
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(3, 0);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(119, 13);
+			this.label1.TabIndex = 25;
+			this.label1.Text = "Firmwares Search Path:";
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Location = new System.Drawing.Point(5, 5);
+			this.label2.Margin = new System.Windows.Forms.Padding(5, 5, 3, 0);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(395, 13);
+			this.label2.TabIndex = 27;
+			this.label2.Text = "Firmware such as BIOS files are copyrighted material and not provided by BizHawk";
+			// 
+			// FirmwaresConfig
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(830, 478);
+			this.Controls.Add(this.tableLayoutPanel1);
+			this.Name = "FirmwaresConfig";
+			this.ShowIcon = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Firmwares";
+			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FirmwaresConfig_FormClosed);
+			this.Load += new System.EventHandler(this.FirmwaresConfig_Load);
+			this.lvFirmwaresContextMenuStrip.ResumeLayout(false);
+			this.panel1.ResumeLayout(false);
+			this.panel1.PerformLayout();
+			this.toolStrip1.ResumeLayout(false);
+			this.toolStrip1.PerformLayout();
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			this.panel2.ResumeLayout(false);
+			this.panel2.PerformLayout();
+			this.ResumeLayout(false);
 
         }
 

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
@@ -183,12 +183,11 @@ namespace BizHawk.Client.EmuHawk
 
 			cbAllowImport = new CheckBox();
 			cbAllowImport.Text = "Allow Importing of Unknown Files";
-			//cbAllowImport.CheckStateChanged += (s, ex) => this.Text = cbAllowImport.CheckState.ToString();
 			cbAllowImport.BackColor = Color.Transparent;
 			cbAllowImport.CheckAlign = ContentAlignment.MiddleLeft;
 			cbAllowImport.TextAlign = ContentAlignment.MiddleLeft;
 			cbAllowImport.Font = new Font("Segeo UI", 9, FontStyle.Regular, GraphicsUnit.Point, 1, false);
-			//cbAllowImport.AutoSize = false;
+			cbAllowImport.Checked = false;
 			ToolStripControlHost host = new ToolStripControlHost(cbAllowImport);
 			var iCount = toolStrip1.Items.Count;
 			toolStrip1.Items.Insert(iCount - 2, host);

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
@@ -57,6 +57,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public string TargetSystem = null;
 
+		private CheckBox cbAllowImport;
+
 		private const int idUnsure = 0;
 		private const int idMissing = 1;
 		private const int idOk = 2;
@@ -178,6 +180,18 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			RefreshBasePath();
+
+			cbAllowImport = new CheckBox();
+			cbAllowImport.Text = "Allow Importing of Unknown Files";
+			//cbAllowImport.CheckStateChanged += (s, ex) => this.Text = cbAllowImport.CheckState.ToString();
+			cbAllowImport.BackColor = Color.Transparent;
+			cbAllowImport.CheckAlign = ContentAlignment.MiddleLeft;
+			cbAllowImport.TextAlign = ContentAlignment.MiddleLeft;
+			cbAllowImport.Font = new Font("Segeo UI", 9, FontStyle.Regular, GraphicsUnit.Point, 1, false);
+			//cbAllowImport.AutoSize = false;
+			ToolStripControlHost host = new ToolStripControlHost(cbAllowImport);
+			var iCount = toolStrip1.Items.Count;
+			toolStrip1.Items.Insert(iCount - 2, host);
 		}
 
 
@@ -652,7 +666,7 @@ namespace BizHawk.Client.EmuHawk
 								File.WriteAllBytes(outfile, ms.ToArray());
 								hf.Unbind();
 
-                                if (Manager.CanFileBeImported(outfile))
+                                if (cbAllowImport.Checked || Manager.CanFileBeImported(outfile))
                                 {
                                     didSomething |= RunImportJobSingle(basepath, outfile, ref errors);
                                 }
@@ -665,7 +679,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 					else
 					{
-                        if (Manager.CanFileBeImported(hf.CanonicalFullPath))
+                        if (cbAllowImport.Checked || Manager.CanFileBeImported(hf.CanonicalFullPath))
                         {
                             didSomething |= RunImportJobSingle(basepath, f, ref errors);
                         } 

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
@@ -189,8 +189,7 @@ namespace BizHawk.Client.EmuHawk
 			cbAllowImport.Font = new Font("Segeo UI", 9, FontStyle.Regular, GraphicsUnit.Point, 1, false);
 			cbAllowImport.Checked = false;
 			ToolStripControlHost host = new ToolStripControlHost(cbAllowImport);
-			var iCount = toolStrip1.Items.Count;
-			toolStrip1.Items.Insert(iCount - 2, host);
+			toolStrip1.Items.Add(host);
 		}
 
 

--- a/BizHawk.Client.EmuHawk/config/FirmwaresConfig.resx
+++ b/BizHawk.Client.EmuHawk/config/FirmwaresConfig.resx
@@ -217,6 +217,21 @@
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="tbbOpenFolder.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>221, 17</value>
   </metadata>


### PR DESCRIPTION
…) - #314 

Another issue from the vaults...

Addresses ticket #314 

This PR:

* Adds a bool return method to _FirmwareManager.cs_ that tests whether a file you are trying to import matches the size and hash of anything in the _FirmwareDatabase_.
* This is then tested in _FirmwaresConfig_ whenever files are imported (either by the 'Import' button or via drag'n'drop) so that files that dont match are not imported
* Added an 'Open Firmware Folder' button in the _FirmwaresConfig_ dialog so users can manually copy in custom firmware if they desire
* Updated the 'Set Customization' context menu click event so that if the file selected does **not** reside in the firmwares folder, the user is given the option to copy it there before the customization is set (so users have a method of getting custom firmware into the firmware folder without manually copying it).