### PR TITLE
Added sleep functions for Lua to client module (resolves #1177)

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
@@ -7,6 +7,8 @@ using NLua;
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Client.Common;
+using System.Threading;
+using System.Diagnostics;
 
 // ReSharper disable StringLiteralTypo
 // ReSharper disable UnusedMember.Global
@@ -471,6 +473,31 @@ namespace BizHawk.Client.EmuHawk
 		public void SaveRam()
 		{
 			GlobalWin.MainForm.FlushSaveRAM();
+		}
+
+		[LuaMethodExample("client.sleep( 50 );")]
+		[LuaMethod("sleep", "sleeps for n milliseconds")]
+		public void Sleep(int millis)
+		{
+			Thread.Sleep(millis);
+		}
+
+		[LuaMethodExample("client.exactsleep( 50 );")]
+		[LuaMethod("exactsleep", "sleeps exactly for n milliseconds")]
+		public void ExactSleep(int millis)
+		{
+			Stopwatch stopwatch = Stopwatch.StartNew();
+			while (millis - stopwatch.ElapsedMilliseconds > 100)
+			{
+				Thread.Sleep(50);
+			}
+			while (true)
+			{
+				if (stopwatch.ElapsedMilliseconds >= millis)
+				{
+					break;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Two new functions for the Lua `client` module, addresses #1177 

* sleep
* exactsleep

Both functions freeze the whole emulator for n milliseconds. `sleep` is a bit more imprecise but uses less resources, `exactsleep` is precises but eats CPU resources.