### PR TITLE
[Untested] Use format strings with the semicolon section separator

### DIFF
--- a/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -200,24 +200,7 @@ namespace BizHawk.Client.Common
 		/// Get a string representation of difference
 		/// between current value and the previous one
 		/// </summary>
-		public override string Diff
-		{
-			get
-			{
-				string diff = "";
-				int diffVal = _value - _previous;
-				if (diffVal > 0)
-				{
-					diff = "+";
-				}
-				else if (diffVal < 0)
-				{
-					diff = "-";
-				}
-
-				return $"{diff}{((byte)Math.Abs(diffVal))}";
-			}
-		}
+		public override string Diff => $"{(byte)Math.Abs(_value - _previous):+G;-G;G}";
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -200,7 +200,7 @@ namespace BizHawk.Client.Common
 		/// Get a string representation of difference
 		/// between current value and the previous one
 		/// </summary>
-		public override string Diff => $"{(byte)Math.Abs(_value - _previous):+G;-G;G}";
+		public override string Diff => $"{_value - (short)_previous:+#;-#;0}";
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -231,7 +231,7 @@ namespace BizHawk.Client.Common
 		/// Get a string representation of difference
 		/// between current value and the previous one
 		/// </summary>
-		public override string Diff => (_previous - _value).ToString();
+		public override string Diff => $"{_value - (long)_previous:+#;-#;0}";
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -214,24 +214,7 @@ namespace BizHawk.Client.Common
 		/// Get a string representation of difference
 		/// between current value and the previous one
 		/// </summary>
-		public override string Diff
-		{
-			get
-			{
-				string diff = "";
-				int diffVal = _value - _previous;
-				if (diffVal > 0)
-				{
-					diff = "+";
-				}
-				else if (diffVal < 0)
-				{
-					diff = "-";
-				}
-
-				return $"{diff}{((ushort)Math.Abs(diffVal))}";
-			}
-		}
+		public override string Diff => $"{(ushort)Math.Abs(_value - _previous):+G;-G;G}";
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -214,7 +214,7 @@ namespace BizHawk.Client.Common
 		/// Get a string representation of difference
 		/// between current value and the previous one
 		/// </summary>
-		public override string Diff => $"{(ushort)Math.Abs(_value - _previous):+G;-G;G}";
+		public override string Diff => $"{_value - (int)_previous:+#;-#;0}";
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
@@ -17,7 +17,11 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 			if (format.IndexOf("n") != -1) format = format.Replace("n", $"{read(addr++):X2}h");
 
 			if (format.IndexOf("+d") != -1) format = format.Replace("+d", "d");
-			if (format.IndexOf("d") != -1) format = format.Replace("d", $"{(sbyte)read(addr++):+X2;-X2}h");
+			if (format.IndexOf("d") != -1)
+			{
+				var b = unchecked ((sbyte) read(addr++));
+				format = format.Replace("d", $"{(b < 0 ? '-' : '+')}{(b < 0 ? -b : b):X2}h");
+			}
 
 			return format;
 		}

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/NewDisassembler.cs
@@ -12,29 +12,12 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 			//d immediately succeeds the opcode
 			//n immediate succeeds the opcode and the displacement (if present)
 			//nn immediately succeeds the opcode and the displacement (if present)
-			if (format.IndexOf("nn") != -1)
-			{
-				byte B = read(addr++);
-				byte C = read(addr++);
-				format = format.Replace("nn", string.Format("{0:X4}h", B + C * 256));
-			}
 
-			if (format.IndexOf("n") != -1)
-			{
-				byte B = read(addr++);
-				format = format.Replace("n", string.Format("{0:X2}h", B));
-			}
+			if (format.IndexOf("nn") != -1) format = format.Replace("nn", $"{read(addr++) + (read(addr++) << 8):X4}h"); // LSB is read first
+			if (format.IndexOf("n") != -1) format = format.Replace("n", $"{read(addr++):X2}h");
 
 			if (format.IndexOf("+d") != -1) format = format.Replace("+d", "d");
-
-			if (format.IndexOf("d") != -1)
-			{
-				byte B = read(addr++);
-				bool neg = ((B & 0x80) != 0);
-				char sign = neg ? '-' : '+';
-				int val = neg ? 256 - B : B;
-				format = format.Replace("d", string.Format("{0}{1:X2}h", sign, val));
-			}
+			if (format.IndexOf("d") != -1) format = format.Replace("d", $"{(sbyte)read(addr++):+X2;-X2}h");
 
 			return format;
 		}


### PR DESCRIPTION
[MSDN](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings#the--section-separator) (scroll up, their anchors don't seem to work)

Vastly simplifies these methods. May also simplify [Timestamp.Value getter](https://github.com/TASVideos/BizHawk/blob/a0e623ef1b5dbbb6bcc0b9f51414fcab9b526c42/BizHawk.Emulation.DiscSystem/DiscTypes.cs#L138) and [Sprintf.FormatNumber](https://github.com/TASVideos/BizHawk/blob/ebe789eed22954d1eb40a0ef0a5937181739e1c3/BizHawk.Common/Sprintf.cs#L633) but that would require touching more code.

Edit edit: Fixed, but had to forego the semicolons in Z80 disasm because it's hex and you apparently can't mix custom and preset formats.