### PR TITLE
Use nameof

### DIFF
--- a/BizHawk.Client.ApiHawk/Classes/Api/EmuApi.cs
+++ b/BizHawk.Client.ApiHawk/Classes/Api/EmuApi.cs
@@ -103,7 +103,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			catch (NotImplementedException)
 			{
-				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement disassemble()");
+				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDisassemblable.Disassemble)}()");
 				return null;
 			}
 		}
@@ -124,7 +124,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			catch (NotImplementedException)
 			{
-				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement getregister()");
+				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.GetCpuFlagsAndRegisters)}()");
 				return null;
 			}
 		}
@@ -147,7 +147,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			catch (NotImplementedException)
 			{
-				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement getregisters()");
+				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.GetCpuFlagsAndRegisters)}()");
 			}
 
 			return table;
@@ -166,7 +166,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			catch (NotImplementedException)
 			{
-				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement setregister()");
+				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.SetCpuRegister)}()");
 			}
 		}
 
@@ -183,7 +183,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			catch (NotImplementedException)
 			{
-				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement totalexecutedcycles()");
+				Console.WriteLine($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.TotalExecutedCycles)}()");
 
 				return 0;
 			}
@@ -201,7 +201,7 @@ namespace BizHawk.Client.ApiHawk
 				return InputPollableCore.IsLagFrame;
 			}
 
-			Console.WriteLine($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+			Console.WriteLine($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			return false;
 		}
 
@@ -213,7 +213,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			else
 			{
-				Console.WriteLine($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+				Console.WriteLine($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			}
 		}
 
@@ -224,7 +224,7 @@ namespace BizHawk.Client.ApiHawk
 				return InputPollableCore.LagCount;
 			}
 
-			Console.WriteLine($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+			Console.WriteLine($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			return 0;
 		}
 
@@ -236,7 +236,7 @@ namespace BizHawk.Client.ApiHawk
 			}
 			else
 			{
-				Console.WriteLine($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+				Console.WriteLine($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			}
 		}
 

--- a/BizHawk.Client.ApiHawk/Classes/Api/MemApiBase.cs
+++ b/BizHawk.Client.ApiHawk/Classes/Api/MemApiBase.cs
@@ -64,7 +64,7 @@ namespace BizHawk.Client.ApiHawk
 				return d.PeekByte(addr);
 			}
 
-			Console.WriteLine("Warning: attempted read of " + addr + " outside the memory size of " + d.Size);
+			Console.WriteLine($"Warning: attempted read of {addr} outside the memory size of {d.Size}");
 			return 0;
 		}
 
@@ -79,7 +79,7 @@ namespace BizHawk.Client.ApiHawk
 				}
 				else
 				{
-					Console.WriteLine("Warning: attempted write to " + addr + " outside the memory size of " + d.Size);
+					Console.WriteLine($"Warning: attempted write to {addr} outside the memory size of {d.Size}");
 				}
 			}
 			else
@@ -166,7 +166,7 @@ namespace BizHawk.Client.ApiHawk
 				if (addr < d.Size)
 					list.Add(d.PeekByte(addr));
 				else { 
-					Console.WriteLine("Warning: Attempted read " + addr + " outside memory domain size of " + d.Size + " in readbyterange()");
+					Console.WriteLine($"Warning: Attempted read {addr} outside memory domain size of {d.Size} in {nameof(ReadByteRange)}()");
 					list.Add(0);
 				}
 			}
@@ -187,7 +187,7 @@ namespace BizHawk.Client.ApiHawk
 					}
 					else
 					{
-						Console.WriteLine("Warning: Attempted write " + addr + " outside memory domain size of " + d.Size + " in writebyterange()");
+						Console.WriteLine($"Warning: Attempted write {addr} outside memory domain size of {d.Size} in {{nameof(WriteByteRange)}}()");
 					}
 				}
 			}
@@ -207,7 +207,7 @@ namespace BizHawk.Client.ApiHawk
 				return BitConverter.ToSingle(bytes, 0);
 			}
 
-			Console.WriteLine("Warning: Attempted read " + addr + " outside memory size of " + d.Size);
+			Console.WriteLine($"Warning: Attempted read {addr} outside memory size of {d.Size}");
 
 			return 0;
 		}
@@ -226,7 +226,7 @@ namespace BizHawk.Client.ApiHawk
 				}
 				else
 				{
-					Console.WriteLine("Warning: Attempted write " + addr + " outside memory size of " + d.Size);
+					Console.WriteLine($"Warning: Attempted write {addr} outside memory size of {d.Size}");
 				}
 			}
 			else

--- a/BizHawk.Client.ApiHawk/Classes/Api/MemApiBase.cs
+++ b/BizHawk.Client.ApiHawk/Classes/Api/MemApiBase.cs
@@ -187,7 +187,7 @@ namespace BizHawk.Client.ApiHawk
 					}
 					else
 					{
-						Console.WriteLine($"Warning: Attempted write {addr} outside memory domain size of {d.Size} in {{nameof(WriteByteRange)}}()");
+						Console.WriteLine($"Warning: Attempted write {addr} outside memory domain size of {d.Size} in {nameof(WriteByteRange)}()");
 					}
 				}
 			}

--- a/BizHawk.Client.Common/OpenAdvanced.cs
+++ b/BizHawk.Client.Common/OpenAdvanced.cs
@@ -60,7 +60,7 @@ namespace BizHawk.Client.Common
 			else if (type == OpenAdvancedTypes.LibretroNoGame) ioa = new OpenAdvanced_LibretroNoGame();
 			else ioa = null;
 			if (ioa == null)
-				throw new InvalidOperationException("IOpenAdvanced deserialization error");
+				throw new InvalidOperationException($"{nameof(IOpenAdvanced)} deserialization error");
 			ioa.Deserialize(token);
 			return ioa;
 		}

--- a/BizHawk.Client.Common/config/ToolDialogSettings.cs
+++ b/BizHawk.Client.Common/config/ToolDialogSettings.cs
@@ -79,7 +79,7 @@ namespace BizHawk.Client.Common
 					return new Point(_wndx.Value, _wndy.Value);
 				}
 
-				throw new InvalidOperationException("TopLeft can not be used when one of the coordinates is null");
+				throw new InvalidOperationException($"{nameof(TopLeft)} can not be used when one of the coordinates is null");
 			}
 		}
 

--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Emu.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Emu.cs
@@ -93,7 +93,7 @@ namespace BizHawk.Client.Common
 			}
 			catch (NotImplementedException)
 			{
-				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement disassemble()");
+				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDisassemblable.Disassemble)}()");
 				return null;
 			}
 		}
@@ -117,7 +117,7 @@ namespace BizHawk.Client.Common
 			}
 			catch (NotImplementedException)
 			{
-				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement getregister()");
+				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.GetCpuFlagsAndRegisters)}()");
 				return 0;
 			}
 		}
@@ -142,7 +142,7 @@ namespace BizHawk.Client.Common
 			}
 			catch (NotImplementedException)
 			{
-				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement getregisters()");
+				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.GetCpuFlagsAndRegisters)}()");
 			}
 
 			return table;
@@ -163,7 +163,7 @@ namespace BizHawk.Client.Common
 			}
 			catch (NotImplementedException)
 			{
-				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement setregister()");
+				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.SetCpuRegister)}()");
 			}
 		}
 
@@ -182,7 +182,7 @@ namespace BizHawk.Client.Common
 			}
 			catch (NotImplementedException)
 			{
-				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement totalexecutedcycles()");
+				Log($"Error: {Emulator.Attributes().CoreName} does not yet implement {nameof(IDebuggable.TotalExecutedCycles)}()");
 
 				return 0;
 			}
@@ -204,7 +204,7 @@ namespace BizHawk.Client.Common
 				return InputPollableCore.IsLagFrame;
 			}
 
-			Log($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+			Log($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			return false;
 		}
 
@@ -218,7 +218,7 @@ namespace BizHawk.Client.Common
 			}
 			else
 			{
-				Log($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+				Log($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			}
 		}
 
@@ -231,7 +231,7 @@ namespace BizHawk.Client.Common
 				return InputPollableCore.LagCount;
 			}
 
-			Log($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+			Log($"Can not get lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			return 0;
 		}
 
@@ -245,7 +245,7 @@ namespace BizHawk.Client.Common
 			}
 			else
 			{
-				Log($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement IInputPollable");
+				Log($"Can not set lag information, {Emulator.Attributes().CoreName} does not implement {nameof(IInputPollable)}");
 			}
 		}
 

--- a/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Client.Common
 			_progressReportWorker = progressReportWorker;
 			if (!Global.Emulator.HasSavestates())
 			{
-				throw new InvalidOperationException("Cannot create a TasMovie against a core that does not implement IStatable");
+				throw new InvalidOperationException($"Cannot create a {nameof(TasMovie)} against a core that does not implement {nameof(IStatable)}");
 			}
 
 			ChangeLog = new TasMovieChangeLog(this);
@@ -74,7 +74,7 @@ namespace BizHawk.Client.Common
 			_progressReportWorker = progressReportWorker;
 			if (!Global.Emulator.HasSavestates())
 			{
-				throw new InvalidOperationException("Cannot create a TasMovie against a core that does not implement IStatable");
+				throw new InvalidOperationException($"Cannot create a {nameof(TasMovie)} against a core that does not implement {nameof(IStatable)}");
 			}
 
 			ChangeLog = new TasMovieChangeLog(this);

--- a/BizHawk.Client.Common/rewind/StreamBlobDatabase.cs
+++ b/BizHawk.Client.Common/rewind/StreamBlobDatabase.cs
@@ -192,7 +192,7 @@ namespace BizHawk.Client.Common
 		{
 			if (_mHead == null)
 			{
-				throw new InvalidOperationException("Attempted to pop from an empty data structure");
+				throw new InvalidOperationException($"Attempted to {nameof(Pop)} from an empty data structure");
 			}
 
 			var ret = _mHead.Value;
@@ -213,7 +213,7 @@ namespace BizHawk.Client.Common
 		{
 			if (_mHead == null)
 			{
-				throw new InvalidOperationException("Attempted to peek from an empty data structure");
+				throw new InvalidOperationException($"Attempted to {nameof(Peek)} from an empty data structure");
 			}
 
 			return _mHead.Value;
@@ -223,7 +223,7 @@ namespace BizHawk.Client.Common
 		{
 			if (_mTail == null)
 			{
-				throw new InvalidOperationException("Attempted to dequeue from an empty data structure");
+				throw new InvalidOperationException($"Attempted to {nameof(Dequeue)} from an empty data structure");
 			}
 
 			var ret = _mTail.Value;

--- a/BizHawk.Client.Common/tools/Watch/Watch.cs
+++ b/BizHawk.Client.Common/tools/Watch/Watch.cs
@@ -46,7 +46,7 @@ namespace BizHawk.Client.Common
 			}
 			else
 			{
-				throw new ArgumentException($"DisplayType {type} is invalid for this type of Watch", nameof(type));
+				throw new ArgumentException($"{nameof(DisplayType)} {type} is invalid for this type of {nameof(Watch)}", nameof(type));
 			}
 		}
 

--- a/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
+++ b/BizHawk.Client.EmuHawk/AVOut/AviWriter.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				throw new ArgumentException("AviWriter only takes its own Codec Tokens!");
+				throw new ArgumentException($"{nameof(AviWriter)} only takes its own {nameof(CodecToken)}s!");
 			}
 		}
 
@@ -321,11 +321,10 @@ namespace BizHawk.Client.EmuHawk
 				int bytes = 0;
 				if (a_bits == 16) bytes = 2;
 				else if (a_bits == 8) bytes = 1;
-				else throw new InvalidOperationException("only 8/16 bits audio are supported by AviWriter and you chose: " + a_bits);
+				else throw new InvalidOperationException($"only 8/16 bits audio are supported by {nameof(AviWriter)} and you chose: {a_bits}");
 				if (a_channels == 1) { }
 				else if (a_channels == 2) { }
-				else throw new InvalidOperationException("only 1/2 channels audio are supported by AviWriter and you chose: " + a_channels);
-
+				else throw new InvalidOperationException($"only 1/2 channels audio are supported by {nameof(AviWriter)} and you chose: {a_channels}");
 				wfex.Init();
 				wfex.nBlockAlign = (ushort)(bytes * a_channels);
 				wfex.nChannels = (ushort)a_channels;
@@ -954,7 +953,7 @@ namespace BizHawk.Client.EmuHawk
 			CodecToken ct = CodecToken.DeSerialize(Global.Config.AVICodecToken);
 			if (ct == null)
 			{
-				throw new Exception("No default AVICodecToken in config!");
+				throw new Exception($"No default {nameof(Global.Config.AVICodecToken)} in config!");
 			}
 
 			_currVideoCodecToken = ct;

--- a/BizHawk.Client.EmuHawk/AVOut/FFmpegWriter.cs
+++ b/BizHawk.Client.EmuHawk/AVOut/FFmpegWriter.cs
@@ -224,7 +224,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				throw new ArgumentException("FFmpegWriter can only take its own codec tokens!");
+				throw new ArgumentException($"{nameof(FFmpegWriter)} can only take its own codec tokens!");
 			}
 		}
 

--- a/BizHawk.Client.EmuHawk/AVOut/GifWriter.cs
+++ b/BizHawk.Client.EmuHawk/AVOut/GifWriter.cs
@@ -99,7 +99,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				throw new ArgumentException("GifWriter only takes its own tokens!");
+				throw new ArgumentException($"{nameof(GifWriter)} only takes its own tokens!");
 			}
 		}
 

--- a/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
+++ b/BizHawk.Client.EmuHawk/AVOut/JMDWriter.cs
@@ -182,7 +182,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (!f.CanWrite)
 				{
-					throw new ArgumentException("Stream must be writable!");
+					throw new ArgumentException($"{nameof(Stream)} must be writable!");
 				}
 
 				this.f = f;

--- a/BizHawk.Client.EmuHawk/CustomControls/InputRoll.cs
+++ b/BizHawk.Client.EmuHawk/CustomControls/InputRoll.cs
@@ -2042,7 +2042,7 @@ namespace BizHawk.Client.EmuHawk
 				// no check will make it crash for user too, not sure which way of alarm we prefer. no alarm at all will cause all sorts of subtle bugs
 				if (ChangedCallback == null)
 				{
-					System.Diagnostics.Debug.Fail("ColumnChangedCallback has died!");
+					System.Diagnostics.Debug.Fail($"{nameof(ColumnChangedCallback)} has died!");
 				}
 				else
 				{

--- a/BizHawk.Client.EmuHawk/CustomControls/VirtualListView.cs
+++ b/BizHawk.Client.EmuHawk/CustomControls/VirtualListView.cs
@@ -398,7 +398,7 @@ namespace BizHawk.Client.EmuHawk
 				if (value == View.LargeIcon ||
 					value == View.SmallIcon) 
 				{
-					throw new ArgumentException("Icon views are invalid for virtual ListViews", "View");
+					throw new ArgumentException($"Icon views are invalid for virtual {nameof(ListView)}s", nameof(View));
 				}
 
 				base.View = value;
@@ -551,7 +551,7 @@ namespace BizHawk.Client.EmuHawk
 						}
 						catch (Exception e)
 						{
-							Debug.WriteLine("Failed to copy text name from client: " + e, "VirtualListView.OnDispInfoNotice");
+							Debug.WriteLine($"Failed to copy text name from client: {e}", $"{nameof(VirtualListView)}.{nameof(OnDispInfoNotice)}");
 						}
 					}
 				}
@@ -705,7 +705,7 @@ namespace BizHawk.Client.EmuHawk
 
 			if (item == null) 
 			{
-				throw new ArgumentException("cannot find item " + idx + " via QueryItem event");
+				throw new ArgumentException($"cannot find item {idx} via {nameof(QueryItem)} event");
 			}
 
 			return item;

--- a/BizHawk.Client.EmuHawk/DisplayManager/Filters/Retro.cs
+++ b/BizHawk.Client.EmuHawk/DisplayManager/Filters/Retro.cs
@@ -249,10 +249,7 @@ namespace BizHawk.Client.EmuHawk.Filters
 		int RSI;
 		Size OutputSize;
 
-		public override string ToString()
-		{
-			return string.Format("RetroShaderPass[#{0}]", RSI);
-		}
+		public override string ToString() => $"{nameof(RetroShaderPass)}[#{RSI}]";
 
 		public RetroShaderPass(RetroShaderChain RSC, int index)
 		{

--- a/BizHawk.Client.EmuHawk/DisplayManager/OSDManager.cs
+++ b/BizHawk.Client.EmuHawk/DisplayManager/OSDManager.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public void Begin(IBlitter blitter)
 		{
-			MessageFont = blitter.GetFontType("MessageFont");
+			MessageFont = blitter.GetFontType(nameof(MessageFont));
 		}
 
 		public Color FixedMessagesColor { get { return Color.FromArgb(Global.Config.MessagesColor); } }

--- a/BizHawk.Client.EmuHawk/GLManager.cs
+++ b/BizHawk.Client.EmuHawk/GLManager.cs
@@ -24,7 +24,7 @@ namespace BizHawk.Client.EmuHawk
 
 		public static void CreateInstance(Bizware.BizwareGL.Drivers.OpenTK.IGL_TK mainContext)
 		{
-			if (Instance != null) throw new InvalidOperationException("Attempt to create more than one GLManager");
+			if (Instance != null) throw new InvalidOperationException($"Attempted to create more than one {nameof(GLManager)}");
 			Instance = new GLManager();
 			Instance.MainContext = mainContext;
 		}

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -234,7 +234,7 @@ namespace BizHawk.Client.EmuHawk
 			if (UnpressState.ContainsKey(button))
 			{
 				if (newState) return;
-				Console.WriteLine("Removing Unpress {0} with newState {1}", button, newState);
+				Console.WriteLine($"Removing Unpress {button} with {nameof(newState)} {newState}");
 				UnpressState.Remove(button);
 				LastState[button] = false;
 				return;

--- a/BizHawk.Client.EmuHawk/LogConsole.cs
+++ b/BizHawk.Client.EmuHawk/LogConsole.cs
@@ -179,7 +179,7 @@ namespace BizHawk.Client.EmuHawk
 				conOut = Win32.CreateFile("CONOUT$", 0x40000000, 2, IntPtr.Zero, 3, 0, IntPtr.Zero);
 
 				if (!Win32.SetStdHandle(-11, conOut))
-				  throw new Exception("SetStdHandle() failed");
+				  throw new Exception($"{nameof(Win32.SetStdHandle)}() failed");
 			}
 
 			//DotNetRewireConout();

--- a/BizHawk.Client.EmuHawk/OpenAdvancedChooser.cs
+++ b/BizHawk.Client.EmuHawk/OpenAdvancedChooser.cs
@@ -91,9 +91,9 @@ namespace BizHawk.Client.EmuHawk
 					CurrentDescription = descr;
 					Console.WriteLine($"core name: {descr.LibraryName} version {descr.LibraryVersion}");
 					Console.WriteLine($"extensions: {descr.ValidExtensions}");
-					Console.WriteLine($"NeedsRomAsPath: {descr.NeedsRomAsPath}");
-					Console.WriteLine($"AcceptsArchives: {descr.NeedsArchives}");
-					Console.WriteLine($"SupportsNoGame: {descr.SupportsNoGame}");
+					Console.WriteLine($"{nameof(descr.NeedsRomAsPath)}: {descr.NeedsRomAsPath}");
+					Console.WriteLine($"{nameof(descr.NeedsArchives)}: {descr.NeedsArchives}");
+					Console.WriteLine($"{nameof(descr.SupportsNoGame)}: {descr.SupportsNoGame}");
 					
 					foreach (var v in descr.Variables.Values)
 						Console.WriteLine(v);

--- a/BizHawk.Client.EmuHawk/config/PSX/PSXOptions.cs
+++ b/BizHawk.Client.EmuHawk/config/PSX/PSXOptions.cs
@@ -178,12 +178,12 @@ namespace BizHawk.Client.EmuHawk
 
 		private void LinkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			MessageBox.Show(@"These options control BizHawk's Display Options to make it act quite a lot like Mednafen:
+			MessageBox.Show($@"These options control BizHawk's Display Options to make it act quite a lot like Mednafen:
 
-DispManagerAR = System (Use emulator-recommended AR)
-DispFixAspectRatio = true (Maintain aspect ratio [letterbox main window as needed])
-DispFinalFilter = bilinear (Like Mednafen)
-DispFixScaleInteger = false (Generally unwanted with bilinear filtering)
+{nameof(Global.Config.DispManagerAR)} = System (Use emulator-recommended AR)
+{nameof(Global.Config.DispFixAspectRatio)} = true (Maintain aspect ratio [letterbox main window as needed])
+{nameof(Global.Config.DispFinalFilter)} = bilinear (Like Mednafen)
+{nameof(Global.Config.DispFixScaleInteger)} = false (Generally unwanted with bilinear filtering)
 
 This is a good place to write that Mednafen's default behaviour is fantastic for gaming!
 But: 1. we think we improved on it a tiny bit with the tweaked mode

--- a/BizHawk.Client.EmuHawk/tools/BatchRunner.cs
+++ b/BizHawk.Client.EmuHawk/tools/BatchRunner.cs
@@ -81,12 +81,12 @@ namespace BizHawk.Client.EmuHawk
 		void OnLoadError(object sender, RomLoader.RomErrorArgs e)
 		{
 			current.Status = Result.EStatus.ErrorOnLoad;
-			current.Messages.Add(string.Format("OnLoadError: {0}, {1}, {2}", e.AttemptedCoreLoad, e.Message, e.Type.ToString()));
+			current.Messages.Add($"{nameof(OnLoadError)}: {e.AttemptedCoreLoad}, {e.Message}, {e.Type}");
 		}
 
 		void CommMessage(string msg)
 		{
-			current.Messages.Add(string.Format("CommMessage: {0}", msg));
+			current.Messages.Add($"{nameof(CommMessage)}: {msg}");
 		}
 
 		int? ChooseArchive(HawkFile hf)

--- a/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (!typeof(IToolForm).IsAssignableFrom(toolType))
 			{
-				throw new ArgumentException($"Type {toolType.Name} does not implement IToolForm.");
+				throw new ArgumentException($"Type {toolType.Name} does not implement {nameof(IToolForm)}.");
 			}
 			
 			// The type[] in parameter is used to avoid an ambigous name exception
@@ -236,7 +236,7 @@ namespace BizHawk.Client.EmuHawk
 
 			if (dest == null)
 			{
-				throw new InvalidOperationException("IToolFormAutoConfig must have menu to bind to!");
+				throw new InvalidOperationException($"{nameof(IToolFormAutoConfig)} must have menu to bind to!");
 			}
 
 			int idx = dest.Count;
@@ -631,7 +631,7 @@ namespace BizHawk.Client.EmuHawk
 						tool = Activator.CreateInstanceFrom(dllPath, "BizHawk.Client.EmuHawk.CustomMainForm").Unwrap() as IExternalToolForm;
 						if (tool == null)
 						{
-							MessageBox.Show("It seems that the object CustomMainForm does not implement IExternalToolForm. Please review the code.", "No, no, no. Wrong Way !", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+							MessageBox.Show($"It seems that the object CustomMainForm does not implement {nameof(IExternalToolForm)}. Please review the code.", "No, no, no. Wrong Way !", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
 							return null;
 						}
 					}

--- a/BizHawk.Client.MultiHawk/Input/Input.cs
+++ b/BizHawk.Client.MultiHawk/Input/Input.cs
@@ -221,7 +221,7 @@ namespace BizHawk.Client.MultiHawk
 			if (UnpressState.ContainsKey(button))
 			{
 				if (newState) return;
-				Console.WriteLine("Removing Unpress {0} with newState {1}", button, newState);
+				Console.WriteLine($"Removing Unpress {button} with {nameof(newState)} {newState}");
 				UnpressState.Remove(button);
 				LastState[button] = false;
 				return;

--- a/BizHawk.Common/AWEMemoryStream.cs
+++ b/BizHawk.Common/AWEMemoryStream.cs
@@ -95,7 +95,7 @@ namespace BizHawk.Common
 			set
 			{
 				if (!Ensure(value + 1))
-					throw new OutOfMemoryException("Couldn't set AWEMemoryStream to specified Position");
+					throw new OutOfMemoryException($"Couldn't set {nameof(AWEMemoryStream)} to specified Position");
 				mPosition = value;
 			}
 		}
@@ -128,7 +128,7 @@ namespace BizHawk.Common
 		public override void SetLength(long value)
 		{
 			if (!Ensure(value))
-				throw new OutOfMemoryException("Couldn't set AWEMemoryStream to specified Length");
+				throw new OutOfMemoryException($"Couldn't set {nameof(AWEMemoryStream)} to specified Length");
 			mLength = value;
 		}
 
@@ -151,7 +151,7 @@ namespace BizHawk.Common
 				{
 					mCurrBlock = block;
 					if (!mBlocks[block].Map(mWindow))
-						throw new Exception("Couldn't map required memory for AWEMemoryStream.Write");
+						throw new Exception($"Couldn't map required memory for {nameof(AWEMemoryStream)}.{nameof(AWEMemoryStream.Write)}");
 				}
 				Marshal.Copy(IntPtr.Add(mWindow, blockOfs), buffer, offset, todo);
 				count -= todo;
@@ -165,7 +165,7 @@ namespace BizHawk.Common
 		{
 			long end = mPosition + count;
 			if (!Ensure(end))
-				throw new OutOfMemoryException("Couldn't reserve required resources for AWEMemoryStream.Write");
+				throw new OutOfMemoryException($"Couldn't reserve required resources for {nameof(AWEMemoryStream)}.{nameof(AWEMemoryStream.Write)}");
 			SetLength(end);
 			while (count > 0)
 			{
@@ -181,7 +181,7 @@ namespace BizHawk.Common
 				{
 					mCurrBlock = block;
 					if (!mBlocks[block].Map(mWindow))
-						throw new Exception("Couldn't map required memory for AWEMemoryStream.Write");
+						throw new Exception($"Couldn't map required memory for {nameof(AWEMemoryStream)}.{nameof(AWEMemoryStream.Write)}");
 				}
 				Marshal.Copy(buffer, offset, IntPtr.Add(mWindow, blockOfs), todo);
 				count -= todo;

--- a/BizHawk.Common/BizInvoke/DynamicLibraryImportResolver.cs
+++ b/BizHawk.Common/BizInvoke/DynamicLibraryImportResolver.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Common.BizInvoke
 		public DynamicLibraryImportResolver(string dllName)
 		{
 			_p = libLoader.LoadPlatformSpecific(dllName);
-			if (_p == IntPtr.Zero) throw new InvalidOperationException("null pointer returned by LoadPlatformSpecific");
+			if (_p == IntPtr.Zero) throw new InvalidOperationException($"null pointer returned by {nameof(PlatformLinkedLibSingleton.PlatformLinkedLibManager.LoadPlatformSpecific)}");
 		}
 
 		public IntPtr Resolve(string entryPoint)

--- a/BizHawk.Common/BizInvoke/MemoryBlock.cs
+++ b/BizHawk.Common/BizInvoke/MemoryBlock.cs
@@ -89,7 +89,7 @@ namespace BizHawk.Common.BizInvoke
 				Kernel32.FileMapProtection.PageExecuteReadWrite | Kernel32.FileMapProtection.SectionCommit, (uint)(size >> 32), (uint)size, null);
 
 			if (_handle == IntPtr.Zero)
-				throw new InvalidOperationException("CreateFileMapping() returned NULL");
+				throw new InvalidOperationException($"{nameof(Kernel32.CreateFileMapping)}() returned NULL");
 			Start = start;
 			End = start + size;
 			Size = size;
@@ -106,7 +106,7 @@ namespace BizHawk.Common.BizInvoke
 			if (Kernel32.MapViewOfFileEx(_handle, Kernel32.FileMapAccessType.Read | Kernel32.FileMapAccessType.Write | Kernel32.FileMapAccessType.Execute,
 				0, 0, Z.UU(Size), Z.US(Start)) != Z.US(Start))
 			{
-				throw new InvalidOperationException("MapViewOfFileEx() returned NULL");
+				throw new InvalidOperationException($"{nameof(Kernel32.MapViewOfFileEx)}() returned NULL");
 			}
 			ProtectAll();
 			Active = true;
@@ -120,7 +120,7 @@ namespace BizHawk.Common.BizInvoke
 			if (!Active)
 				throw new InvalidOperationException("Not active");
 			if (!Kernel32.UnmapViewOfFile(Z.US(Start)))
-				throw new InvalidOperationException("UnmapViewOfFile() returned NULL");
+				throw new InvalidOperationException($"{nameof(Kernel32.UnmapViewOfFile)}() returned NULL");
 			Active = false;
 		}
 
@@ -175,7 +175,7 @@ namespace BizHawk.Common.BizInvoke
 			// that to complicate things
 			Kernel32.MemoryProtection old;
 			if (!Kernel32.VirtualProtect(Z.UU(Start), Z.UU(Size), Kernel32.MemoryProtection.READONLY, out old))
-				throw new InvalidOperationException("VirtualProtect() returned FALSE!");
+				throw new InvalidOperationException($"{nameof(Kernel32.VirtualProtect)}() returned FALSE!");
 
 			_snapshot = new byte[Size];
 			var ds = new MemoryStream(_snapshot, true);
@@ -197,7 +197,7 @@ namespace BizHawk.Common.BizInvoke
 			// temporarily switch the entire block to `R`
 			Kernel32.MemoryProtection old;
 			if (!Kernel32.VirtualProtect(Z.UU(Start), Z.UU(Size), Kernel32.MemoryProtection.READONLY, out old))
-				throw new InvalidOperationException("VirtualProtect() returned FALSE!");
+				throw new InvalidOperationException($"{nameof(Kernel32.VirtualProtect)}() returned FALSE!");
 			var ret = WaterboxUtils.Hash(GetStream(Start, Size, false));
 			ProtectAll();
 			return ret;
@@ -232,7 +232,7 @@ namespace BizHawk.Common.BizInvoke
 					ulong zend = GetStartAddr(i + 1);
 					Kernel32.MemoryProtection old;
 					if (!Kernel32.VirtualProtect(Z.UU(zstart), Z.UU(zend - zstart), p, out old))
-						throw new InvalidOperationException("VirtualProtect() returned FALSE!");
+						throw new InvalidOperationException($"{nameof(Kernel32.VirtualProtect)}() returned FALSE!");
 					ps = i + 1;
 				}
 			}
@@ -261,7 +261,7 @@ namespace BizHawk.Common.BizInvoke
 				Kernel32.MemoryProtection old;
 				if (!Kernel32.VirtualProtect(Z.UU(computedStart),
 					Z.UU(computedLength), p, out old))
-					throw new InvalidOperationException("VirtualProtect() returned FALSE!");
+					throw new InvalidOperationException($"{nameof(Kernel32.VirtualProtect)}() returned FALSE!");
 			}
 		}
 
@@ -302,7 +302,7 @@ namespace BizHawk.Common.BizInvoke
 			private void EnsureNotDisposed()
 			{
 				if (_owner.Start == 0)
-					throw new ObjectDisposedException("MemoryBlock");
+					throw new ObjectDisposedException(nameof(MemoryBlock));
 			}
 
 			private MemoryBlock _owner;

--- a/BizHawk.Common/HawkFile.cs
+++ b/BizHawk.Common/HawkFile.cs
@@ -131,7 +131,7 @@ namespace BizHawk.Common
 		{
 			if (_boundStream == null)
 			{
-				throw new InvalidOperationException("HawkFile: Can't call GetStream() before youve successfully bound something!");
+				throw new InvalidOperationException($"{nameof(HawkFile)}: Can't call {nameof(GetStream)}() before you've successfully bound something!");
 			}
 
 			return _boundStream;
@@ -217,7 +217,7 @@ namespace BizHawk.Common
 		{
 			if (_rootPath != null)
 			{
-				throw new InvalidOperationException("Don't reopen a HawkFile.");
+				throw new InvalidOperationException($"Don't reopen a {nameof(HawkFile)}.");
 			}
 
 			string autobind = null;
@@ -334,7 +334,7 @@ namespace BizHawk.Common
 			_extractor.ExtractFile(archiveIndex, _boundStream);
 			_boundStream.Position = 0;
 			_memberPath = _archiveItems[index].Name; // TODO - maybe go through our own list of names? maybe not, its indexes dont match..
-			Console.WriteLine("HawkFile bound " + CanonicalFullPath);
+			Console.WriteLine($"{nameof(HawkFile)} bound {CanonicalFullPath}");
 			_boundIndex = archiveIndex;
 			return this;
 		}
@@ -360,7 +360,7 @@ namespace BizHawk.Common
 		private void BindRoot()
 		{
 			_boundStream = _rootStream;
-			Console.WriteLine("HawkFile bound " + CanonicalFullPath);
+			Console.WriteLine($"{nameof(HawkFile)} bound {CanonicalFullPath}");
 		}
 
 		/// <summary>

--- a/BizHawk.Common/NDBDatabase.cs
+++ b/BizHawk.Common/NDBDatabase.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Common
 			}
 
 			if (FreeWatermark == BlockCount)
-				throw new OutOfMemoryException("NDBDatabase out of reserved space");
+				throw new OutOfMemoryException($"{nameof(NDBDatabase)} out of reserved space");
 
 			var b = new Block() { Number = FreeWatermark };
 			FreeWatermark++;

--- a/BizHawk.Common/QuickCollections.cs
+++ b/BizHawk.Common/QuickCollections.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Common
 		public void Enqueue(T item)
 		{
 			if (size >= buffer.Length)
-				throw new Exception("QuickQueue capacity breached!");
+				throw new Exception($"{nameof(QuickQueue<T>)} capacity breached!");
 
 			buffer[tail] = item;
 			tail = (tail + 1) % buffer.Length;
@@ -82,7 +82,7 @@ namespace BizHawk.Common
 		public T Dequeue()
 		{
 			if (size == 0)
-				throw new Exception("QuickQueue is empty!");
+				throw new Exception($"{nameof(QuickQueue<T>)} is empty!");
 
 			T item = buffer[head];
 			head = (head + 1) % buffer.Length;

--- a/BizHawk.Common/Serializer.cs
+++ b/BizHawk.Common/Serializer.cs
@@ -658,7 +658,7 @@ namespace BizHawk.Common
 			{
 				if (name.Length > length)
 				{
-					throw new InvalidOperationException("SyncFixedString too long");
+					throw new InvalidOperationException($"{nameof(SyncFixedString)} too long");
 				}
 
 				var buf = val.ToCharArray();

--- a/BizHawk.Common/SwitcherStream.cs
+++ b/BizHawk.Common/SwitcherStream.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Common
 						return;
 					}
 
-					throw new InvalidOperationException("Cannot set position to non-zero in a SwitcherStream with DenySeekHack=true");
+					throw new InvalidOperationException($"Cannot set position to non-zero in a {nameof(SwitcherStream)} with {DenySeekHack}=true");
 				}
 
 				_currStream.Position = value;
@@ -79,7 +79,7 @@ namespace BizHawk.Common
 					return 0;
 				}
 
-				throw new InvalidOperationException("Cannot call Seek with non-zero offset or non-Begin origin in a SwitcherStream with DenySeekHack=true");
+				throw new InvalidOperationException($"Cannot call {nameof(Seek)} with non-zero offset or non-{nameof(SeekOrigin.Begin)} origin in a {nameof(SwitcherStream)} with {nameof(DenySeekHack)}=true");
 			}
 
 			return _currStream.Seek(offset, origin);

--- a/BizHawk.Emulation.Common/Base Implementations/CallbackBasedTraceBuffer.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/CallbackBasedTraceBuffer.cs
@@ -31,7 +31,7 @@ namespace BizHawk.Emulation.Common
 			}
 			catch (NotImplementedException)
 			{
-				throw new InvalidOperationException("GetCpuFlagsAndRegisters is required");
+				throw new InvalidOperationException($"{nameof(IDebuggable.GetCpuFlagsAndRegisters)} is required");
 			}
 
 			Header = "Instructions";

--- a/BizHawk.Emulation.Common/Base Implementations/SimpleSyncSoundProvider.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/SimpleSyncSoundProvider.cs
@@ -29,7 +29,7 @@ namespace BizHawk.Emulation.Common.Base_Implementations
 		{
 			if (_nsamp != 0)
 			{
-				Console.WriteLine("Warning: Samples disappeared from SimpleSyncSoundProvider");
+				Console.WriteLine($"Warning: Samples disappeared from {nameof(SimpleSyncSoundProvider)}");
 			}
 
 			if (_buffer.Length < nsamp * 2)

--- a/BizHawk.Emulation.Common/Interfaces/Services/IDebuggable.cs
+++ b/BizHawk.Emulation.Common/Interfaces/Services/IDebuggable.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Emulation.Common
 			}
 			else if (bitSize > 64 || bitSize == 0)
 			{
-				throw new System.ArgumentOutOfRangeException(nameof(bitSize), "BitSize must be in 1..64");
+				throw new System.ArgumentOutOfRangeException(nameof(bitSize), $"{nameof(BitSize)} must be in 1..64");
 			}
 			else
 			{

--- a/BizHawk.Emulation.Common/Sound/Utilities/SpeexResampler.cs
+++ b/BizHawk.Emulation.Common/Sound/Utilities/SpeexResampler.cs
@@ -280,13 +280,13 @@ namespace BizHawk.Emulation.Common
 				case LibSpeexDSP.RESAMPLER_ERR.SUCCESS:
 					return;
 				case LibSpeexDSP.RESAMPLER_ERR.ALLOC_FAILED:
-					throw new InsufficientMemoryException("LibSpeexDSP: Alloc failed");
+					throw new InsufficientMemoryException($"{nameof(LibSpeexDSP)}: Alloc failed");
 				case LibSpeexDSP.RESAMPLER_ERR.BAD_STATE:
-					throw new Exception("LibSpeexDSP: Bad state");
+					throw new Exception($"{nameof(LibSpeexDSP)}: Bad state");
 				case LibSpeexDSP.RESAMPLER_ERR.INVALID_ARG:
-					throw new ArgumentException("LibSpeexDSP: Bad Argument");
+					throw new ArgumentException($"{nameof(LibSpeexDSP)}: Bad Argument");
 				case LibSpeexDSP.RESAMPLER_ERR.PTR_OVERLAP:
-					throw new Exception("LibSpeexDSP: Buffers cannot overlap");
+					throw new Exception($"{nameof(LibSpeexDSP)}: Buffers cannot overlap");
 			}
 		}
 
@@ -304,7 +304,7 @@ namespace BizHawk.Emulation.Common
 		{
 			if (drainer != null && input != null)
 			{
-				throw new ArgumentException("Can't autofetch without being an ISyncSoundProvider?");
+				throw new ArgumentException($"Can't autofetch without being an {nameof(ISoundProvider)}?");
 			}
 
 			LibSpeexDSP.RESAMPLER_ERR err = LibSpeexDSP.RESAMPLER_ERR.SUCCESS;
@@ -312,7 +312,7 @@ namespace BizHawk.Emulation.Common
 
 			if (_st == IntPtr.Zero)
 			{
-				throw new Exception("LibSpeexDSP returned null!");
+				throw new Exception($"{nameof(LibSpeexDSP)} returned null!");
 			}
 
 			CheckError(err);

--- a/BizHawk.Emulation.DiscSystem/API_MednaDisc.cs
+++ b/BizHawk.Emulation.DiscSystem/API_MednaDisc.cs
@@ -17,11 +17,11 @@ namespace BizHawk.Emulation.DiscSystem
 		public MednaDisc(string pathToDisc)
 		{
 			if (!IsLibraryAvailable)
-				throw new InvalidOperationException("MednaDisc library is not available!");
+				throw new InvalidOperationException($"{nameof(MednaDisc)} library is not available!");
 
 			handle = mednadisc_LoadCD(pathToDisc);
 			if (handle == IntPtr.Zero)
-				throw new InvalidOperationException("Failed to load MednaDisc: " + pathToDisc);
+				throw new InvalidOperationException($"Failed to load {nameof(MednaDisc)}: {pathToDisc}");
 
 			//read the mednafen toc
 			TOCTracks = new MednadiscTOCTrack[101];

--- a/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscFormats/CCD_format.cs
@@ -250,7 +250,7 @@ namespace BizHawk.Emulation.DiscSystem
 			ccdf.DataTracksScrambled = discSection.FetchOrDefault(0, "DATATRACKSSCRAMBLED");
 			ccdf.CDTextLength = discSection.FetchOrDefault(0, "CDTEXTLENGTH");
 
-			if (ccdf.DataTracksScrambled==1) throw new CCDParseException("Malformed CCD format: DataTracksScrambled=1 not supported. Please report this, so we can understand what it means.");
+			if (ccdf.DataTracksScrambled==1) throw new CCDParseException($"Malformed CCD format: {nameof(ccdf.DataTracksScrambled)}=1 not supported. Please report this, so we can understand what it means.");
 
 			for (int i = 2; i < sections.Count; i++)
 			{

--- a/BizHawk.Emulation.DiscSystem/DiscMountJob.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscMountJob.cs
@@ -52,7 +52,7 @@ namespace BizHawk.Emulation.DiscSystem
 			switch (IN_DiscInterface)
 			{
 				case DiscInterface.LibMirage:
-					throw new NotSupportedException("LibMirage not supported yet");
+					throw new NotSupportedException($"{nameof(DiscInterface.LibMirage)} not supported yet");
 				case DiscInterface.BizHawk:
 					RunBizHawk();
 					break;

--- a/BizHawk.Emulation.DiscSystem/DiscStream.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscStream.cs
@@ -80,7 +80,7 @@ namespace BizHawk.Emulation.DiscSystem
 					dsr.Policy.UserData2048Mode = DiscSectorReaderPolicy.EUserData2048Mode.AssumeMode2_Form1;
 					break;
 				default:
-					throw new NotSupportedException("Unsupported EDiscStreamView");
+					throw new NotSupportedException($"Unsupported {nameof(EDiscStreamView)}");
 			}
 
 

--- a/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscStructure_From_DiscTOC_Job.cs
+++ b/BizHawk.Emulation.DiscSystem/Internal/Jobs/Synthesize_DiscStructure_From_DiscTOC_Job.cs
@@ -22,7 +22,7 @@ namespace BizHawk.Emulation.DiscSystem
 			session.Number = 1;
 
 			if (TOCRaw.FirstRecordedTrackNumber != 1)
-				throw new InvalidOperationException("Unsupported: FirstRecordedTrackNumber != 1");
+				throw new InvalidOperationException($"Unsupported: {nameof(TOCRaw.FirstRecordedTrackNumber)} != 1");
 
 			//add a lead-in track
 			session.Tracks.Add(new DiscStructure.Track()

--- a/Bizware/BizHawk.Bizware.BizwareGL.GdiPlus/GdiPlusGuiRenderer.cs
+++ b/Bizware/BizHawk.Bizware.BizwareGL.GdiPlus/GdiPlusGuiRenderer.cs
@@ -146,7 +146,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.GdiPlus
 		public void End()
 		{
 			if (!IsActive)
-				throw new InvalidOperationException("GuiRenderer is not active!");
+				throw new InvalidOperationException($"{nameof(GuiRenderer)} is not active!");
 			IsActive = false;
 			if (CurrentImageAttributes != null)
 			{
@@ -202,7 +202,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.GdiPlus
 			var tw = tex.Opaque as IGL_GdiPlus.TextureWrapper;
 			//TODO - we can support bicubic for the final presentation..
 			if ((int)tw.MagFilter != (int)tw.MinFilter)
-				throw new InvalidOperationException("tw.MagFilter != tw.MinFilter");
+				throw new InvalidOperationException($"{nameof(tw)}.{nameof(tw.MagFilter)} != {nameof(tw)}.{nameof(tw.MinFilter)}");
 			if (tw.MagFilter == TextureMagFilter.Linear)
 				g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Bilinear;
 			if (tw.MagFilter == TextureMagFilter.Nearest)

--- a/Bizware/BizHawk.Bizware.BizwareGL.OpenTK/IGL_TK.cs
+++ b/Bizware/BizHawk.Bizware.BizwareGL.OpenTK/IGL_TK.cs
@@ -548,7 +548,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.OpenTK
 			GL.DrawBuffers(1, buffers);
 
 			if (GL.Ext.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
-				throw new InvalidOperationException("Error creating framebuffer (at CheckFramebufferStatus)");
+				throw new InvalidOperationException($"Error creating framebuffer (at {nameof(GL.Ext.CheckFramebufferStatus)})");
 
 			//since we're done configuring unbind this framebuffer, to return to the default
 			GL.Ext.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
@@ -732,7 +732,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.OpenTK
 			errcode = GL.GetError();
 			if (errcode != ErrorCode.NoError)
 				if (required)
-					throw new InvalidOperationException("Error compiling shader (ShaderSource) " + errcode);
+					throw new InvalidOperationException($"Error compiling shader ({nameof(GL.ShaderSource)}) {errcode}");
 				else success = false;
 
 			GL.CompileShader(sid);
@@ -742,7 +742,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.OpenTK
 
 			if (errcode != ErrorCode.NoError)
 			{
-				string message = "Error compiling shader (CompileShader) " + errcode + "\r\n\r\n" + resultLog;
+				string message = $"Error compiling shader ({nameof(GL.CompileShader)}) {errcode}\r\n\r\n{resultLog}";
 				if (required)
 					throw new InvalidOperationException(message);
 				else
@@ -757,7 +757,7 @@ namespace BizHawk.Bizware.BizwareGL.Drivers.OpenTK
 
 			if (n == 0)
 				if (required)
-					throw new InvalidOperationException("Error compiling shader (CompileShader )" + "\r\n\r\n" + resultLog);
+					throw new InvalidOperationException($"Error compiling shader ({nameof(GL.GetShader)})\r\n\r\n{resultLog}");
 				else success = false;
 
 			return success;

--- a/Bizware/BizHawk.Bizware.BizwareGL/ArtManager.cs
+++ b/Bizware/BizHawk.Bizware.BizwareGL/ArtManager.cs
@@ -27,7 +27,7 @@ namespace BizHawk.Bizware.BizwareGL
 		public void Open()
 		{
 			AssertIsOpen(false);
-			if (IsClosedForever) throw new InvalidOperationException("ArtManager instance has been closed forever!");
+			if (IsClosedForever) throw new InvalidOperationException($"{nameof(ArtManager)} instance has been closed forever!");
 			IsOpened = true;
 		}
 
@@ -140,7 +140,7 @@ namespace BizHawk.Bizware.BizwareGL
 		/// <summary>
 		/// Throws an exception if the instance is not open
 		/// </summary>
-		private void AssertIsOpen(bool state) { if (IsOpened != state) throw new InvalidOperationException("ArtManager instance is not open!"); }
+		private void AssertIsOpen(bool state) { if (IsOpened != state) throw new InvalidOperationException($"{nameof(ArtManager)} instance is not open!"); }
 
 		public IGL Owner { get; private set; }
 

--- a/Bizware/BizHawk.Bizware.BizwareGL/BitmapBuffer.cs
+++ b/Bizware/BizHawk.Bizware.BizwareGL/BitmapBuffer.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Bizware.BizwareGL
 		public BitmapData LockBits() //TODO - add read/write semantic, for wraps
 		{
 			if(CurrLock != null)
-				throw new InvalidOperationException("BitmapBuffer can only be locked once!");
+				throw new InvalidOperationException($"{nameof(BitmapBuffer)} can only be locked once!");
 
 			if (WrappedBitmap != null)
 			{

--- a/Bizware/BizHawk.Bizware.BizwareGL/GuiRenderer.cs
+++ b/Bizware/BizHawk.Bizware.BizwareGL/GuiRenderer.cs
@@ -180,7 +180,7 @@ namespace BizHawk.Bizware.BizwareGL
 		public void End()
 		{
 			if (!IsActive)
-				throw new InvalidOperationException("GuiRenderer is not active!");
+				throw new InvalidOperationException($"{nameof(GuiRenderer)} is not active!");
 			IsActive = false;
 		}
 


### PR DESCRIPTION
Prevents type/method/etc. identifiers and their string representations in literals becoming mismatched, which already happened and I had to dig through blames to check what the correct field was.

see also #1514