### PR TITLE
[Untested] Banish most gotos from client

### DIFF
--- a/BizHawk.Client.Common/FirmwareManager.cs
+++ b/BizHawk.Client.Common/FirmwareManager.cs
@@ -68,7 +68,7 @@ namespace BizHawk.Client.Common
 				}
 
 				resolved = null;
-				_resolutionDictionary.TryGetValue(record, out resolved)
+				_resolutionDictionary.TryGetValue(record, out resolved);
 			}
 
 			return resolved;

--- a/BizHawk.Client.Common/FirmwareManager.cs
+++ b/BizHawk.Client.Common/FirmwareManager.cs
@@ -54,23 +54,21 @@ namespace BizHawk.Client.Common
 		public ResolutionInfo Resolve(FirmwareDatabase.FirmwareRecord record, bool forbidScan = false)
 		{
 			// purpose of forbidScan: sometimes this is called from a loop in Scan(). we dont want to repeatedly DoScanAndResolve in that case, its already been done.
-			bool first = true;
 
-		RETRY:
 			ResolutionInfo resolved;
 			_resolutionDictionary.TryGetValue(record, out resolved);
 
 			// couldnt find it! do a scan and resolve to try harder
 			// NOTE: this could result in bad performance in some cases if the scanning happens repeatedly..
-			if (resolved == null && first)
+			if (resolved == null)
 			{
 				if (!forbidScan)
 				{
 					DoScanAndResolve();
 				}
 
-				first = false;
-				goto RETRY;
+				resolved = null;
+				_resolutionDictionary.TryGetValue(record, out resolved)
 			}
 
 			return resolved;

--- a/BizHawk.Client.Common/FirmwareManager.cs
+++ b/BizHawk.Client.Common/FirmwareManager.cs
@@ -223,11 +223,9 @@ namespace BizHawk.Client.Common
 									Size = fo.Size
 								};
 							_resolutionDictionary[fr] = ri;
-							goto DONE_FIRMWARE;
+							break;
 						}
 					}
-
-				DONE_FIRMWARE: ;
 				}
 
 				// apply user overrides

--- a/BizHawk.Client.Common/rewind/Rewinder.cs
+++ b/BizHawk.Client.Common/rewind/Rewinder.cs
@@ -212,13 +212,17 @@ namespace BizHawk.Client.Common
 			if (currentState.Length != _lastState.Length)
 			{
 				// If the state sizes mismatch, capture a full state rather than trying to do anything clever
-				goto CaptureFullState;
+				CaptureStateNonDelta(_lastState);
+				UpdateLastState(currentState);
+				return;
 			}
 
 			if (currentState.Length == 0)
 			{
 				// handle empty states as a "full" (empty) state
-				goto CaptureFullState;
+				CaptureStateNonDelta(_lastState);
+				UpdateLastState(currentState);
+				return;
 			}
 
 			int index = 0;
@@ -259,7 +263,9 @@ namespace BizHawk.Client.Common
 					if (index + length + MaxHeaderSize >= stateLength)
 					{
 						// If the delta ends up being larger than the full state, capture the full state instead
-						goto CaptureFullState;
+						CaptureStateNonDelta(_lastState);
+						UpdateLastState(currentState);
+						return;
 					}
 
 					// Offset Delta
@@ -279,11 +285,6 @@ namespace BizHawk.Client.Common
 
 			_rewindBuffer.Push(new ArraySegment<byte>(_deltaBuffer, 0, index));
 
-			UpdateLastState(currentState);
-			return;
-
-		CaptureFullState:
-			CaptureStateNonDelta(_lastState);
 			UpdateLastState(currentState);
 		}
 

--- a/BizHawk.Client.DiscoHawk/DiscoHawk.cs
+++ b/BizHawk.Client.DiscoHawk/DiscoHawk.cs
@@ -312,177 +312,11 @@ namespace BizHawk.Client.DiscoHawk
 		static bool CompareFile(string infile, DiscInterface loadDiscInterface, DiscInterface cmpif, bool verbose, CancellationTokenSource cancelToken, StringWriter sw)
 		{
 			Disc src_disc = null, dst_disc = null;
-
 			try
 			{
-				bool success = false;
-
-				sw.WriteLine("BEGIN COMPARE: {0}\nSRC {1} vs DST {2}", infile, loadDiscInterface, cmpif);
-
-				//reload the original disc, with new policies as needed
-				var dmj = new DiscMountJob { IN_DiscInterface = loadDiscInterface, IN_FromPath = infile };
-				if (cmpif == DiscInterface.MednaDisc)
-				{
-					dmj.IN_DiscMountPolicy.CUE_PregapContradictionModeA = false;
-				}
-				dmj.Run();
-
-				src_disc = dmj.OUT_Disc;
-
-				var dst_dmj = new DiscMountJob { IN_DiscInterface = cmpif, IN_FromPath = infile };
-				dst_dmj.Run();
-				dst_disc = dst_dmj.OUT_Disc;
-
-				var src_dsr = new DiscSectorReader(src_disc);
-				var dst_dsr = new DiscSectorReader(dst_disc);
-
-				var src_toc = src_disc.TOC;
-				var dst_toc = dst_disc.TOC;
-
-				var src_databuf = new byte[2448];
-				var dst_databuf = new byte[2448];
-
-				Action<DiscTOC.TOCItem> sw_dump_toc_one = (item) =>
-				{
-					if (!item.Exists)
-						sw.Write("(---missing---)");
-					else
-						sw.Write("({0:X2} - {1})", (byte)item.Control, item.LBA);
-				};
-
-
-				Action<int> sw_dump_toc = (index) =>
-				{
-					sw.Write("SRC TOC#{0,3} ", index); sw_dump_toc_one(src_toc.TOCItems[index]); sw.WriteLine();
-					sw.Write("DST TOC#{0,3} ", index); sw_dump_toc_one(dst_toc.TOCItems[index]); sw.WriteLine();
-				};
-
-				//verify sector count
-				if (src_disc.Session1.LeadoutLBA != dst_disc.Session1.LeadoutLBA)
-				{
-					sw.Write("LeadoutTrack.LBA {0} vs {1}\n", src_disc.Session1.LeadoutTrack.LBA, dst_disc.Session1.LeadoutTrack.LBA);
-					goto SKIPPO;
-				}
-
-				//verify TOC match
-				if (src_disc.TOC.FirstRecordedTrackNumber != dst_disc.TOC.FirstRecordedTrackNumber
-					|| src_disc.TOC.LastRecordedTrackNumber != dst_disc.TOC.LastRecordedTrackNumber)
-				{
-					sw.WriteLine("Mismatch of RecordedTrackNumbers: {0}-{1} vs {2}-{3}",
-						src_disc.TOC.FirstRecordedTrackNumber, src_disc.TOC.LastRecordedTrackNumber,
-						dst_disc.TOC.FirstRecordedTrackNumber, dst_disc.TOC.LastRecordedTrackNumber
-						);
-					goto SKIPPO;
-				}
-
-				bool badToc = false;
-				for (int t = 0; t < 101; t++)
-				{
-					if (src_toc.TOCItems[t].Exists != dst_toc.TOCItems[t].Exists
-						|| src_toc.TOCItems[t].Control != dst_toc.TOCItems[t].Control
-						|| src_toc.TOCItems[t].LBA != dst_toc.TOCItems[t].LBA
-						)
-					{
-						sw.WriteLine("Mismatch in TOCItem");
-						sw_dump_toc(t);
-						badToc = true;
-					}
-				}
-				if (badToc)
-					goto SKIPPO;
-
-				Action<string, int, byte[], int, int> sw_dump_chunk_one = (comment, lba, buf, addr, count) =>
-				{
-					sw.Write("{0} -  ", comment);
-					for (int i = 0; i < count; i++)
-					{
-						if (i + addr >= buf.Length) continue;
-						sw.Write("{0:X2}{1}", buf[addr + i], (i == count - 1) ? " " : "  ");
-					}
-					sw.WriteLine();
-				};
-
-				int[] offenders = new int[12];
-				Action<int, int, int, int, int> sw_dump_chunk = (lba, dispaddr, addr, count, numoffenders) =>
-				{
-					var hashedOffenders = new HashSet<int>();
-					for (int i = 0; i < numoffenders; i++) hashedOffenders.Add(offenders[i]);
-					sw.Write("                          ");
-					for (int i = 0; i < count; i++) sw.Write((hashedOffenders.Contains(dispaddr + i)) ? "vvv " : "    ");
-					sw.WriteLine();
-					sw.Write("                          ");
-					for (int i = 0; i < count; i++) sw.Write("{0:X3} ", dispaddr + i, (i == count - 1) ? " " : "  ");
-					sw.WriteLine();
-					sw.Write("                          ");
-					sw.Write(new string('-', count * 4));
-					sw.WriteLine();
-					sw_dump_chunk_one(string.Format("SRC #{0,6} ({1})", lba, new Timestamp(lba)), lba, src_databuf, addr, count);
-					sw_dump_chunk_one(string.Format("DST #{0,6} ({1})", lba, new Timestamp(lba)), lba, dst_databuf, addr, count);
-				};
-
-				//verify each sector contents
-				int nSectors = src_disc.Session1.LeadoutLBA;
-				for (int lba = -150; lba < nSectors; lba++)
-				{
-					if (verbose)
-						if (lba % 1000 == 0)
-							Console.WriteLine("LBA {0} of {1}", lba, nSectors);
-
-					if (cancelToken != null)
-						if (cancelToken.Token.IsCancellationRequested)
-							return false;
-
-					src_dsr.ReadLBA_2448(lba, src_databuf, 0);
-					dst_dsr.ReadLBA_2448(lba, dst_databuf, 0);
-
-					//check the header
-					for (int b = 0; b < 16; b++)
-					{
-						if (src_databuf[b] != dst_databuf[b])
-						{
-							sw.WriteLine("Mismatch in sector header at byte {0}", b);
-							offenders[0] = b;
-							sw_dump_chunk(lba, 0, 0, 16, 1);
-							goto SKIPPO;
-						}
-					}
-
-					//check userdata
-					for (int b = 16; b < 2352; b++)
-					{
-						if (src_databuf[b] != dst_databuf[b])
-						{
-							sw.Write("LBA {0} mismatch at userdata byte {1}; terminating sector cmp\n", lba, b);
-							goto SKIPPO;
-						}
-					}
-
-					//check subchannels
-					for (int c = 0, b = 2352; c < 8; c++)
-					{
-						int numOffenders = 0;
-						for (int e = 0; e < 12; e++, b++)
-						{
-							if (src_databuf[b] != dst_databuf[b])
-							{
-								offenders[numOffenders++] = e;
-							}
-						}
-						if (numOffenders != 0)
-						{
-							sw.Write("LBA {0} mismatch(es) at subchannel {1}; terminating sector cmp\n", lba, (char)('P' + c));
-							sw_dump_chunk(lba, 0, 2352 + c * 12, 12, numOffenders);
-							goto SKIPPO;
-						}
-					}
-				}
-
-				success = true;
-
-			SKIPPO:
+				var success = CompareFile_Sub(infile, loadDiscInterface, cmpif, verbose, cancelToken, sw, src_disc, dst_disc);
 				sw.WriteLine("END COMPARE");
 				sw.WriteLine("-----------------------------");
-
 				return success;
 			}
 			finally
@@ -492,11 +326,172 @@ namespace BizHawk.Client.DiscoHawk
 				if (dst_disc != null)
 					dst_disc.Dispose();
 			}
-		
 		} //CompareFile
 
-	} //class DiscoHawk
+		private static bool CompareFile_Sub(string infile, DiscInterface loadDiscInterface, DiscInterface cmpif, bool verbose, CancellationTokenSource cancelToken, StringWriter sw, Disc src_disc, Disc dst_disc)
+		{
+			sw.WriteLine("BEGIN COMPARE: {0}\nSRC {1} vs DST {2}", infile, loadDiscInterface, cmpif);
 
+			//reload the original disc, with new policies as needed
+			var dmj = new DiscMountJob { IN_DiscInterface = loadDiscInterface, IN_FromPath = infile };
+			if (cmpif == DiscInterface.MednaDisc)
+			{
+				dmj.IN_DiscMountPolicy.CUE_PregapContradictionModeA = false;
+			}
+			dmj.Run();
+
+			src_disc = dmj.OUT_Disc;
+
+			var dst_dmj = new DiscMountJob { IN_DiscInterface = cmpif, IN_FromPath = infile };
+			dst_dmj.Run();
+			dst_disc = dst_dmj.OUT_Disc;
+
+			var src_dsr = new DiscSectorReader(src_disc);
+			var dst_dsr = new DiscSectorReader(dst_disc);
+
+			var src_toc = src_disc.TOC;
+			var dst_toc = dst_disc.TOC;
+
+			var src_databuf = new byte[2448];
+			var dst_databuf = new byte[2448];
+
+			Action<DiscTOC.TOCItem> sw_dump_toc_one = (item) =>
+			{
+				if (!item.Exists)
+					sw.Write("(---missing---)");
+				else
+					sw.Write("({0:X2} - {1})", (byte)item.Control, item.LBA);
+			};
+
+
+			Action<int> sw_dump_toc = (index) =>
+			{
+				sw.Write("SRC TOC#{0,3} ", index); sw_dump_toc_one(src_toc.TOCItems[index]); sw.WriteLine();
+				sw.Write("DST TOC#{0,3} ", index); sw_dump_toc_one(dst_toc.TOCItems[index]); sw.WriteLine();
+			};
+
+			//verify sector count
+			if (src_disc.Session1.LeadoutLBA != dst_disc.Session1.LeadoutLBA)
+			{
+				sw.Write("LeadoutTrack.LBA {0} vs {1}\n", src_disc.Session1.LeadoutTrack.LBA, dst_disc.Session1.LeadoutTrack.LBA);
+				return false;
+			}
+
+			//verify TOC match
+			if (src_disc.TOC.FirstRecordedTrackNumber != dst_disc.TOC.FirstRecordedTrackNumber
+				|| src_disc.TOC.LastRecordedTrackNumber != dst_disc.TOC.LastRecordedTrackNumber)
+			{
+				sw.WriteLine("Mismatch of RecordedTrackNumbers: {0}-{1} vs {2}-{3}",
+					src_disc.TOC.FirstRecordedTrackNumber, src_disc.TOC.LastRecordedTrackNumber,
+					dst_disc.TOC.FirstRecordedTrackNumber, dst_disc.TOC.LastRecordedTrackNumber
+					);
+				return false;
+			}
+
+			bool badToc = false;
+			for (int t = 0; t < 101; t++)
+			{
+				if (src_toc.TOCItems[t].Exists != dst_toc.TOCItems[t].Exists
+					|| src_toc.TOCItems[t].Control != dst_toc.TOCItems[t].Control
+					|| src_toc.TOCItems[t].LBA != dst_toc.TOCItems[t].LBA
+					)
+				{
+					sw.WriteLine("Mismatch in TOCItem");
+					sw_dump_toc(t);
+					badToc = true;
+				}
+			}
+			if (badToc)
+				return false;
+
+			Action<string, int, byte[], int, int> sw_dump_chunk_one = (comment, lba, buf, addr, count) =>
+			{
+				sw.Write("{0} -  ", comment);
+				for (int i = 0; i < count; i++)
+				{
+					if (i + addr >= buf.Length) continue;
+					sw.Write("{0:X2}{1}", buf[addr + i], (i == count - 1) ? " " : "  ");
+				}
+				sw.WriteLine();
+			};
+
+			int[] offenders = new int[12];
+			Action<int, int, int, int, int> sw_dump_chunk = (lba, dispaddr, addr, count, numoffenders) =>
+			{
+				var hashedOffenders = new HashSet<int>();
+				for (int i = 0; i < numoffenders; i++) hashedOffenders.Add(offenders[i]);
+				sw.Write("                          ");
+				for (int i = 0; i < count; i++) sw.Write((hashedOffenders.Contains(dispaddr + i)) ? "vvv " : "    ");
+				sw.WriteLine();
+				sw.Write("                          ");
+				for (int i = 0; i < count; i++) sw.Write("{0:X3} ", dispaddr + i, (i == count - 1) ? " " : "  ");
+				sw.WriteLine();
+				sw.Write("                          ");
+				sw.Write(new string('-', count * 4));
+				sw.WriteLine();
+				sw_dump_chunk_one(string.Format("SRC #{0,6} ({1})", lba, new Timestamp(lba)), lba, src_databuf, addr, count);
+				sw_dump_chunk_one(string.Format("DST #{0,6} ({1})", lba, new Timestamp(lba)), lba, dst_databuf, addr, count);
+			};
+
+			//verify each sector contents
+			int nSectors = src_disc.Session1.LeadoutLBA;
+			for (int lba = -150; lba < nSectors; lba++)
+			{
+				if (verbose)
+					if (lba % 1000 == 0)
+						Console.WriteLine("LBA {0} of {1}", lba, nSectors);
+
+				if (cancelToken != null)
+					if (cancelToken.Token.IsCancellationRequested)
+						return false;
+
+				src_dsr.ReadLBA_2448(lba, src_databuf, 0);
+				dst_dsr.ReadLBA_2448(lba, dst_databuf, 0);
+
+				//check the header
+				for (int b = 0; b < 16; b++)
+				{
+					if (src_databuf[b] != dst_databuf[b])
+					{
+						sw.WriteLine("Mismatch in sector header at byte {0}", b);
+						offenders[0] = b;
+						sw_dump_chunk(lba, 0, 0, 16, 1);
+						return false;
+					}
+				}
+
+				//check userdata
+				for (int b = 16; b < 2352; b++)
+				{
+					if (src_databuf[b] != dst_databuf[b])
+					{
+						sw.Write("LBA {0} mismatch at userdata byte {1}; terminating sector cmp\n", lba, b);
+						return false;
+					}
+				}
+
+				//check subchannels
+				for (int c = 0, b = 2352; c < 8; c++)
+				{
+					int numOffenders = 0;
+					for (int e = 0; e < 12; e++, b++)
+					{
+						if (src_databuf[b] != dst_databuf[b])
+						{
+							offenders[numOffenders++] = e;
+						}
+					}
+					if (numOffenders != 0)
+					{
+						sw.Write("LBA {0} mismatch(es) at subchannel {1}; terminating sector cmp\n", lba, (char)('P' + c));
+						sw_dump_chunk(lba, 0, 2352 + c * 12, 12, numOffenders);
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+	}
 }
 
 //code to test ECM:

--- a/BizHawk.Client.EmuHawk/DisplayManager/FilterManager.cs
+++ b/BizHawk.Client.EmuHawk/DisplayManager/FilterManager.cs
@@ -149,8 +149,14 @@ namespace BizHawk.Client.EmuHawk.FilterManager
 
 		public void Compile(string channel, Size insize, Size outsize, bool finalTarget)
 		{
-		RETRY:
-			
+			while (true)
+			{
+				if (Compile_Sub(channel, insize, outsize, finalTarget)) break;
+			}
+		}
+
+		private bool Compile_Sub(string channel, Size insize, Size outsize, bool finalTarget)
+		{
 			Program.Clear();
 
 			//prep filters for initialization
@@ -200,7 +206,7 @@ namespace BizHawk.Client.EmuHawk.FilterManager
 					{
 						var renderer = new Render();
 						Filters.Insert(i, renderer);
-						goto RETRY;
+						return false; // Continue retry loop in Compile
 					}
 					//check if the desired disposition needs to change from a render target to a texture
 					//(if so, the current render target gets resolved, and made no longer current
@@ -208,7 +214,7 @@ namespace BizHawk.Client.EmuHawk.FilterManager
 					{
 						var resolver = new Resolve();
 						Filters.Insert(i, resolver);
-						goto RETRY;
+						return false; // Continue retry loop in Compile
 					}
 				}
 
@@ -261,7 +267,7 @@ namespace BizHawk.Client.EmuHawk.FilterManager
 			{
 				var renderer = new Render();
 				Filters.Insert(Filters.Count, renderer);
-				goto RETRY;
+				return false; // Continue retry loop in Compile
 			}
 
 			//patch the program so that the final rendertarget set operation is the framebuffer instead
@@ -280,6 +286,8 @@ namespace BizHawk.Client.EmuHawk.FilterManager
 					}
 				}
 			}
+
+			return true; // Break out of loop in Compile
 		}
 	}
 }

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -501,13 +501,9 @@ namespace BizHawk.Client.EmuHawk
 				{
 					var ie = DequeueEvent();
 
-					//as a special perk, we'll accept escape immediately
-					if (ie.EventType == InputEventType.Press && ie.LogicalButton.Button == "Escape")
-						goto ACCEPT;
+					//as a special perk, we'll accept escape immediately, otherwise Press events are ignored
+					if (ie.EventType == InputEventType.Press && ie.LogicalButton.Button != "Escape") continue;
 
-					if (ie.EventType == InputEventType.Press) continue;
-
-				ACCEPT:
 					Console.WriteLine("Bind Event: {0} ", ie);
 
 					foreach (var kvp in LastState)

--- a/BizHawk.Client.MultiHawk/Input/Input.cs
+++ b/BizHawk.Client.MultiHawk/Input/Input.cs
@@ -480,13 +480,9 @@ namespace BizHawk.Client.MultiHawk
 				{
 					var ie = DequeueEvent();
 
-					//as a special perk, we'll accept escape immediately
-					if (ie.EventType == InputEventType.Press && ie.LogicalButton.Button == "Escape")
-						goto ACCEPT;
+					//as a special perk, we'll accept escape immediately, otherwise Press events are ignored
+					if (ie.EventType == InputEventType.Press && ie.LogicalButton.Button != "Escape") continue;
 
-					if (ie.EventType == InputEventType.Press) continue;
-
-				ACCEPT:
 					Console.WriteLine("Bind Event: {0} ", ie);
 
 					foreach (var kvp in LastState)

--- a/BizHawk.Emulation.Cores/CPUs/HuC6280/Execute.cs
+++ b/BizHawk.Emulation.Cores/CPUs/HuC6280/Execute.cs
@@ -64,6 +64,7 @@ namespace BizHawk.Emulation.Cores.Components.H6280
 
                 if (CDL != null && CDL.Active) CDLOpcode();
 
+                var skipClearTFlag = false;
                 byte opcode = ReadMemory(PC++);
                 switch (opcode)
                 {
@@ -438,7 +439,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                     case 0x28: // PLP
                         P = ReadMemory((ushort)(++S + 0x2100));
                         PendingCycles -= 4;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0x29: // AND #nn
                         value8 = ReadMemory(PC++);
                         if (FlagT == false) { 
@@ -644,7 +646,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                         PC = ReadMemory((ushort)(++S + 0x2100));
                         PC |= (ushort)(ReadMemory((ushort)(++S + 0x2100)) << 8);
                         PendingCycles -= 7;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0x41: // EOR (addr,X)
                         value8 = ReadMemory(ReadWordPageWrap((ushort)((byte)(ReadMemory(PC++)+X)+0x2000)));
                         if (FlagT == false) { 
@@ -2181,7 +2184,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                             Console.WriteLine("SETTING T FLAG, NEXT INSTRUCTION IS UNHANDLED:  {0}", b);
                         FlagT = true;
                         PendingCycles -= 2;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0xF5: // SBC zp,X
                         value8 = ReadMemory((ushort)(((ReadMemory(PC++)+X)&0xFF)+0x2000));
                         temp = A - value8 - (FlagC ? 0 : 1);
@@ -2292,8 +2296,7 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                         break;
                 }
 
-                P &= 0xDF; // Clear T flag
-            AfterClearTFlag: // SET command jumps here
+                if (!skipClearTFlag) P &= 0xDF; // Clear T flag - skipped for 0x28, 0x40, and 0xF4
                 int delta = lastCycles - PendingCycles;
                 if (LowSpeed)
                 {

--- a/BizHawk.Emulation.DiscSystem/DiscMountJob.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscMountJob.cs
@@ -146,7 +146,11 @@ namespace BizHawk.Emulation.DiscSystem
 				catch (DiscJobAbortException) { okParse = false; parseJob.FinishLog(); }
 				if (!string.IsNullOrEmpty(parseJob.OUT_Log)) Console.WriteLine(parseJob.OUT_Log);
 				ConcatenateJobLog(parseJob);
-				if (!okParse) return RunBizHawk_Done();
+				if (!okParse)
+				{
+					RunBizHawk_Done();
+					return;
+				}
 
 				//compile the cue file:
 				//includes this work: resolve required bin files and find out what it's gonna take to load the cue
@@ -158,14 +162,19 @@ namespace BizHawk.Emulation.DiscSystem
 				catch (DiscJobAbortException) { okCompile = false; compileJob.FinishLog();  }
 				if (!string.IsNullOrEmpty(compileJob.OUT_Log)) Console.WriteLine(compileJob.OUT_Log);
 				ConcatenateJobLog(compileJob);
-				if (!okCompile || compileJob.OUT_ErrorLevel) return RunBizHawk_Done();
+				if (!okCompile || compileJob.OUT_ErrorLevel)
+				{
+					RunBizHawk_Done();
+					return;
+				}
 
 				//check slow loading threshold
 				if (compileJob.OUT_LoadTime > IN_SlowLoadAbortThreshold)
 				{
 					Warn("Loading terminated due to slow load threshold");
 					OUT_SlowLoadAborted = true;
-					return RunBizHawk_Done();
+					RunBizHawk_Done();
+					return;
 				}
 
 				//actually load it all up

--- a/BizHawk.Emulation.DiscSystem/DiscTypes.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscTypes.cs
@@ -105,29 +105,26 @@ namespace BizHawk.Emulation.DiscSystem
 
 		/// <summary>
 		/// creates a timestamp from a string in the form mm:ss:ff
+		/// TODO use a datetime library
 		/// </summary>
 		public Timestamp(string str)
 		{
-			if (str.Length != 8) goto BOGUS;
-			if (str[0] < '0' || str[0] > '9') goto BOGUS;
-			if (str[1] < '0' || str[1] > '9') goto BOGUS;
-			if (str[2] != ':') goto BOGUS;
-			if (str[3] < '0' || str[3] > '9') goto BOGUS;
-			if (str[4] < '0' || str[4] > '9') goto BOGUS;
-			if (str[5] != ':') goto BOGUS;
-			if (str[6] < '0' || str[6] > '9') goto BOGUS;
-			if (str[7] < '0' || str[7] > '9') goto BOGUS;
-			MIN = (byte)((str[0] - '0') * 10 + (str[1] - '0'));
-			SEC = (byte)((str[3] - '0') * 10 + (str[4] - '0'));
-			FRAC = (byte)((str[6] - '0') * 10 + (str[7] - '0'));
-			Valid = true;
+			Valid = str.Length == 8 && str[0] >= '0' && str[0] <= '9' && str[1] >= '0' && str[1] <= '9' &&
+				str[2] == ':' && str[3] >= '0' && str[3] <= '9' && str[4] >= '0' && str[4] <= '9' &&
+				str[5] == ':' && str[6] >= '0' && str[6] <= '9' && str[7] >= '0' && str[7] <= '9';
+			if (Valid)
+			{
+				MIN = (byte) (10 * (str[0] - '0') + (str[1] - '0'));
+				SEC = (byte) (10 * (str[3] - '0') + (str[4] - '0'));
+				FRAC = (byte) (10 * (str[6] - '0') + (str[7] - '0'));
+			}
+			else
+			{
+				MIN = 0;
+				SEC = 0;
+				FRAC = 0;
+			}
 			Negative = false;
-			return;
-		BOGUS:
-			MIN = SEC = FRAC = 0;
-			Valid = false;
-			Negative = false;
-			return;
 		}
 
 		/// <summary>

--- a/BizHawk.Emulation.DiscSystem/DiscTypes.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscTypes.cs
@@ -109,12 +109,10 @@ namespace BizHawk.Emulation.DiscSystem
 		/// </summary>
 		public Timestamp(string str)
 		{
-			Valid = str.Length == 8 &&
-				str[0] >= '0' && str[0] <= '9' && str[1] >= '0' && str[1] <= '9' &&
-				str[2] == ':' &&
-				str[3] >= '0' && str[3] <= '9' && str[4] >= '0' && str[4] <= '9' &&
-				str[5] == ':' &&
-				str[6] >= '0' && str[6] <= '9' && str[7] >= '0' && str[7] <= '9';
+			Valid =
+				str[0] >= '0' && str[0] <= '9' && str[1] >= '0' && str[1] <= '9' && str[2] == ':' &&
+				str[3] >= '0' && str[3] <= '9' && str[4] >= '0' && str[4] <= '9' && str[5] == ':' &&
+				str[6] >= '0' && str[6] <= '9' && str[7] >= '0' && str[7] <= '9' && str.Length == 8;
 			if (Valid)
 			{
 				MIN = (byte) (10 * (str[0] - '0') + (str[1] - '0'));

--- a/BizHawk.Emulation.DiscSystem/DiscTypes.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscTypes.cs
@@ -109,9 +109,12 @@ namespace BizHawk.Emulation.DiscSystem
 		/// </summary>
 		public Timestamp(string str)
 		{
-			Valid = str.Length == 8 && str[0] >= '0' && str[0] <= '9' && str[1] >= '0' && str[1] <= '9' &&
-				str[2] == ':' && str[3] >= '0' && str[3] <= '9' && str[4] >= '0' && str[4] <= '9' &&
-				str[5] == ':' && str[6] >= '0' && str[6] <= '9' && str[7] >= '0' && str[7] <= '9';
+			Valid = str.Length == 8 &&
+				str[0] >= '0' && str[0] <= '9' && str[1] >= '0' && str[1] <= '9' &&
+				str[2] == ':' &&
+				str[3] >= '0' && str[3] <= '9' && str[4] >= '0' && str[4] <= '9' &&
+				str[5] == ':' &&
+				str[6] >= '0' && str[6] <= '9' && str[7] >= '0' && str[7] <= '9';
 			if (Valid)
 			{
 				MIN = (byte) (10 * (str[0] - '0') + (str[1] - '0'));


### PR DESCRIPTION
a.k.a. how many PRs can I have open at once

Skipping all `goto case`s until I look up what that is. Also skipping `StreamBlobDatabase.Enqueue` because it has TWO labels. Also skipping `ArchiveExtractCallback.GetStream` because it mixes `goto` and `return`.

TexAtlas?:
* [ ] no idea

Firmwares:
* [x] Really doesn't need testing, literally replaced goto w/ break.

TAStudio:
* [ ] whatever StateManagerDecay does at ([callsite](https://github.com/TASVideos/BizHawk/blob/938154f72eda86d380e58c25c5b0e3dc01529391/BizHawk.Client.Common/movie/tasproj/TasStateManager.cs#L298))

Rewind:
* [ ] works?

DiscoHawk
* [ ] file comparison?

MultiHawk keybinds:
* [ ] keydown ignored except escape

EmuHawk keybinds:
* [ ] keydown ignored except escape

DiscSystem:
* [ ] Timestamp from string in [DiscTypes.cs](https://github.com/TASVideos/BizHawk/blob/938154f72eda86d380e58c25c5b0e3dc01529391/BizHawk.Emulation.DiscSystem/DiscTypes.cs)
* [ ] iso to cue in [DiscMountJob.cs](https://github.com/TASVideos/BizHawk/blob/938154f72eda86d380e58c25c5b0e3dc01529391/BizHawk.Emulation.DiscSystem/DiscMountJob.cs)

FilterManager:
* [ ] shader compilation?

MainForm/Program:
* [ ] works
* [ ] frame advance while (video) recording?

PCESoundDebugger:
* [ ] works?