### PR TITLE
Fix tables in comments with mixed whitespace

### DIFF
--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Display/CRCT_6845.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Display/CRCT_6845.cs
@@ -302,25 +302,25 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
         #region Internal Registers and State
 
         /*
-        Index	Register Name	                    Range	    CPC Setting	Notes
-        0	    Horizontal Total	                00000000	63	        Width of the screen, in characters. Should always be 63 (64 characters). 1 character == 1μs.
-        1	    Horizontal Displayed	            00000000	40	        Number of characters displayed. Once horizontal character count (HCC) matches this value, DISPTMG is set to 1.
-        2	    Horizontal Sync Position	        00000000	46	        When to start the HSync signal.
-        3	    Horizontal and Vertical Sync Widths	VVVVHHHH	128+14	    HSync pulse width in characters (0 means 16 on some CRTC), should always be more than 8; VSync width in scan-lines. (0 means 16 on some CRTC. Not present on all CRTCs, fixed to 16 lines on these)
-        4	    Vertical Total	                    x0000000	38	        Height of the screen, in characters.
-        5	    Vertical Total Adjust	            xxx00000	0	        Measured in scanlines, can be used for smooth vertical scrolling on CPC.
-        6	    Vertical Displayed	                x0000000	25	        Height of displayed screen in characters. Once vertical character count (VCC) matches this value, DISPTMG is set to 1.
-        7	    Vertical Sync position	            x0000000	30	        When to start the VSync signal, in characters.
-        8	    Interlace and Skew	                xxxxxx00	0	        00: No interlace; 01: Interlace Sync Raster Scan Mode; 10: No Interlace; 11: Interlace Sync and Video Raster Scan Mode
-        9	    Maximum Raster Address	            xxx00000	7	        Maximum scan line address on CPC can hold between 0 and 7, higher values' upper bits are ignored
-        10	    Cursor Start Raster	                xBP00000	0	        Cursor not used on CPC. B = Blink On/Off; P = Blink Period Control (Slow/Fast). Sets first raster row of character that cursor is on to invert.
-        11	    Cursor End Raster	                xxx00000	0	        Sets last raster row of character that cursor is on to invert
-        12	    Display Start Address (High)	    xx000000	32
-        13	    Display Start Address (Low)	        00000000	0	        Allows you to offset the start of screen memory for hardware scrolling, and if using memory from address &0000 with the firmware.
-        14	    Cursor Address (High)	            xx000000	0
-        15	    Cursor Address (Low)	            00000000	0
-        16	    Light Pen Address (High)	        xx000000		        Read Only
-        17	    Light Pen Address (Low)	            00000000		        Read Only
+        Index    Register Name                          Range       CPC Setting    Notes
+        0        Horizontal Total                       00000000    63             Width of the screen, in characters. Should always be 63 (64 characters). 1 character == 1μs.
+        1        Horizontal Displayed                   00000000    40             Number of characters displayed. Once horizontal character count (HCC) matches this value, DISPTMG is set to 1.
+        2        Horizontal Sync Position               00000000    46             When to start the HSync signal.
+        3        Horizontal and Vertical Sync Widths    VVVVHHHH    128+14         HSync pulse width in characters (0 means 16 on some CRTC), should always be more than 8; VSync width in scan-lines. (0 means 16 on some CRTC. Not present on all CRTCs, fixed to 16 lines on these)
+        4        Vertical Total                         x0000000    38             Height of the screen, in characters.
+        5        Vertical Total Adjust                  xxx00000    0              Measured in scanlines, can be used for smooth vertical scrolling on CPC.
+        6        Vertical Displayed                     x0000000    25             Height of displayed screen in characters. Once vertical character count (VCC) matches this value, DISPTMG is set to 1.
+        7        Vertical Sync position                 x0000000    30             When to start the VSync signal, in characters.
+        8        Interlace and Skew                     xxxxxx00    0              00: No interlace; 01: Interlace Sync Raster Scan Mode; 10: No Interlace; 11: Interlace Sync and Video Raster Scan Mode
+        9        Maximum Raster Address                 xxx00000    7              Maximum scan line address on CPC can hold between 0 and 7, higher values' upper bits are ignored
+        10       Cursor Start Raster                    xBP00000    0              Cursor not used on CPC. B = Blink On/Off; P = Blink Period Control (Slow/Fast). Sets first raster row of character that cursor is on to invert.
+        11       Cursor End Raster                      xxx00000    0              Sets last raster row of character that cursor is on to invert
+        12       Display Start Address (High)           xx000000    32
+        13       Display Start Address (Low)            00000000    0              Allows you to offset the start of screen memory for hardware scrolling, and if using memory from address &0000 with the firmware.
+        14       Cursor Address (High)                  xx000000    0
+        15       Cursor Address (Low)                   00000000    0
+        16       Light Pen Address (High)               xx000000                   Read Only
+        17       Light Pen Address (Low)                00000000                   Read Only
         */
         /// <summary>
         /// 6845 internal registers
@@ -879,26 +879,26 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
         }
 
         /*
-                RegIdx	Register Name	            Type
-                                                    0	        1	        2	        3	                4
-                0	    Horizontal Total	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                1	    Horizontal Displayed	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                2	    Horizontal Sync Position	Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                3	    H and V Sync Widths	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                4	    Vertical Total	            Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                5	    Vertical Total Adjust	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                6	    Vertical Displayed	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                7	    Vertical Sync position	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                8	    Interlace and Skew	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                9	    Maximum Raster Address	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                10	    Cursor Start Raster	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                11	    Cursor End Raster	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                12	    Disp. Start Address (High)	Read/Write	Write Only	Write Only	Read/Write (note 2)	(note 3)
-                13	    Disp. Start Address (Low)	Read/Write	Write Only	Write Only	Read/Write (note 2)	(note 3)
-                14	    Cursor Address (High)	    Read/Write	Read/Write	Read/Write	Read/Write (note 2)	(note 3)
-                15	    Cursor Address (Low)	    Read/Write	Read/Write	Read/Write	Read/Write (note 2)	(note 3)
-                16	    Light Pen Address (High)	Read Only	Read Only	Read Only	Read Only (note 2)	(note 3)
-                17	    Light Pen Address (Low)	    Read Only	Read Only	Read Only	Read Only (note 2)	(note 3)
+                RegIdx    Register Name                 Type
+                                                        0             1             2             3                      4
+                0         Horizontal Total              Write Only    Write Only    Write Only    (note 2)               (note 3)
+                1         Horizontal Displayed          Write Only    Write Only    Write Only    (note 2)               (note 3)
+                2         Horizontal Sync Position      Write Only    Write Only    Write Only    (note 2)               (note 3)
+                3         H and V Sync Widths           Write Only    Write Only    Write Only    (note 2)               (note 3)
+                4         Vertical Total                Write Only    Write Only    Write Only    (note 2)               (note 3)
+                5         Vertical Total Adjust         Write Only    Write Only    Write Only    (note 2)               (note 3)
+                6         Vertical Displayed            Write Only    Write Only    Write Only    (note 2)               (note 3)
+                7         Vertical Sync position        Write Only    Write Only    Write Only    (note 2)               (note 3)
+                8         Interlace and Skew            Write Only    Write Only    Write Only    (note 2)               (note 3)
+                9         Maximum Raster Address        Write Only    Write Only    Write Only    (note 2)               (note 3)
+                10        Cursor Start Raster           Write Only    Write Only    Write Only    (note 2)               (note 3)
+                11        Cursor End Raster             Write Only    Write Only    Write Only    (note 2)               (note 3)
+                12        Disp. Start Address (High)    Read/Write    Write Only    Write Only    Read/Write (note 2)    (note 3)
+                13        Disp. Start Address (Low)     Read/Write    Write Only    Write Only    Read/Write (note 2)    (note 3)
+                14        Cursor Address (High)         Read/Write    Read/Write    Read/Write    Read/Write (note 2)    (note 3)
+                15        Cursor Address (Low)          Read/Write    Read/Write    Read/Write    Read/Write (note 2)    (note 3)
+                16        Light Pen Address (High)      Read Only     Read Only     Read Only     Read Only (note 2)     (note 3)
+                17        Light Pen Address (Low)       Read Only     Read Only     Read Only     Read Only (note 2)     (note 3)
 
                 1. On type 0 and 1, if a Write Only register is read from, "0" is returned.
                 2. See the document "Extra CPC Plus Hardware Information" for more details.
@@ -1093,10 +1093,10 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
         #region PortIODevice
 
         /*
-            #BCXX	%x0xxxx00 xxxxxxxx	6845 CRTC Index	                        -	    Write
-            #BDXX	%x0xxxx01 xxxxxxxx	6845 CRTC Data Out	                    -	    Write
-            #BEXX	%x0xxxx10 xxxxxxxx	6845 CRTC Status (as far as supported)	Read	-
-            #BFXX	%x0xxxx11 xxxxxxxx	6845 CRTC Data In (as far as supported)	Read	-
+            #BCXX    %x0xxxx00 xxxxxxxx    6845 CRTC Index                            -       Write
+            #BDXX    %x0xxxx01 xxxxxxxx    6845 CRTC Data Out                         -       Write
+            #BEXX    %x0xxxx10 xxxxxxxx    6845 CRTC Status (as far as supported)     Read    -
+            #BFXX    %x0xxxx11 xxxxxxxx    6845 CRTC Data In (as far as supported)    Read    -
          */
 
         /// <summary>

--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Display/CRTC6845.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/Hardware/Display/CRTC6845.cs
@@ -13,27 +13,27 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 	/// the CPC, CPC+ and GX4000 ranges. The CPC community have assigned them type numbers.
 	/// If different implementations share the same type number it indicates that they are functionally identical:
 	/// 
-	///		Part No.	Manufacturer	Type No.	Info.
-	///		------------------------------------------------------------------------------------------------------
-	///		HD6845S		Hitachi			0	
-	///		Datasheet:	http://www.cpcwiki.eu/imgs/c/c0/Hd6845.hitachi.pdf
-	///		------------------------------------------------------------------------------------------------------
-	///		UM6845		UMC				0
-	///		Datasheet:	http://www.cpcwiki.eu/imgs/1/13/Um6845.umc.pdf
-	///		------------------------------------------------------------------------------------------------------
-	///		UM6845R		UMC				1
-	///		Datasheet:	http://www.cpcwiki.eu/imgs/b/b5/Um6845r.umc.pdf
-	///		------------------------------------------------------------------------------------------------------
-	///		MC6845		Motorola		2
-	///		Datasheet:	http://www.cpcwiki.eu/imgs/d/da/Mc6845.motorola.pdf & http://bitsavers.trailing-edge.com/components/motorola/_dataSheets/6845.pdf
-	///		------------------------------------------------------------------------------------------------------
-	///		AMS40489	Amstrad			3			Only exists in the CPC464+, CPC6128+ and GX4000 and is integrated into a single CPC+ ASIC chip (along with the gatearray)
-	///		Datasheet:	{none}
-	///		------------------------------------------------------------------------------------------------------
-	///		AMS40041	Amstrad			4			'Pre-ASIC' IC. The CRTC is integrated into a aingle ASIC IC with functionality being almost identical to the AMS40489
-	///		(or 40226)								Used in the 'Cost-Down' range of CPC464 and CPC6128 systems
-	///		Datasheet:	{none}
-	/// 
+	/// Part No.      Manufacturer    Type No.    Info.
+	/// ------------------------------------------------------------------------------------------------------
+	/// HD6845S       Hitachi         0
+	/// Datasheet:    http://www.cpcwiki.eu/imgs/c/c0/Hd6845.hitachi.pdf
+	/// ------------------------------------------------------------------------------------------------------
+	/// UM6845        UMC             0
+	/// Datasheet:    http://www.cpcwiki.eu/imgs/1/13/Um6845.umc.pdf
+	/// ------------------------------------------------------------------------------------------------------
+	/// UM6845R       UMC             1
+	/// Datasheet:    http://www.cpcwiki.eu/imgs/b/b5/Um6845r.umc.pdf
+	/// ------------------------------------------------------------------------------------------------------
+	/// MC6845        Motorola        2
+	/// Datasheet:    http://www.cpcwiki.eu/imgs/d/da/Mc6845.motorola.pdf & http://bitsavers.trailing-edge.com/components/motorola/_dataSheets/6845.pdf
+	/// ------------------------------------------------------------------------------------------------------
+	/// AMS40489      Amstrad         3           Only exists in the CPC464+, CPC6128+ and GX4000 and is integrated into a single CPC+ ASIC chip (along with the gatearray)
+	/// Datasheet:    {none}
+	/// ------------------------------------------------------------------------------------------------------
+	/// AMS40041      Amstrad         4           'Pre-ASIC' IC. The CRTC is integrated into a aingle ASIC IC with functionality being almost identical to the AMS40489
+	/// (or 40226)                                Used in the 'Cost-Down' range of CPC464 and CPC6128 systems
+	/// Datasheet:    {none}
+	///
 	/// </summary>
 	public class CRTC6845
 	{
@@ -148,23 +148,23 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 		/// Built from R12, R13 and CLK
 		/// </summary>
 		/*
-            Memory Address Signal	Signal source	Signal name
-            A15	                    6845	        MA13
-            A14	                    6845	        MA12
-            A13	                    6845	        RA2
-            A12	                    6845	        RA1
-            A11	                    6845	        RA0
-            A10	                    6845	        MA9
-            A9	                    6845	        MA8
-            A8	                    6845	        MA7
-            A7	                    6845	        MA6
-            A6	                    6845	        MA5
-            A5	                    6845	        MA4
-            A4	                    6845	        MA3
-            A3	                    6845	        MA2
-            A2	                    6845	        MA1
-            A1	                    6845	        MA0
-            A0	                    Gate-Array	    CLK
+            Memory Address Signal    Signal source    Signal name
+            A15                      6845             MA13
+            A14                      6845             MA12
+            A13                      6845             RA2
+            A12                      6845             RA1
+            A11                      6845             RA0
+            A10                      6845             MA9
+            A9                       6845             MA8
+            A8                       6845             MA7
+            A7                       6845             MA6
+            A6                       6845             MA5
+            A5                       6845             MA4
+            A4                       6845             MA3
+            A3                       6845             MA2
+            A2                       6845             MA1
+            A1                       6845             MA0
+            A0                       Gate-Array       CLK
          */
 		public ushort AddressLineCPC
 		{
@@ -323,26 +323,26 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 		#region Databus Interface
 
 		/*
-                RegIdx	Register Name	            Type
-                                                    0	        1	        2	        3	                4
-                0	    Horizontal Total	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                1	    Horizontal Displayed	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                2	    Horizontal Sync Position	Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                3	    H and V Sync Widths	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                4	    Vertical Total	            Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                5	    Vertical Total Adjust	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                6	    Vertical Displayed	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                7	    Vertical Sync position	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                8	    Interlace and Skew	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                9	    Maximum Raster Address	    Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                10	    Cursor Start Raster	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                11	    Cursor End Raster	        Write Only	Write Only	Write Only	(note 2)	        (note 3)
-                12	    Disp. Start Address (High)	Read/Write	Write Only	Write Only	Read/Write (note 2)	(note 3)
-                13	    Disp. Start Address (Low)	Read/Write	Write Only	Write Only	Read/Write (note 2)	(note 3)
-                14	    Cursor Address (High)	    Read/Write	Read/Write	Read/Write	Read/Write (note 2)	(note 3)
-                15	    Cursor Address (Low)	    Read/Write	Read/Write	Read/Write	Read/Write (note 2)	(note 3)
-                16	    Light Pen Address (High)	Read Only	Read Only	Read Only	Read Only (note 2)	(note 3)
-                17	    Light Pen Address (Low)	    Read Only	Read Only	Read Only	Read Only (note 2)	(note 3)
+                RegIdx    Register Name                 Type
+                                                        0             1             2             3                      4
+                0         Horizontal Total              Write Only    Write Only    Write Only    (note 2)               (note 3)
+                1         Horizontal Displayed          Write Only    Write Only    Write Only    (note 2)               (note 3)
+                2         Horizontal Sync Position      Write Only    Write Only    Write Only    (note 2)               (note 3)
+                3         H and V Sync Widths           Write Only    Write Only    Write Only    (note 2)               (note 3)
+                4         Vertical Total                Write Only    Write Only    Write Only    (note 2)               (note 3)
+                5         Vertical Total Adjust         Write Only    Write Only    Write Only    (note 2)               (note 3)
+                6         Vertical Displayed            Write Only    Write Only    Write Only    (note 2)               (note 3)
+                7         Vertical Sync position        Write Only    Write Only    Write Only    (note 2)               (note 3)
+                8         Interlace and Skew            Write Only    Write Only    Write Only    (note 2)               (note 3)
+                9         Maximum Raster Address        Write Only    Write Only    Write Only    (note 2)               (note 3)
+                10        Cursor Start Raster           Write Only    Write Only    Write Only    (note 2)               (note 3)
+                11        Cursor End Raster             Write Only    Write Only    Write Only    (note 2)               (note 3)
+                12        Disp. Start Address (High)    Read/Write    Write Only    Write Only    Read/Write (note 2)    (note 3)
+                13        Disp. Start Address (Low)     Read/Write    Write Only    Write Only    Read/Write (note 2)    (note 3)
+                14        Cursor Address (High)         Read/Write    Read/Write    Read/Write    Read/Write (note 2)    (note 3)
+                15        Cursor Address (Low)          Read/Write    Read/Write    Read/Write    Read/Write (note 2)    (note 3)
+                16        Light Pen Address (High)      Read Only     Read Only     Read Only     Read Only (note 2)     (note 3)
+                17        Light Pen Address (Low)       Read Only     Read Only     Read Only     Read Only (note 2)     (note 3)
 
                 1. On type 0 and 1, if a Write Only register is read from, "0" is returned.
                 2. See the document "Extra CPC Plus Hardware Information" for more details.
@@ -350,10 +350,10 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
         */
 
 		/* CPC:
-        #BCXX	%x0xxxx00 xxxxxxxx	6845 CRTC Index	                        -	    Write
-        #BDXX	%x0xxxx01 xxxxxxxx	6845 CRTC Data Out	                    -	    Write
-        #BEXX	%x0xxxx10 xxxxxxxx	6845 CRTC Status (as far as supported)	Read	-
-        #BFXX	%x0xxxx11 xxxxxxxx	6845 CRTC Data In (as far as supported)	Read	-
+        #BCXX    %x0xxxx00 xxxxxxxx    6845 CRTC Index                            -       Write
+        #BDXX    %x0xxxx01 xxxxxxxx    6845 CRTC Data Out                         -       Write
+        #BEXX    %x0xxxx10 xxxxxxxx    6845 CRTC Status (as far as supported)     Read    -
+        #BFXX    %x0xxxx11 xxxxxxxx    6845 CRTC Data In (as far as supported)    Read    -
 
 			The Read/Write functions below are geared toward Amstrad CPC only
 			They could be overridden for a different implementation if needs be

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/MemoryMap.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/MemoryMap.cs
@@ -5,22 +5,22 @@ using BizHawk.Emulation.Common;
 
 
 /*
-	$FFFF 			Interrupt Enable Flag
-	$FF80-$FFFE 	Zero Page - 127 bytes
-	$FF00-$FF7F 	Hardware I/O Registers
-	$FEA0-$FEFF 	Unusable Memory
-	$FE00-$FE9F 	OAM - Object Attribute Memory
-	$E000-$FDFF 	Echo RAM - Reserved, Do Not Use
-	$D000-$DFFF 	Internal RAM - Bank 1-7 (switchable - CGB only)
-	$C000-$CFFF 	Internal RAM - Bank 0 (fixed)
-	$A000-$BFFF 	Cartridge RAM (If Available)
-	$9C00-$9FFF 	BG Map Data 2
-	$9800-$9BFF 	BG Map Data 1
-	$8000-$97FF 	Character RAM
-	$4000-$7FFF 	Cartridge ROM - Switchable Banks 1-xx
-	$0150-$3FFF 	Cartridge ROM - Bank 0 (fixed)
-	$0100-$014F 	Cartridge Header Area
-	$0000-$00FF 	Restart and Interrupt Vectors
+	$FFFF          Interrupt Enable Flag
+	$FF80-$FFFE    Zero Page - 127 bytes
+	$FF00-$FF7F    Hardware I/O Registers
+	$FEA0-$FEFF    Unusable Memory
+	$FE00-$FE9F    OAM - Object Attribute Memory
+	$E000-$FDFF    Echo RAM - Reserved, Do Not Use
+	$D000-$DFFF    Internal RAM - Bank 1-7 (switchable - CGB only)
+	$C000-$CFFF    Internal RAM - Bank 0 (fixed)
+	$A000-$BFFF    Cartridge RAM (If Available)
+	$9C00-$9FFF    BG Map Data 2
+	$9800-$9BFF    BG Map Data 1
+	$8000-$97FF    Character RAM
+	$4000-$7FFF    Cartridge ROM - Switchable Banks 1-xx
+	$0150-$3FFF    Cartridge ROM - Bank 0 (fixed)
+	$0100-$014F    Cartridge Header Area
+	$0000-$00FF    Restart and Interrupt Vectors
 */
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawk

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/PPU.regs.cs
@@ -803,21 +803,21 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		//BWrite[x+7]=B2007;
 
 
-//Address 	Size 	Description
-//$0000 	$1000 	Pattern Table 0
-//$1000 	$1000 	Pattern Table 1
-//$2000 	$3C0 	Name Table 0
-//$23C0 	$40 	Attribute Table 0
-//$2400 	$3C0 	Name Table 1
-//$27C0 	$40 	Attribute Table 1
-//$2800 	$3C0 	Name Table 2
-//$2BC0 	$40 	Attribute Table 2
-//$2C00 	$3C0 	Name Table 3
-//$2FC0 	$40 	Attribute Table 3
-//$3000 	$F00 	Mirror of 2000h-2EFFh
-//$3F00 	$10 	BG Palette
-//$3F10 	$10 	Sprite Palette
-//$3F20 	$E0 	Mirror of 3F00h-3F1Fh
+//Address    Size    Description
+//$0000      $1000   Pattern Table 0
+//$1000      $1000   Pattern Table 1
+//$2000      $3C0    Name Table 0
+//$23C0      $40     Attribute Table 0
+//$2400      $3C0    Name Table 1
+//$27C0      $40     Attribute Table 1
+//$2800      $3C0    Name Table 2
+//$2BC0      $40     Attribute Table 2
+//$2C00      $3C0    Name Table 3
+//$2FC0      $40     Attribute Table 3
+//$3000      $F00    Mirror of 2000h-2EFFh
+//$3F00      $10     BG Palette
+//$3F10      $10     Sprite Palette
+//$3F20      $E0     Mirror of 3F00h-3F1Fh
 
 
 //appendix 1


### PR DESCRIPTION
Someone's IDE put smart tabs in comments:
![pic](https://i.imgur.com/hGt3GVM.png)