### PR TITLE
[Untested] Banish all gotos from cores

### DIFF
--- a/BizHawk.Emulation.Cores/CPUs/HuC6280/Execute.cs
+++ b/BizHawk.Emulation.Cores/CPUs/HuC6280/Execute.cs
@@ -64,6 +64,7 @@ namespace BizHawk.Emulation.Cores.Components.H6280
 
                 if (CDL != null && CDL.Active) CDLOpcode();
 
+                var skipClearTFlag = false;
                 byte opcode = ReadMemory(PC++);
                 switch (opcode)
                 {
@@ -438,7 +439,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                     case 0x28: // PLP
                         P = ReadMemory((ushort)(++S + 0x2100));
                         PendingCycles -= 4;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0x29: // AND #nn
                         value8 = ReadMemory(PC++);
                         if (FlagT == false) { 
@@ -644,7 +646,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                         PC = ReadMemory((ushort)(++S + 0x2100));
                         PC |= (ushort)(ReadMemory((ushort)(++S + 0x2100)) << 8);
                         PendingCycles -= 7;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0x41: // EOR (addr,X)
                         value8 = ReadMemory(ReadWordPageWrap((ushort)((byte)(ReadMemory(PC++)+X)+0x2000)));
                         if (FlagT == false) { 
@@ -2181,7 +2184,8 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                             Console.WriteLine("SETTING T FLAG, NEXT INSTRUCTION IS UNHANDLED:  {0}", b);
                         FlagT = true;
                         PendingCycles -= 2;
-                        goto AfterClearTFlag;
+                        skipClearTFlag = true;
+                        break;
                     case 0xF5: // SBC zp,X
                         value8 = ReadMemory((ushort)(((ReadMemory(PC++)+X)&0xFF)+0x2000));
                         temp = A - value8 - (FlagC ? 0 : 1);
@@ -2292,8 +2296,7 @@ namespace BizHawk.Emulation.Cores.Components.H6280
                         break;
                 }
 
-                P &= 0xDF; // Clear T flag
-            AfterClearTFlag: // SET command jumps here
+                if (!skipClearTFlag) P &= 0xDF; // Clear T flag - skipped for 0x28, 0x40, and 0xF4
                 int delta = lastCycles - PendingCycles;
                 if (LowSpeed)
                 {

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/ExROM.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/Boards/ExROM.cs
@@ -255,30 +255,30 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 				// top 2 bits of address come from chr_reg_high
 				bank_1k += chr_reg_high << 8;
 				ofs = addr & (4 * 1024 - 1);
-				goto MAPPED;
-			}
-
-			if (NES.ppu.reg_2000.obj_size_16)
-			{
-				bool isPattern = NES.ppu.PPUON;
-				if (NES.ppu.ppuphase == PPU.PPUPHASE.OBJ && isPattern)
-					bank_1k = a_banks_1k[bank_1k];
-				else if (NES.ppu.ppuphase == PPU.PPUPHASE.BG && isPattern)
-					bank_1k = b_banks_1k[bank_1k];
-				else
-				{
-					if (ab_mode == 0)
-						bank_1k = a_banks_1k[bank_1k];
-					else
-						bank_1k = b_banks_1k[bank_1k];
-				}
 			}
 			else
 			{
-				bank_1k = a_banks_1k[bank_1k];
+				if (NES.ppu.reg_2000.obj_size_16)
+				{
+					bool isPattern = NES.ppu.PPUON;
+					if (NES.ppu.ppuphase == PPU.PPUPHASE.OBJ && isPattern)
+						bank_1k = a_banks_1k[bank_1k];
+					else if (NES.ppu.ppuphase == PPU.PPUPHASE.BG && isPattern)
+						bank_1k = b_banks_1k[bank_1k];
+					else
+					{
+						if (ab_mode == 0)
+							bank_1k = a_banks_1k[bank_1k];
+						else
+							bank_1k = b_banks_1k[bank_1k];
+					}
+				}
+				else
+				{
+					bank_1k = a_banks_1k[bank_1k];
+				}
 			}
-		
-			MAPPED:
+
 			bank_1k &= chr_bank_mask_1k;
 			addr = (bank_1k<<10)|ofs;
 			return addr;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.cs
@@ -103,21 +103,25 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 			const int radius = 10; // look at pixel values up to this far away, roughly
 
-			int sum = 0;
 			int ymin = Math.Max(Math.Max(y - radius, ppur.status.sl - 20), 0);
 			int ymax = Math.Min(y + radius, 239);
 			int xmin = Math.Max(x - radius, 0);
 			int xmax = Math.Min(x + radius, 255);
-
 			int ystop = ppur.status.sl - 2;
 			int xstop = ppur.status.cycle - 20;
 
+			int sum = 0;
+			LightGunCallback_Sub(sum, xmin, xmax, xstop, ymin, ymax, ystop);
+			return sum >= 2000;
+		}
+
+		private void LightGunCallback_Sub(int sum, int xmin, int xmax, int xstop, int ymin, int ymax, int ystop)
+		{
 			for (int j = ymin; j <= ymax; j++)
 			{
 				for (int i = xmin; i <= xmax; i++)
 				{
-					if (j >= ystop && i >= xstop || j > ystop)
-						goto loopout;
+					if (j >= ystop && i >= xstop || j > ystop) return; // Break both loops and return in LightGunCallback
 
 					short s = xbuf[j * 256 + i];
 
@@ -126,8 +130,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 					sum += _currentLuma[palcolor];
 				}
 			}
-			loopout:
-			return sum >= 2000;
 		}
 
 		//when the ppu issues a write it goes through here and into the game board


### PR DESCRIPTION
Is 4 simultaneous PRs a record? I feel like no-one's been stupid enough to do it before.

Excluding `goto case` because I don't know how it works.

NES:
* [ ] Light Gun - either I broke it or I'm not good at aiming with the Virtual Pad
* [ ] ExROM cart (do they exist?)

TG-16/PCE:
* [ ] Op-codes 0x28, 0x40, and 0xF4?