### PR TITLE
Inconsequential changes (no whitespace)

### DIFF
--- a/BizHawk.Client.DiscoHawk/DiscoHawkDialog.cs
+++ b/BizHawk.Client.DiscoHawk/DiscoHawkDialog.cs
@@ -95,7 +95,7 @@ namespace BizHawk.Client.DiscoHawk
 			}
 
 			var cueBin = boundDisc.DumpCueBin(boundDiscRecord.BaseName, GetCuePrefs());
-			txtCuePreview.Text = cueBin.cue.Replace("\n", "\r\n"); ;
+			txtCuePreview.Text = cueBin.cue.Replace("\n", "\r\n");
 		}
 
 		private void btnPresetCanonical_Click(object sender, EventArgs e)

--- a/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -350,8 +350,8 @@ namespace BizHawk.Client.EmuHawk
 
 			set
 			{
-				var item = StartFromSlotBox.Items.
-					OfType<object>()
+				var item = StartFromSlotBox.Items
+					.OfType<object>()
 					.FirstOrDefault(o => o.ToString() == value);
 
 				if (item != null)

--- a/BizHawk.Emulation.Cores/CPUs/LR35902/Operations.cs
+++ b/BizHawk.Emulation.Cores/CPUs/LR35902/Operations.cs
@@ -159,7 +159,7 @@ namespace BizHawk.Emulation.Common.Components.LR35902
 
 		public void SRL_Func(ushort src)
 		{
-			FlagC = Regs[src].Bit(0) ? true : false;
+			FlagC = Regs[src].Bit(0);
 
 			Regs[src] = (ushort)(Regs[src] >> 1);
 

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Operations.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Operations.cs
@@ -267,7 +267,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 
 		public void SRL_Func(ushort src)
 		{
-			FlagC = Regs[src].Bit(0) ? true : false;
+			FlagC = Regs[src].Bit(0);
 
 			Regs[src] = (ushort)(Regs[src] >> 1);
 

--- a/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/PZX/PzxConverter.cs
+++ b/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/Media/Tape/PZX/PzxConverter.cs
@@ -249,7 +249,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
                             dCount = GetInt32(b, pos);
                             initPulseLevel = (uint)((dCount & 0x80000000) == 0 ? 0 : 1);
 
-                            t.InitialPulseLevel =  initPulseLevel == 1 ? true : false;
+                            t.InitialPulseLevel =  initPulseLevel == 1;
 
                             dCount = (int)(dCount & 0x7FFFFFFF);
                             pos += 4;
@@ -334,7 +334,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 
                         var d = GetInt32(b, pos);
                         iniPulseLevel = ((d & 0x80000000) == 0 ? 0 : 1);
-                        t.InitialPulseLevel = iniPulseLevel == 1 ? true : false;
+                        t.InitialPulseLevel = iniPulseLevel == 1;
                         pCount = (d & 0x7FFFFFFF);
 
                         // convert to tape block

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
@@ -172,7 +172,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 				byte cart_1 = header[0x35];
 				byte cart_2 = header[0x36];
 
-				_isPAL = (header[0x39] > 0) ? true : false;
+				_isPAL = (header[0x39] > 0);
 
 				if (cart_2.Bit(1))
 				{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC1_Multi.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC1_Multi.cs
@@ -120,7 +120,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			{
 				if (addr < 0x2000)
 				{
-					RAM_enable = ((value & 0xA) == 0xA) ? true : false;
+					RAM_enable = ((value & 0xA) == 0xA);
 				}
 				else if (addr < 0x4000)
 				{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC2.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC2.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			{
 				if ((addr & 0x100) == 0)
 				{
-					RAM_enable = ((value & 0xA) == 0xA) ? true : false;
+					RAM_enable = ((value & 0xA) == 0xA);
 				}
 			}
 			else if (addr < 0x4000)

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC3.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC3.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			{
 				if (addr < 0x2000)
 				{
-					RAM_enable = ((value & 0xA) == 0xA) ? true : false;
+					RAM_enable = ((value & 0xA) == 0xA);
 				}
 				else if (addr < 0x4000)
 				{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC7.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/Mappers/Mapper_MBC7.cs
@@ -419,11 +419,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 					case 5:
 						if ((instr_clocks >= 0) && (instr_clocks <= 7))
 						{
-							DO = ((Core.cart_RAM[EE_addr * 2 + 1] >> (7 - instr_clocks)) & 1) == 1 ? true : false;
+							DO = ((Core.cart_RAM[EE_addr * 2 + 1] >> (7 - instr_clocks)) & 1) == 1;
 						}
 						else if ((instr_clocks >= 8) && (instr_clocks <= 15))
 						{
-							DO = ((Core.cart_RAM[EE_addr * 2] >> (15 - instr_clocks)) & 1) == 1 ? true : false;
+							DO = ((Core.cart_RAM[EE_addr * 2] >> (15 - instr_clocks)) & 1) == 1;
 						}
 
 						if (instr_clocks == 15)

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Cony.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Cony.cs
@@ -451,7 +451,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 			else if (addr == 0x200)
 			{
-				IRQCount &= 0xFF00; IRQCount |= value; ;
+				IRQCount &= 0xFF00; IRQCount |= value;
 				IRQSignal = false;
 			}
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper222.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/Mapper222.cs
@@ -66,14 +66,14 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				//Console.WriteLine("IRQ GO: SL {0} val {1}", NES.ppu.ppur.status.sl, value);
 				//break;
 				case 0x1000: SetMirrorType(!value.Bit(0) ? EMirrorType.Vertical : EMirrorType.Horizontal);break;
-				case 0x3000: chr[0] = value & chr_bank_mask_1k; ; break;
-				case 0x3002: chr[1] = value & chr_bank_mask_1k; ; break;
-				case 0x4000: chr[2] = value & chr_bank_mask_1k; ; break;
-				case 0x4002: chr[3] = value & chr_bank_mask_1k; ; break;
-				case 0x5000: chr[4] = value & chr_bank_mask_1k; ; break;
-				case 0x5002: chr[5] = value & chr_bank_mask_1k; ; break;
-				case 0x6000: chr[6] = value & chr_bank_mask_1k; ; break;
-				case 0x6002: chr[7] = value & chr_bank_mask_1k; ; break;
+				case 0x3000: chr[0] = value & chr_bank_mask_1k; break;
+				case 0x3002: chr[1] = value & chr_bank_mask_1k; break;
+				case 0x4000: chr[2] = value & chr_bank_mask_1k; break;
+				case 0x4002: chr[3] = value & chr_bank_mask_1k; break;
+				case 0x5000: chr[4] = value & chr_bank_mask_1k; break;
+				case 0x5002: chr[5] = value & chr_bank_mask_1k; break;
+				case 0x6000: chr[6] = value & chr_bank_mask_1k; break;
+				case 0x6002: chr[7] = value & chr_bank_mask_1k; break;
 
 
 			}

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
@@ -307,7 +307,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				string str = "oamdata" + i.ToString() + "y";
 				oam_byte = t_oam[i].oam_y; ser.Sync(str, ref oam_byte); t_oam[i].oam_y = oam_byte;
 				str = "oamdata" + i.ToString() + "ind";
-				oam_byte = t_oam[i].oam_ind; ; ser.Sync(str, ref oam_byte); t_oam[i].oam_ind = oam_byte;
+				oam_byte = t_oam[i].oam_ind; ser.Sync(str, ref oam_byte); t_oam[i].oam_ind = oam_byte;
 				str = "oamdata" + i.ToString() + "attr";
 				oam_byte = t_oam[i].oam_attr; ser.Sync(str, ref oam_byte); t_oam[i].oam_attr = oam_byte;
 				str = "oamdata" + i.ToString() + "x";

--- a/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IVideoProvider.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IVideoProvider.cs
@@ -78,7 +78,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 						for (int i = 0; i < xpad; i++)
 							*pdst++ = unchecked((int)0xff000000);
 						for (int i = 0; i < gpwidth; i++)
-							*pdst++ = *psrc++; ;
+							*pdst++ = *psrc++;
 						for (int i = 0; i < xpad2; i++)
 							*pdst++ = unchecked((int)0xff000000);
 						psrc += rinc;


### PR DESCRIPTION
I'll do something more helpful next, I promise.

Edit: to save you the trouble, the commit desc is "Remove useless semicolon, remove useless `? true : false`, move period to next line". Pretty self-explanatory stuff.

***

I've got a list of things like this that aren't removed pre-compile, the last few might be controversial. Input on what is and isn't project convention would be appreciated so I have something to do while Mono work is being tested.
* `"a" + b + "c"` -> `$"a{b}c"`
* `String.Format("a {0} c", b)` -> `$"a{b}c"` (I think this can't be done in some places)
* `Type Property { get; }` -> `readonly Type Property` where possible
* renaming files where it doesn't match the contained class name, excluding partial classes ofc
* LF -> CRLF, not sure how LFs happened in a Windows codebase
* `@"C:\a\path\to\something"` or `"C:\\a\\path"` -> Path.Combine
* CS0162 unreachable code (most likely a fallthrough return where the code above has since been fixed)
* CS0168/CS0169 var declared but never used
* CS0067/CS0219/CS0414 var declared and assigned to but never used
* CS0612 deprecated API used (where API change is easy)
* CS0649 var declared and used but never assigned to (should be readonly?)
* `for (var item in arr) if (item.something == something) return item.something; return default;` -> `return Array.Find(arr, item => item.something == something)?.something ?? default`
* `if (something != null) return something.prop; else return default;` -> `something?.prop ?? default`
* `if (disposable != null) disposable.Dispose();` -> `disposable.?Dispose();`
* typos in docs
* remove \\-escaped newline (C# doesn't do this, thankfully, and it's only in two comment lines. Still, better safe than sorry)
* I think there's three files indented with two spaces, that and #1437 should leave only 4-space indents which are easy to convert should you decide to try again
* `if(`, `for(` -> `if (`, `for (` for all keywords
* `{ a , b , c }` -> `{ a, b, c }`
* `var.Method (arg)` -> `var.Method(arg)`
* `if (short expression) varName = MethodA(); else varName = MethodB();` -> `varName = short expression ? MethodA() : MethodB();` (or the reverse for long expressions?)
* enforce Allman braces