### PR TITLE
PCEHawk - DESR enforce 16bit register size - #1363

### DIFF
--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/VDC.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/VDC.cs
@@ -227,8 +227,8 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			for (; Registers[LENR] < 0xFFFF; Registers[LENR]--, wordsDone++)
 			{
 				VRAM[Registers[DESR] & 0x7FFF] = VRAM[Registers[SOUR] & 0x7FFF];
-				UpdatePatternData(Registers[DESR]);
-				UpdateSpriteData(Registers[DESR]);
+				UpdatePatternData((ushort)(Registers[DESR] & 0x7FFF));
+				UpdateSpriteData((ushort)(Registers[DESR] & 0x7FFF));
 				Registers[DESR] = (ushort)(Registers[DESR] + advanceDest);
 				Registers[SOUR] = (ushort)(Registers[SOUR] + advanceSource);
 

--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/VDC.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/VDC.cs
@@ -227,8 +227,8 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			for (; Registers[LENR] < 0xFFFF; Registers[LENR]--, wordsDone++)
 			{
 				VRAM[Registers[DESR] & 0x7FFF] = VRAM[Registers[SOUR] & 0x7FFF];
-				UpdatePatternData((ushort)(Registers[DESR] & 0x7FFF));
-				UpdateSpriteData((ushort)(Registers[DESR] & 0x7FFF));
+				UpdatePatternData(Registers[DESR]);
+				UpdateSpriteData(Registers[DESR]);
 				Registers[DESR] = (ushort)(Registers[DESR] + advanceDest);
 				Registers[SOUR] = (ushort)(Registers[SOUR] + advanceSource);
 
@@ -267,8 +267,8 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			int tileNo = addr >> 4;
 			int tileLineOffset = addr & 0x7;
 
-			int bitplane01 = VRAM[(tileNo * 16) + tileLineOffset];
-			int bitplane23 = VRAM[(tileNo * 16) + tileLineOffset + 8];
+			int bitplane01 = VRAM[((tileNo * 16) + tileLineOffset) & 0x7FFF];
+			int bitplane23 = VRAM[((tileNo * 16) + tileLineOffset + 8) & 0x7FFF];
 
 			int patternBufferBase = (tileNo * 64) + (tileLineOffset * 8);
 
@@ -290,7 +290,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			int line = addr & 0x0F;
 
 			int ofs = (tileNo * 256) + (line * 16) + 15;
-			ushort value = VRAM[addr];
+			ushort value = VRAM[addr & 0x7FFF];
 			byte bitAnd = (byte)(~(1 << bitplane));
 			byte bitOr = (byte)(1 << bitplane);
 


### PR DESCRIPTION
So I think this should do for #1363

According to here:  http://www.emulatronia.com/doctec/consolas/pce/vdcdox.txt
DESR is only 16bit.

```
17($11) R?/W    DESR - '(DMA) Destination Address Register'

                     b 15-0  This register sets the destination 
                             address for DMA transfers.
                             All bits used 
                             (although no VRAM above $7FFF).
```

@NarryG can you test?

@zeromus can you make sure I have not been stupid?