### PR TITLE
EmuHawk: _LoadRom() - Change deterministic back to how it was before. 

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3589,23 +3589,12 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			try
-			{                
-                bool deterministic;
-
-                if (args.Deterministic == null)
-                {
-					// movies should require deterministic emulation in ALL cases
-					// if the core is managing its own DE through SyncSettings a 'deterministic' bool can be passed into the core's constructor
-					// it is then up to the core itself to override its own local DeterministicEmulation setting
-					// if a movie is *not* queued then make this false (this is needed for mGBA logic and is how things were working before I changed them -Asni)
-					deterministic = Global.MovieSession.QueuedMovie != null;
-				}
-                else
-                {
-                    // a value was actually supplied somehow - use this
-                    deterministic = args.Deterministic.Value;
-                }
-
+			{
+				// movies should require deterministic emulation in ALL cases
+				// if the core is managing its own DE through SyncSettings a 'deterministic' bool can be passed into the core's constructor
+				// it is then up to the core itself to override its own local DeterministicEmulation setting
+				bool deterministic = args.Deterministic ?? Global.MovieSession.QueuedMovie != null;
+				
 				if (!GlobalWin.Tools.AskSave())
 				{
 					return false;

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -3594,23 +3594,16 @@ namespace BizHawk.Client.EmuHawk
 
                 if (args.Deterministic == null)
                 {
-                    // force deterministic in this case
-                    // this is usually null for most cores
-                    // previously this was getting set to false if a movie was not queued for recording - surely that can't be good..
-                    deterministic = true;
-                }
+					// movies should require deterministic emulation in ALL cases
+					// if the core is managing its own DE through SyncSettings a 'deterministic' bool can be passed into the core's constructor
+					// it is then up to the core itself to override its own local DeterministicEmulation setting
+					// if a movie is *not* queued then make this false (this is needed for mGBA logic and is how things were working before I changed them -Asni)
+					deterministic = Global.MovieSession.QueuedMovie != null;
+				}
                 else
                 {
                     // a value was actually supplied somehow - use this
                     deterministic = args.Deterministic.Value;
-                }
-
-                if (Global.MovieSession.QueuedMovie != null)
-                {
-                    // movies should require deterministic emulation in ALL cases
-                    // if the core is managing its own DE through SyncSettings a 'deterministic' bool should be passed into the core's constructor
-                    // it is then up to the core itself to override its own local DeterministicEmulation setting
-                    deterministic = true;
                 }
 
 				if (!GlobalWin.Tools.AskSave())


### PR DESCRIPTION
This fixes #1432

A while ago in a PR, I rather naively forced `deterministic` to True when `args.Deterministic == null` in `MainForm._LoadRom()`. This broke a bunch of stuff related to how the mGBA was initialised (specifically `SkipBios` and `RTCTime()` were being handled). It also meant that all cores that don't specifically handle Deterministic Emulation within their SyncSettings (which is many/most of them looking at it) always had DE set to TRUE with no possibility of being able to use frame or audio skip.

This PR reverts determinism handling in MainForm back to how it was:

* If `Global.MovieSession.QueuedMovie != null` then `deterministic = true`
* If `args.Deterministic != null` then `deterministic = args.Deterministic`
* Otherwise, `deterministic = false`

Basically, if there is a threat of a movie, determinism must be enforced, otherwise turn it off and let individual cores handle this themselves (if they want to).

This makes far more sense as a baseline (and clearly why it was this way originally).