### PR TITLE
Sync TAStudio Recording mode to movie state

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -480,25 +480,25 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.LuaConsole.ResumeScripts(false);
 				}
 
+				if (GlobalWin.Tools.Has<TAStudio>())
+				{
+					// There are instances where the movie will be switched out of recording mode but TAStudio doesn't know about it
+					// update the state here
+					if (GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingIsChecked != Global.MovieSession.Movie.IsRecording)
+					{
+						Global.MovieSession.ReadOnly = true;
+						GlobalWin.Tools.TAStudio.WasRecording = false;
+						GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingIsChecked = Global.MovieSession.Movie.IsRecording;
+					}
+
+				}
+
 				StepRunLoop_Core();
 				StepRunLoop_Throttle();
 
 				Render();
 
 				CheckMessages();
-				
-				if (GlobalWin.Tools.Has<TAStudio>())
-				{
-					// There are instances where the movie will be switched out of recording mode but TAStudio doesn't know about it
-					// update the state here
-					if (GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingModeCheckbox.Checked != Global.MovieSession.Movie.IsRecording)
-					{
-						Global.MovieSession.ReadOnly = true;
-						GlobalWin.Tools.TAStudio.WasRecording = false;
-						GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingModeCheckbox.Checked = Global.MovieSession.Movie.IsRecording;
-					}
-					
-				}
 
 				if (_exitRequestPending)
 				{
@@ -4480,8 +4480,8 @@ namespace BizHawk.Client.EmuHawk
 
 					if (isRewinding)
 					{
-						runFrame = true; // TODO: the master should be deciding this!
-						Master.Rewind(ref runFrame);
+						runFrame = Emulator.Frame > 1; // TODO: the master should be deciding this!
+						Master.Rewind();
 					}
 				}
 				else
@@ -4514,7 +4514,7 @@ namespace BizHawk.Client.EmuHawk
 
 				if (isRewinding)
 				{
-					runFrame = Global.Rewinder.Rewind(1);
+					runFrame = Global.Rewinder.Rewind(1) && Emulator.Frame > 1;
 
 					if (runFrame && Global.MovieSession.Movie.IsRecording)
 					{

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -486,6 +486,19 @@ namespace BizHawk.Client.EmuHawk
 				Render();
 
 				CheckMessages();
+				
+				if (GlobalWin.Tools.Has<TAStudio>())
+				{
+					// There are instances where the movie will be switched out of recording mode but TAStudio doesn't know about it
+					// update the state here
+					if (GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingModeCheckbox.Checked != Global.MovieSession.Movie.IsRecording)
+					{
+						Global.MovieSession.ReadOnly = true;
+						GlobalWin.Tools.TAStudio.WasRecording = false;
+						GlobalWin.Tools.TAStudio.TasPlaybackBox.RecordingModeCheckbox.Checked = Global.MovieSession.Movie.IsRecording;
+					}
+					
+				}
 
 				if (_exitRequestPending)
 				{

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.Designer.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.Designer.cs
@@ -192,7 +192,7 @@
 		private System.Windows.Forms.CheckBox AutoRestoreCheckbox;
 		private System.Windows.Forms.CheckBox TurboSeekCheckbox;
 		private System.Windows.Forms.CheckBox FollowCursorCheckbox;
-		private System.Windows.Forms.CheckBox RecordingModeCheckbox;
+		public System.Windows.Forms.CheckBox RecordingModeCheckbox;
 		private System.Windows.Forms.ToolTip toolTip1;
 	}
 }

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.Designer.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.Designer.cs
@@ -192,7 +192,7 @@
 		private System.Windows.Forms.CheckBox AutoRestoreCheckbox;
 		private System.Windows.Forms.CheckBox TurboSeekCheckbox;
 		private System.Windows.Forms.CheckBox FollowCursorCheckbox;
-		public System.Windows.Forms.CheckBox RecordingModeCheckbox;
+		private System.Windows.Forms.CheckBox RecordingModeCheckbox;
 		private System.Windows.Forms.ToolTip toolTip1;
 	}
 }

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
@@ -83,6 +83,20 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		[Browsable(true)]
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public bool RecordingIsChecked
+		{
+			get
+			{
+				return RecordingModeCheckbox.Checked;
+			}
+			set
+			{
+				RecordingModeCheckbox.Checked = value;
+			}
+		}
+
 		public PlaybackBox()
 		{
 			InitializeComponent();


### PR DESCRIPTION
Fixes a bug where the current movie can be in a different recording state then the displayed TAStudio state (according to the checkbox.)

This happens when appending frames by clicking and dragging input.

Note: Probably / maybe, this should happen anytime input is changed by manually using the piano roll, but it currently only happens in this instance. Maybe that can be future work?



