### PR TITLE
Remaining string interpolation (excluding BizHawk.Emulation.Cores)

### DIFF
--- a/BizHawk.Client.ApiHawk/Classes/ClientApi.cs
+++ b/BizHawk.Client.ApiHawk/Classes/ClientApi.cs
@@ -161,7 +161,7 @@ namespace BizHawk.Client.ApiHawk
 		/// <param name="name">Savetate friendly name</param>
 		public static void LoadState(string name)
 		{
-			InvokeMainFormMethod("LoadState", new object[] { Path.Combine(PathManager.GetSaveStatePath(Global.Game), $"{name}.{"State"}"), name, false, false });
+			InvokeMainFormMethod("LoadState", new object[] { Path.Combine(PathManager.GetSaveStatePath(Global.Game), $"{name}.State"), name, false, false });
 		}
 
 
@@ -250,7 +250,7 @@ namespace BizHawk.Client.ApiHawk
 		/// <param name="name">Savetate friendly name</param>
 		public static void SaveState(string name)
 		{
-			InvokeMainFormMethod("SaveState", new object[] { Path.Combine(PathManager.GetSaveStatePath(Global.Game), $"{name}.{"State"}"), name, false });
+			InvokeMainFormMethod("SaveState", new object[] { Path.Combine(PathManager.GetSaveStatePath(Global.Game), $"{name}.State"), name, false });
 		}
 
 		/// <summary>

--- a/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -190,7 +190,7 @@ namespace BizHawk.Client.Common
 				case DisplayType.Signed:
 					return ((sbyte)val).ToString();
 				case DisplayType.Hex:
-					return val.ToHexString(2);
+					return $"{val:X2}";
 				case DisplayType.Binary:
 					return Convert.ToString(val, 2).PadLeft(8, '0').Insert(4, " ");
 			}

--- a/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -215,7 +215,7 @@ namespace BizHawk.Client.Common
 				case DisplayType.Signed:
 					return ((int)val).ToString();
 				case DisplayType.Hex:
-					return val.ToHexString(8);
+					return $"{val:X8}";
 				case DisplayType.FixedPoint_20_12:
 					return $"{(int)val / 4096.0:0.######}";
 				case DisplayType.FixedPoint_16_16:

--- a/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -202,7 +202,7 @@ namespace BizHawk.Client.Common
 				case DisplayType.Signed:
 					return ((short)val).ToString();
 				case DisplayType.Hex:
-					return val.ToHexString(4);
+					return $"{val:X4}";
 				case DisplayType.FixedPoint_12_4:
 					return $"{val / 16.0:F4}";
 				case DisplayType.Binary:

--- a/BizHawk.Client.DBMan/DATTools/DATConverter.cs
+++ b/BizHawk.Client.DBMan/DATTools/DATConverter.cs
@@ -120,7 +120,7 @@ namespace BizHawk.Client.DBMan
 			{
 				if (s.ToString().Trim() == "")
 				{
-					MessageBox.Show("The selected file: " + s.ToString() + "Cannot be found.\n\nSort this out and try again");
+					MessageBox.Show($"The selected file: {s}Cannot be found.\n\nSort this out and try again");
 					return;
 				}
 
@@ -140,9 +140,7 @@ namespace BizHawk.Client.DBMan
 				res = dp.ParseDAT(files.ToArray());
 			}
 
-			string fName = "gamedb_" + 
-				GameDB.GetSystemCode((SystemType)Enum.Parse(typeof(SystemType), comboBoxSystemSelect.SelectedValue.ToString())) +
-				"_DevExport_" + DateTime.UtcNow.ToString("yyyy-MM-dd_HH_mm_ss") + ".txt";
+			string fName = $"gamedb_{GameDB.GetSystemCode((SystemType)Enum.Parse(typeof(SystemType), comboBoxSystemSelect.SelectedValue.ToString()))}_DevExport_{DateTime.UtcNow:yyyy-MM-dd_HH_mm_ss}.txt";
 
 			try
 			{
@@ -150,7 +148,7 @@ namespace BizHawk.Client.DBMan
 			}
 			catch (Exception ex)
 			{
-				MessageBox.Show("Error writing file: " + fName + "\n\n" + ex.Message);
+				MessageBox.Show($"Error writing file: {fName}\n\n{ex.Message}");
 			}
 
 		}

--- a/BizHawk.Client.DBMan/DATTools/NOINTROParser.cs
+++ b/BizHawk.Client.DBMan/DATTools/NOINTROParser.cs
@@ -60,9 +60,9 @@ namespace BizHawk.Client.DBMan
 				// start comment block
 				List<string> comments = new List<string>
 				{
-					"Type:\t" + "NO-INTRO",
-					"Source:\t" + description,
-					"FileGen:\t" + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + " (UTC)",
+					"Type:\tNO-INTRO",
+					$"Source:\t{description}",
+					$"FileGen:\t{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} (UTC)",
 				};
 
 				AddCommentBlock(comments.ToArray());

--- a/BizHawk.Client.DBMan/DATTools/TOSECParser.cs
+++ b/BizHawk.Client.DBMan/DATTools/TOSECParser.cs
@@ -61,9 +61,9 @@ namespace BizHawk.Client.DBMan
 				// start comment block
 				List<string> comments = new List<string>
 				{
-					"Type:\t" + category,
-					"Source:\t" + description,
-					"FileGen:\t" + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + " (UTC)",
+					$"Type:\t{category}",
+					$"Source:\t{description}",
+					$"FileGen:\t{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} (UTC)",
 				};
 
 				AddCommentBlock(comments.ToArray());

--- a/BizHawk.Client.DBMan/DB.cs
+++ b/BizHawk.Client.DBMan/DB.cs
@@ -36,7 +36,7 @@ namespace BizHawk.Client.DBMan
 			}
 		}
 		
-		public string SizeFriendly { get { return string.Format("{0} bytes ({1}k)", Size, Size / 1024); } }
+		public string SizeFriendly => $"{Size} bytes ({Size >> 10}k)";
 		public bool New { get { return (Created > Modified); } }
 
 		public string NameWithTheFlipped

--- a/BizHawk.Client.DBMan/RomHasher.cs
+++ b/BizHawk.Client.DBMan/RomHasher.cs
@@ -190,10 +190,7 @@ namespace BizHawk.Client.DBMan
 			}
 		}
 
-		static string Hash_CRC32(byte[] data)
-		{
-			return string.Format("{0:X8}", CRC32.Calculate(data));
-		}
+		static string Hash_CRC32(byte[] data) => $"{CRC32.Calculate(data):X8}";
 
 		static string Hash_SHA1(byte[] data)
 		{

--- a/BizHawk.Client.EmuHawk/config/NES/NESSyncSettingsForm.cs
+++ b/BizHawk.Client.EmuHawk/config/NES/NESSyncSettingsForm.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Client.EmuHawk
 				var sb = new StringBuilder();
 				foreach (var b in _syncSettings.InitialWRamStatePattern)
 				{
-					sb.Append(b.ToHexString(2));
+					sb.Append($"{b:X2}");
 				}
 
 				RamPatternOverrideBox.Text = sb.ToString();

--- a/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Disassembler.cs
+++ b/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Disassembler.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 
+using BizHawk.Common.NumberExtensions;
+
 namespace BizHawk.Client.EmuHawk
 {
 	public partial class GenericDebugger
@@ -75,7 +77,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (column == 0)
 				{
-					text = string.Format($"{{0:X{_pcRegisterSize}}}", _disassemblyLines[index].Address);
+					text = _disassemblyLines[index].Address.ToHexString(_pcRegisterSize);
 				}
 				else if (column == 1)
 				{
@@ -206,7 +208,7 @@ namespace BizHawk.Client.EmuHawk
 						blob.AppendLine();
 					}
 
-					blob.Append(string.Format($"{{0:X{_pcRegisterSize}}}", _disassemblyLines[index].Address))
+					blob.Append(_disassemblyLines[index].Address.ToHexString(_pcRegisterSize))
 						.Append(" ")
 						.Append(_disassemblyLines[index].Mnemonic);
 				}

--- a/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
+++ b/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
@@ -59,7 +59,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			int tone = note % 12;
 			int octave = note / 12;
-			return $"{noteNames[tone]}{octave}";
+			return noteNames[tone] + octave;
 		}
 
 		//this isnt thoroughly debugged but it seems to work OK

--- a/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
+++ b/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
@@ -725,7 +725,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (mode == SNESGraphicsDecoder.BGMode.Unavailable) return "Unavailable";
 			if (mode == SNESGraphicsDecoder.BGMode.Text) return $"Text{bpp}bpp";
-			if (mode == SNESGraphicsDecoder.BGMode.OBJ) return string.Format("OBJ", bpp);
+			if (mode == SNESGraphicsDecoder.BGMode.OBJ) return "OBJ";
 			if (mode == SNESGraphicsDecoder.BGMode.Mode7) return "Mode7";
 			if (mode == SNESGraphicsDecoder.BGMode.Mode7Ext) return "Mode7Ext";
 			if (mode == SNESGraphicsDecoder.BGMode.Mode7DC) return "Mode7DC";

--- a/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
+++ b/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
@@ -130,8 +130,8 @@ namespace BizHawk.Client.EmuHawk
 		string FormatVramAddress(int address)
 		{
 			int excess = address & 1023;
-			if (excess != 0) return $"@{address.ToHexString(4)}";
-			else return $"@{address.ToHexString(4)} ({address / 1024}K)";
+			if (excess != 0) return $"@{address:X4}";
+			else return $"@{address:X4} ({address / 1024}K)";
 		}
 
 		public void NewUpdate(ToolFormUpdateType type) { }
@@ -786,7 +786,7 @@ namespace BizHawk.Client.EmuHawk
 				addr *= 2;
 
 			addr &= 0xFFFF;
-			txtMapEntryTileAddr.Text = $"@{addr.ToHexString(4)}";
+			txtMapEntryTileAddr.Text = $"@{addr:X4}";
 		}
 
 		void UpdateColorDetails()

--- a/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
+++ b/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
@@ -413,7 +413,9 @@ namespace BizHawk.Client.EmuHawk
 		private void StartLogFile(bool append = false)
 		{
 			var data = Tracer.Header;
-			_streamWriter = new StreamWriter($"{_baseName}{(_segmentCount == 0 ? string.Empty : $"_{_segmentCount}")}{_extension}", append);
+			_streamWriter = new StreamWriter(
+				string.Concat(_baseName, _segmentCount == 0 ? string.Empty : $"_{_segmentCount}", _extension),
+				append);
 			_streamWriter.WriteLine(data);
 			if (append)
 			{

--- a/BizHawk.Client.MultiHawk/Input/GamePad.cs
+++ b/BizHawk.Client.MultiHawk/Input/GamePad.cs
@@ -192,19 +192,19 @@ namespace BizHawk.Client.MultiHawk
 			for (int i = 0; i < state.GetButtons().Length; i++)
 			{
 				int j = i;
-				AddItem(string.Format("B{0}", i + 1), () => state.IsPressed(j));
+				AddItem($"B{i + 1}", () => state.IsPressed(j));
 			}
 
 			for (int i = 0; i < state.GetPointOfViewControllers().Length; i++)
 			{
 				int j = i;
-				AddItem(string.Format("POV{0}U", i + 1),
+				AddItem($"POV{i + 1}U",
 					() => { int t = state.GetPointOfViewControllers()[j]; return (t >= 0 && t <= 4500) || (t >= 31500 && t < 36000); });
-				AddItem(string.Format("POV{0}D", i + 1),
+				AddItem($"POV{i + 1}D",
 					() => { int t = state.GetPointOfViewControllers()[j]; return t >= 13500 && t <= 22500; });
-				AddItem(string.Format("POV{0}L", i + 1),
+				AddItem($"POV{i + 1}L",
 					() => { int t = state.GetPointOfViewControllers()[j]; return t >= 22500 && t <= 31500; });
-				AddItem(string.Format("POV{0}R", i + 1),
+				AddItem($"POV{i + 1}R",
 					() => { int t = state.GetPointOfViewControllers()[j]; return t >= 4500 && t <= 13500; });
 			}
 		}

--- a/BizHawk.Client.MultiHawk/Input/Input.cs
+++ b/BizHawk.Client.MultiHawk/Input/Input.cs
@@ -183,10 +183,7 @@ namespace BizHawk.Client.MultiHawk
 		{
 			public LogicalButton LogicalButton;
 			public InputEventType EventType;
-			public override string ToString()
-			{
-				return string.Format("{0}:{1}", EventType.ToString(), LogicalButton.ToString());
-			}
+			public override string ToString() => $"{EventType.ToString()}:{LogicalButton.ToString()}";
 		}
 
 		private readonly WorkingDictionary<string, object> ModifierState = new WorkingDictionary<string, object>();

--- a/BizHawk.Client.MultiHawk/Mainform.cs
+++ b/BizHawk.Client.MultiHawk/Mainform.cs
@@ -1083,11 +1083,11 @@ namespace BizHawk.Client.MultiHawk
 				{
 					if (Global.MovieSession.Movie.IsFinished)
 					{
-						frame += string.Format(" / {0} (finished)", Global.MovieSession.Movie.FrameCount);
+						frame += $" / {Global.MovieSession.Movie.FrameCount} (finished)";
 					}
 					else if (Global.MovieSession.Movie.IsPlaying)
 					{
-						frame += string.Format(" / {0}", Global.MovieSession.Movie.FrameCount);
+						frame += $" / {Global.MovieSession.Movie.FrameCount}";
 					}
 				}
 

--- a/BizHawk.Client.MultiHawk/movie/PlayMovie.cs
+++ b/BizHawk.Client.MultiHawk/movie/PlayMovie.cs
@@ -435,7 +435,7 @@ namespace BizHawk.Client.MultiHawk
 			}
 
 			var FpsItem = new ListViewItem("Fps");
-			FpsItem.SubItems.Add(string.Format("{0:0.#######}", Fps(_movieList[firstIndex])));
+			FpsItem.SubItems.Add($"{Fps(_movieList[firstIndex]):0.#######}");
 			DetailsView.Items.Add(FpsItem);
 
 			var FramesItem = new ListViewItem("Frames");

--- a/BizHawk.Common/Extensions/BufferExtensions.cs
+++ b/BizHawk.Common/Extensions/BufferExtensions.cs
@@ -100,7 +100,7 @@ namespace BizHawk.Common.BufferExtensions
 
 			for (int i = 0; i < buffer.Length && i * 2 < hex.Length; i++)
 			{
-				var bytehex = $"{hex[i * 2]}{hex[(i * 2) + 1]}";
+				var bytehex = hex[i * 2].ToString() + hex[(i * 2) + 1];
 				buffer[i] = byte.Parse(bytehex, NumberStyles.HexNumber);
 			}
 		}
@@ -136,7 +136,7 @@ namespace BizHawk.Common.BufferExtensions
 
 			for (int i = 0; i < buffer.Length && i * 4 < hex.Length; i++)
 			{
-				var shorthex = $"{hex[i * 4]}{hex[(i * 4) + 1]}{hex[(i * 4) + 2]}{hex[(i * 4) + 3]}";
+				var shorthex = string.Concat(hex[i * 4], hex[(i * 4) + 1], hex[(i * 4) + 2], hex[(i * 4) + 3]);
 				buffer[i] = short.Parse(shorthex, NumberStyles.HexNumber);
 			}
 		}
@@ -150,7 +150,7 @@ namespace BizHawk.Common.BufferExtensions
 
 			for (int i = 0; i < buffer.Length && i * 4 < hex.Length; i++)
 			{
-				var ushorthex = $"{hex[i * 4]}{hex[(i * 4) + 1]}{hex[(i * 4) + 2]}{hex[(i * 4) + 3]}";
+				var ushorthex = string.Concat(hex[i * 4], hex[(i * 4) + 1], hex[(i * 4) + 2], hex[(i * 4) + 3]);
 				buffer[i] = ushort.Parse(ushorthex, NumberStyles.HexNumber);
 			}
 		}

--- a/BizHawk.Common/Extensions/NumberExtensions.cs
+++ b/BizHawk.Common/Extensions/NumberExtensions.cs
@@ -15,16 +15,6 @@ namespace BizHawk.Common.NumberExtensions
 			return string.Format($"{{0:X{numdigits}}}", n);
 		}
 
-		public static string ToHexString(this byte n, int numdigits)
-		{
-			return string.Format($"{{0:X{numdigits}}}", n);
-		}
-
-		public static string ToHexString(this ushort n, int numdigits)
-		{
-			return string.Format($"{{0:X{numdigits}}}", n);
-		}
-
 		public static string ToHexString(this long n, int numdigits)
 		{
 			return string.Format($"{{0:X{numdigits}}}", n);

--- a/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
+++ b/BizHawk.Emulation.Cores/CPUs/Z80A/Z80A.cs
@@ -747,7 +747,7 @@ namespace BizHawk.Emulation.Cores.Components.Z80A
 
 			for (ushort i = 0; i < bytes_read; i++)
 			{
-				byte_code += ReadMemory((ushort)(RegPC + i)).ToHexString(2);
+				byte_code += $"{ReadMemory((ushort)(RegPC + i)):X2}";
 				if (i < (bytes_read - 1))
 				{
 					byte_code += " ";

--- a/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/RiffMaster.cs
+++ b/BizHawk.Emulation.DiscSystem/DiscFormats/Blobs/RiffMaster.cs
@@ -40,10 +40,8 @@ namespace BizHawk.Emulation.DiscSystem
 			BaseStream = null;
 		}
 
-		private static string ReadTag(BinaryReader br)
-		{
-			return $"{br.ReadChar()}{br.ReadChar()}{br.ReadChar()}{br.ReadChar()}";
-		}
+		private static string ReadTag(BinaryReader br) =>
+			string.Concat(br.ReadChar(), br.ReadChar(), br.ReadChar(), br.ReadChar());
 
 		protected static void WriteTag(BinaryWriter bw, string tag)
 		{


### PR DESCRIPTION
Everything that didn't make the other PRs.

~~[This needs review](https://github.com/TASVideos/BizHawk/blob/e6374ef4771ff0f0b973bd5f671675269e3f7a96/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs#L728)~~ clearly [copied from the line above](https://github.com/TASVideos/BizHawk/commit/3dd1c5c493d16a90264ab3d0a884c3c6f59d92fc#diff-a1d4c970bc553c6c0a85f7c2cb2ac433R695) and the unnecessary `string.Format` call was never removed. edit: after fixing that, appveyor stopped building this branch ¯\\\_(ツ)\_/¯