### PR TITLE
added new command line parameter audiosync

### DIFF
--- a/BizHawk.Client.EmuHawk/ArgParser.cs
+++ b/BizHawk.Client.EmuHawk/ArgParser.cs
@@ -32,6 +32,7 @@ namespace BizHawk.Client.EmuHawk
 		public string mmf_filename = null;
 		public string URL_get = null;
 		public string URL_post = null;
+		public bool? audiosync = null;
 
 		public void ParseArguments(string[] args)
 
@@ -130,6 +131,10 @@ namespace BizHawk.Client.EmuHawk
 				else if (arg.StartsWith("--url_post="))
 				{
 					URL_post = args[i].Substring(args[i].IndexOf('=') + 1);
+				}
+				else if (arg.StartsWith("--audiosync="))
+				{
+					audiosync = arg.Substring(arg.IndexOf('=') + 1) == "true";
 				}
 				else
 				{

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -287,6 +287,11 @@ namespace BizHawk.Client.EmuHawk
 				LoadRomFromRecent(Global.Config.RecentRoms.MostRecent);
 			}
 
+			if (argParser.audiosync.HasValue)
+			{
+				Global.Config.VideoWriterAudioSync = argParser.audiosync.Value;
+			}
+
 			if (argParser.cmdMovie != null)
 			{
 				_supressSyncSettingsWarning = true; // We dont' want to be nagged if we are attempting to automate


### PR DESCRIPTION
Based on the discussion here #1398 it seemed like a good idea to be able to set 'alternate sync' in movie settings via the command line. Use case for me would be to create PNG imageseries from multiple movie files. Currently I need to do it manually since `alternate sync` is enabled by default.

Not sure about the best name for this parameter, internally it is called `VideoWriterAudioSync ` but in the user interface it is called `alternate sync`.