### PR TITLE
Serializer: Add support for float[], double and double[]

### DIFF
--- a/BizHawk.Common/Serializer.cs
+++ b/BizHawk.Common/Serializer.cs
@@ -440,6 +440,90 @@ namespace BizHawk.Common
 			}
 		}
 
+		public void Sync(string name, ref float[] val, bool useNull)
+		{
+			if (IsText)
+			{
+				SyncText(name, ref val, useNull);
+			}
+			else if (IsReader)
+			{
+				val = Util.ByteBufferToFloatBuffer(Util.ReadByteBuffer(_br, false));
+				if (val == null && !useNull)
+				{
+					val = new float[0];
+				}
+			}
+			else
+			{
+				Util.WriteByteBuffer(_bw, Util.FloatBufferToByteBuffer(val));
+			}
+		}
+
+		public void SyncText(string name, ref float[] val, bool useNull)
+		{
+			if (IsReader)
+			{
+				if (Present(name))
+				{
+					var bytes = Util.HexStringToBytes(Item(name));
+					val = Util.ByteBufferToFloatBuffer(bytes);
+				}
+
+				if (val != null && val.Length == 0 && useNull)
+				{
+					val = null;
+				}
+			}
+			else
+			{
+				var temp = val ?? new float[0];
+				_tw.WriteLine("{0} {1}", name, Util.FloatBufferToByteBuffer(temp).BytesToHexString());
+			}
+		}
+
+		public void Sync(string name, ref double[] val, bool useNull)
+		{
+			if (IsText)
+			{
+				SyncText(name, ref val, useNull);
+			}
+			else if (IsReader)
+			{
+				val = Util.ByteBufferToDoubleBuffer(Util.ReadByteBuffer(_br, false));
+				if (val == null && !useNull)
+				{
+					val = new double[0];
+				}
+			}
+			else
+			{
+				Util.WriteByteBuffer(_bw, Util.DoubleBufferToByteBuffer(val));
+			}
+		}
+
+		public void SyncText(string name, ref double[] val, bool useNull)
+		{
+			if (IsReader)
+			{
+				if (Present(name))
+				{
+					var bytes = Util.HexStringToBytes(Item(name));
+					val = Util.ByteBufferToDoubleBuffer(bytes);
+				}
+
+				if (val != null && val.Length == 0 && useNull)
+				{
+					val = null;
+				}
+			}
+			else
+			{
+				var temp = val ?? new double[0];
+				_tw.WriteLine("{0} {1}", name, Util.DoubleBufferToByteBuffer(temp).BytesToHexString());
+			}
+		}
+
 		public void Sync(string name, ref Bit val)
 		{
 			if (IsText)
@@ -597,6 +681,22 @@ namespace BizHawk.Common
 		}
 
 		public void Sync(string name, ref float val)
+		{
+			if (IsText)
+			{
+				SyncText(name, ref val);
+			}
+			else if (IsReader)
+			{
+				Read(ref val);
+			}
+			else
+			{
+				Write(ref val);
+			}
+		}
+
+		public void Sync(string name, ref double val)
 		{
 			if (IsText)
 			{
@@ -907,6 +1007,18 @@ namespace BizHawk.Common
 			}
 		}
 
+		private void SyncText(string name, ref double val)
+		{
+			if (IsReader)
+			{
+				ReadText(name, ref val);
+			}
+			else
+			{
+				WriteText(name, ref val);
+			}
+		}
+
 		private void SyncText(string name, ref bool val)
 		{
 			if (IsReader)
@@ -1135,6 +1247,16 @@ namespace BizHawk.Common
 			_bw.Write(val);
 		}
 
+		private void Read(ref double val)
+		{
+			val = _br.ReadDouble();
+		}
+
+		private void Write(ref double val)
+		{
+			_bw.Write(val);
+		}
+
 		private void ReadText(string name, ref float val)
 		{
 			if (Present(name))
@@ -1144,6 +1266,19 @@ namespace BizHawk.Common
 		}
 
 		private void WriteText(string name, ref float val)
+		{
+			_tw.WriteLine("{0} {1}", name, val);
+		}
+
+		private void ReadText(string name, ref double val)
+		{
+			if (Present(name))
+			{
+				val = double.Parse(Item(name));
+			}
+		}
+
+		private void WriteText(string name, ref double val)
 		{
 			_tw.WriteLine("{0} {1}", name, val);
 		}

--- a/BizHawk.Common/Util.cs
+++ b/BizHawk.Common/Util.cs
@@ -299,6 +299,38 @@ namespace BizHawk.Common
 			return ret;
 		}
 
+		public static float[] ByteBufferToFloatBuffer(byte[] buf)
+		{
+			int num = buf.Length / sizeof(float);
+			var ret = new float[num];
+			Buffer.BlockCopy(buf, 0, ret, 0, num);
+			return ret;
+		}
+
+		public static byte[] FloatBufferToByteBuffer(float[] buf)
+		{
+			int num = buf.Length;
+			var ret = new byte[num * sizeof(float)];
+			Buffer.BlockCopy(buf, 0, ret, 0, ret.Length);
+			return ret;
+		}
+
+		public static double[] ByteBufferToDoubleBuffer(byte[] buf)
+		{
+			int num = buf.Length;
+			var ret = new double[num / sizeof(double)];
+			Buffer.BlockCopy(buf, 0, ret, 0, num);
+			return ret;
+		}
+
+		public static byte[] DoubleBufferToByteBuffer(double[] buf)
+		{
+			int num = buf.Length;
+			var ret = new byte[num * sizeof(double)];
+			Buffer.BlockCopy(buf, 0, ret, 0, ret.Length);
+			return ret;
+		}
+
 		public static byte[] ReadByteBuffer(BinaryReader br, bool returnNull)
 		{
 			int len = br.ReadInt32();


### PR DESCRIPTION
As the title says.

Implements required logic to serialize and deserialize double values and double arrays, along with float arrays. Works with both binary and text sync modes.

It uses Buffer.BlockCopy for the array stuff (hopefully this is quick enough).