### PR TITLE
Use SystemColors, not Color.FromName() to avoid the extra hop

### DIFF
--- a/BizHawk.Client.Common/config/Config.cs
+++ b/BizHawk.Client.Common/config/Config.cs
@@ -406,9 +406,9 @@ namespace BizHawk.Client.Common
 		public bool DisplayRamWatch = false;
 
 		// Hex Editor Colors
-		public Color HexBackgrndColor = Color.FromName("Control");
-		public Color HexForegrndColor = Color.FromName("ControlText");
-		public Color HexMenubarColor = Color.FromName("Control");
+		public Color HexBackgrndColor = SystemColors.Control;
+		public Color HexForegrndColor = SystemColors.ControlText;
+		public Color HexMenubarColor = SystemColors.Control;
 		public Color HexFreezeColor = Color.LightBlue;
 		public Color HexHighlightColor = Color.Pink;
 		public Color HexHighlightFreezeColor = Color.Violet;


### PR DESCRIPTION
And work around unimplemented stuff in the System.Drawing implementation that I'm using