### PR TITLE
Attempt to resolve #832 , needs a lot of testing probably

### DIFF
--- a/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/BizHawk.Client.Common/movie/MovieSession.cs
@@ -143,8 +143,11 @@ namespace BizHawk.Client.Common
 			if (Global.Emulator.Frame == 0)
 			{
 				MovieControllerAdapter.LatchFromSource(input);
-				(Movie as TasMovie).GreenzoneCurrentFrame();
-				Movie.RecordFrame(Global.Emulator.Frame, Global.MovieOutputHardpoint);
+				if (Movie.IsRecording)
+				{
+					(Movie as TasMovie).GreenzoneCurrentFrame();
+					Movie.RecordFrame(Global.Emulator.Frame, Global.MovieOutputHardpoint);
+				}
 				return;
 			}
 

--- a/BizHawk.Client.Common/movie/MovieSession.cs
+++ b/BizHawk.Client.Common/movie/MovieSession.cs
@@ -132,19 +132,24 @@ namespace BizHawk.Client.Common
 		{
 			var input = Movie.GetInputState(Global.Emulator.Frame);
 
-			// adelikat: TODO: this is likely the source of frame 0 TAStudio bugs, I think the intent is to check if the movie is 0 length?
-			//if (Global.Emulator.Frame == 0) // Hacky
-			//{
-			//	HandleMovieAfterFrameLoop(); // Frame 0 needs to be handled.
-			//}
-
 			if (input == null)
 			{
-				HandleMovieAfterFrameLoop();
+				MovieControllerAdapter.SetSticky();
+				(Movie as TasMovie).GreenzoneCurrentFrame();
+				Movie.RecordFrame(Global.Emulator.Frame, Global.MovieOutputHardpoint);
+				return;
+			}
+
+			if (Global.Emulator.Frame == 0)
+			{
+				MovieControllerAdapter.LatchFromSource(input);
+				(Movie as TasMovie).GreenzoneCurrentFrame();
+				Movie.RecordFrame(Global.Emulator.Frame, Global.MovieOutputHardpoint);
 				return;
 			}
 
 			MovieControllerAdapter.LatchFromSource(input);
+			
 			if (MultiTrack.IsActive)
 			{
 				Global.MultitrackRewiringAdapter.Source = MovieControllerAdapter;
@@ -294,7 +299,7 @@ namespace BizHawk.Client.Common
 			// we don't want tasmovie to latch user input outside its internal recording mode, so limit it to autohold
 			if (Movie is TasMovie && Movie.IsPlaying)
 			{
-				MovieControllerAdapter.LatchSticky();
+				MovieControllerAdapter.SetSticky();
 			}
 			else
 			{

--- a/BizHawk.Client.Common/movie/bk2/Bk2ControllerAdapter.cs
+++ b/BizHawk.Client.Common/movie/bk2/Bk2ControllerAdapter.cs
@@ -151,6 +151,24 @@ namespace BizHawk.Client.Common
 			}
 		}
 
+		public void SetSticky()
+		{
+			foreach (var button in Definition.BoolButtons)
+			{
+				_myBoolButtons[button] = Global.AutofireStickyXORAdapter.IsSticky(button);
+			}
+
+			int i = 0;
+			// float controls don't have sticky logic. but old values remain in MovieOutputHardpoint if we don't update this here
+			foreach (var name in Definition.FloatControls)
+			{
+				var temp = Definition.FloatRanges[i];
+				_myFloatControls[name] = temp.Mid;
+				AutoPatternFloat pattern = new AutoPatternFloat(temp.Mid, 1, temp.Mid, 0);
+				i++;
+			}
+		}
+
 		/// <summary>
 		/// latches all buttons from the supplied mnemonic string
 		/// </summary>

--- a/BizHawk.Client.Common/movie/bkm/BkmControllerAdapter.cs
+++ b/BizHawk.Client.Common/movie/bkm/BkmControllerAdapter.cs
@@ -71,6 +71,11 @@ namespace BizHawk.Client.Common
 			}
 		}
 
+		public void SetSticky()
+		{
+
+		}
+
 		/// <summary>
 		/// latches all buttons from the supplied mnemonic string
 		/// </summary>

--- a/BizHawk.Client.Common/movie/interfaces/IMovieController.cs
+++ b/BizHawk.Client.Common/movie/interfaces/IMovieController.cs
@@ -12,6 +12,8 @@ namespace BizHawk.Client.Common
 
 		void LatchSticky();
 
+		void SetSticky();
+
 		void SetControllersAsMnemonic(string mnemonic);
 	}
 }

--- a/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -69,7 +69,6 @@ namespace BizHawk.Client.Common
 		public void SetFrame(int frame, string source)
 		{
 			ChangeLog.AddGeneralUndo(frame, frame, "Set Frame At: " + frame);
-
 			SetFrameAt(frame, source);
 			InvalidateAfter(frame);
 
@@ -392,7 +391,7 @@ namespace BizHawk.Client.Common
 			int oldLength = InputLogLength;
 			ChangeLog.AddGeneralUndo(oldLength, oldLength + numFrames - 1);
 
-			Global.MovieSession.MovieControllerAdapter.LatchSticky();
+			//Global.MovieSession.MovieControllerAdapter.LatchSticky();
 
 			var lg = LogGeneratorInstance();
 			lg.SetSource(Global.MovieOutputHardpoint); // account for autohold. needs autohold pattern to be already recorded in the current frame


### PR DESCRIPTION
The previous logic was always latching input from the background global controller state, which is not what we want for default state. 

Separately this was also happening when appending new frames by drag and drop, which is obviously not what we want.

I think this PR resolves these issues without any regressions, but of course it needs a lot of verification before merging.