### PR TITLE
This fixes a bug in TAStudio where you cannot use '<'to get to frame 0

### DIFF
--- a/BizHawk.Client.EmuHawk/IControlMainform.cs
+++ b/BizHawk.Client.EmuHawk/IControlMainform.cs
@@ -43,7 +43,7 @@
 		/// Returns whether or not the rewind action actually occured
 		/// </summary>
 		/// <returns></returns>
-		bool Rewind();
+		bool Rewind(ref bool runframe);
 
 		bool WantsToControlRestartMovie { get; }
 

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -4461,7 +4461,7 @@ namespace BizHawk.Client.EmuHawk
 					if (isRewinding)
 					{
 						runFrame = true; // TODO: the master should be deciding this!
-						Master.Rewind();
+						Master.Rewind(ref runFrame);
 					}
 				}
 				else

--- a/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.IControlMainform.cs
+++ b/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.IControlMainform.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Client.EmuHawk
 		// TODO: We probably want to do this
 		public bool WantsToControlRewind { get { return false; } }
 		public void CaptureRewind() { }
-		public bool Rewind() { return false; }
+		public bool Rewind(ref bool runframe) { return false; }
 
 		public bool WantsToControlRestartMovie { get { return false; } }
 		public void RestartMovie() { }

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -84,7 +84,7 @@
 			// Do nothing, Tastudio handles this just fine
 		}
 
-		public bool Rewind()
+		public bool Rewind(ref bool runframe)
 		{
 			// copypasted from TasView_MouseWheel(), just without notch logic
 			if (Mainform.IsSeeking && !Mainform.EmulatorPaused)
@@ -105,7 +105,9 @@
 			else
 			{
 				StopSeeking(); // late breaking memo: dont know whether this is needed
-				GoToPreviousFrame();
+				int dist = GoToPreviousFrame();
+
+				if (Emulator.Frame == 0) { runframe = false; }
 			}
 
 			return true;

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -28,17 +28,18 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		// SuuperW: I changed this to public so that it could be used by MarkerControl.cs
-		public void GoToFrame(int frame, bool fromLua = false, bool fromRewinding = false)
+		public int GoToFrame(int frame, bool fromLua = false, bool fromRewinding = false)
 		{
 			// If seeking to a frame before or at the end of the movie, use StartAtNearestFrameAndEmulate
 			// Otherwise, load the latest state (if not already there) and seek while recording.
+			int dist = 0;
 
 			WasRecording = CurrentTasMovie.IsRecording || WasRecording;
 
 			if (frame <= CurrentTasMovie.InputLogLength)
 			{
 				// Get as close as we can then emulate there
-				StartAtNearestFrameAndEmulate(frame, fromLua, fromRewinding);
+				dist = StartAtNearestFrameAndEmulate(frame, fromLua, fromRewinding);
 
 				MaybeFollowCursor();
 			}
@@ -69,14 +70,20 @@ namespace BizHawk.Client.EmuHawk
 
 			RefreshDialog();
 			UpdateOtherTools();
+
+			return dist;
 		}
 
-		public void GoToPreviousFrame()
+		public int GoToPreviousFrame()
 		{
+			int dist = -1;
+
 			if (Emulator.Frame > 0)
 			{
-				GoToFrame(Emulator.Frame - 1);
+				dist = GoToFrame(Emulator.Frame - 1);
 			}
+
+			return dist;
 		}
 
 		public void GoToNextFrame()

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -854,14 +854,17 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void StartAtNearestFrameAndEmulate(int frame, bool fromLua, bool fromRewinding)
+		private int StartAtNearestFrameAndEmulate(int frame, bool fromLua, bool fromRewinding)
 		{
 			if (frame == Emulator.Frame)
-				return;
+				return 0;
 
 			_unpauseAfterSeeking = (fromRewinding || WasRecording) && !Mainform.EmulatorPaused;
 			TastudioPlayMode();
 			KeyValuePair<int, byte[]> closestState = CurrentTasMovie.TasStateManager.GetStateClosestToFrame(frame);
+
+			int dist = frame - closestState.Key;
+
 			if (closestState.Value != null && (frame < Emulator.Frame || closestState.Key > Emulator.Frame))
 			{
 				LoadState(closestState);
@@ -913,6 +916,8 @@ namespace BizHawk.Client.EmuHawk
 					// users who are clicking around.. I dont know.
 				}
 			}
+
+			return dist;
 		}
 
 		public void LoadState(KeyValuePair<int, byte[]> state)


### PR DESCRIPTION
This resolves the TODO involving runFrame, which is supposed to be false when we want to be at frame zero, but is currently always true.

I don't believe it has any side effects from other code paths, and I tested it out in my own projects, but it could use a second look just to be sure