### PR TITLE
Revert #1371

### DIFF
--- a/BizHawk.Client.EmuHawk/IControlMainform.cs
+++ b/BizHawk.Client.EmuHawk/IControlMainform.cs
@@ -43,7 +43,7 @@
 		/// Returns whether or not the rewind action actually occured
 		/// </summary>
 		/// <returns></returns>
-		bool Rewind(ref bool runframe);
+		bool Rewind();
 
 		bool WantsToControlRestartMovie { get; }
 

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -4468,7 +4468,7 @@ namespace BizHawk.Client.EmuHawk
 					if (isRewinding)
 					{
 						runFrame = true; // TODO: the master should be deciding this!
-						Master.Rewind(ref runFrame);
+						Master.Rewind();
 					}
 				}
 				else

--- a/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.IControlMainform.cs
+++ b/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.IControlMainform.cs
@@ -28,7 +28,7 @@ namespace BizHawk.Client.EmuHawk
 		// TODO: We probably want to do this
 		public bool WantsToControlRewind { get { return false; } }
 		public void CaptureRewind() { }
-		public bool Rewind(ref bool runframe) { return false; }
+		public bool Rewind() { return false; }
 
 		public bool WantsToControlRestartMovie { get { return false; } }
 		public void RestartMovie() { }

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.IControlMainForm.cs
@@ -84,7 +84,7 @@
 			// Do nothing, Tastudio handles this just fine
 		}
 
-		public bool Rewind(ref bool runframe)
+		public bool Rewind()
 		{
 			// copypasted from TasView_MouseWheel(), just without notch logic
 			if (Mainform.IsSeeking && !Mainform.EmulatorPaused)
@@ -105,9 +105,7 @@
 			else
 			{
 				StopSeeking(); // late breaking memo: dont know whether this is needed
-				int dist = GoToPreviousFrame();
-
-				if (Emulator.Frame == 0) { runframe = false; }
+				GoToPreviousFrame();
 			}
 
 			return true;

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -28,18 +28,17 @@ namespace BizHawk.Client.EmuHawk
 		}
 
 		// SuuperW: I changed this to public so that it could be used by MarkerControl.cs
-		public int GoToFrame(int frame, bool fromLua = false, bool fromRewinding = false)
+		public void GoToFrame(int frame, bool fromLua = false, bool fromRewinding = false)
 		{
 			// If seeking to a frame before or at the end of the movie, use StartAtNearestFrameAndEmulate
 			// Otherwise, load the latest state (if not already there) and seek while recording.
-			int dist = 0;
 
 			WasRecording = CurrentTasMovie.IsRecording || WasRecording;
 
 			if (frame <= CurrentTasMovie.InputLogLength)
 			{
 				// Get as close as we can then emulate there
-				dist = StartAtNearestFrameAndEmulate(frame, fromLua, fromRewinding);
+				StartAtNearestFrameAndEmulate(frame, fromLua, fromRewinding);
 
 				MaybeFollowCursor();
 			}
@@ -70,20 +69,14 @@ namespace BizHawk.Client.EmuHawk
 
 			RefreshDialog();
 			UpdateOtherTools();
-
-			return dist;
 		}
 
-		public int GoToPreviousFrame()
+		public void GoToPreviousFrame()
 		{
-			int dist = -1;
-
 			if (Emulator.Frame > 0)
 			{
-				dist = GoToFrame(Emulator.Frame - 1);
+				GoToFrame(Emulator.Frame - 1);
 			}
-
-			return dist;
 		}
 
 		public void GoToNextFrame()

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -880,17 +880,14 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private int StartAtNearestFrameAndEmulate(int frame, bool fromLua, bool fromRewinding)
+		private void StartAtNearestFrameAndEmulate(int frame, bool fromLua, bool fromRewinding)
 		{
 			if (frame == Emulator.Frame)
-				return 0;
+				return;
 
 			_unpauseAfterSeeking = (fromRewinding || WasRecording) && !Mainform.EmulatorPaused;
 			TastudioPlayMode();
 			KeyValuePair<int, byte[]> closestState = CurrentTasMovie.TasStateManager.GetStateClosestToFrame(frame);
-
-			int dist = frame - closestState.Key;
-
 			if (closestState.Value != null && (frame < Emulator.Frame || closestState.Key > Emulator.Frame))
 			{
 				LoadState(closestState);
@@ -942,8 +939,6 @@ namespace BizHawk.Client.EmuHawk
 					// users who are clicking around.. I dont know.
 				}
 			}
-
-			return dist;
 		}
 
 		public void LoadState(KeyValuePair<int, byte[]> state)


### PR DESCRIPTION
This reverts PR #1371 "This fixes a bug in TAStudio where you cannot use '<'to get to frame 0", see the review:
https://github.com/TASVideos/BizHawk/pull/1371#pullrequestreview-179454301