### PR TITLE
Z80: fix IN A, (N) flag affection

### DIFF
--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Operations.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Operations.cs
@@ -58,7 +58,13 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 			Flag3 = Regs[dest].Bit(3);
 		}
 
-		public void TR_Func(ushort dest, ushort src)
+        public void IN_A_N_Func(ushort dest, ushort src_l, ushort src_h)
+        {
+            Regs[dest] = ReadHardware((ushort)(Regs[src_l] | (Regs[src_h]) << 8));
+            Regs[DB] = Regs[dest];
+        }
+
+        public void TR_Func(ushort dest, ushort src)
 		{
 			Regs[dest] = Regs[src];
 		}

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Tables_Direct.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Tables_Direct.cs
@@ -609,7 +609,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 						IDLE,
 						WAIT,
 						WAIT,
-						IN, A, Z, W,
+						IN_A_N, A, Z, W,
 						INC16, Z, W,
 						WAIT,
 						OP_F,

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
@@ -80,6 +80,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 		public const ushort RST = 65;
 		public const ushort REP_OP_I = 66;
 		public const ushort REP_OP_O = 67;
+        public const ushort IN_A_N = 68;
 
 		// non-state variables
 		public ushort Ztemp1, Ztemp2, Ztemp3, Ztemp4;	
@@ -478,6 +479,9 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 				case IN:
 					IN_Func(cur_instr[instr_pntr++], cur_instr[instr_pntr++], cur_instr[instr_pntr++]);
 					break;
+                case IN_A_N:
+                    IN_A_N_Func(cur_instr[instr_pntr++], cur_instr[instr_pntr++], cur_instr[instr_pntr++]);
+                    break;
 				case NEG:
 					NEG_8_Func(cur_instr[instr_pntr++]);
 					break;


### PR DESCRIPTION
From ticket #1323 

@alyosha-tas : I think this should do it. Can you cast a quick eye over just to make sure you are happy (and I have not gone about things in a weird way).

It looks like IN A, (N) is the only non-ED instruction anyway, so the changes are minimal.

This fixes the 5 SMS games listed in #1323 , the games in #1267 and #1264 , and Tails Skypatrol from #1157 . 

From a speccy point of view, the timing and flag tests are also passing (along with the various ULA-related tests).