### PR TITLE
Polar stuff

### DIFF
--- a/BizHawk.Client.Common/BizHawk.Client.Common.csproj
+++ b/BizHawk.Client.Common/BizHawk.Client.Common.csproj
@@ -142,6 +142,7 @@
     <Compile Include="inputAdapters\OverrideAdaptor.cs" />
     <Compile Include="inputAdapters\SimpleController.cs" />
     <Compile Include="inputAdapters\UDLRController.cs" />
+    <Compile Include="input\PolarRectConversion.cs" />
     <Compile Include="IonicZipWriter.cs" />
     <Compile Include="IPS.cs" />
     <Compile Include="IZipWriter.cs" />
@@ -320,7 +321,6 @@
       <Name>BizHawk.Bizware.BizwareGL</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>

--- a/BizHawk.Client.Common/input/PolarRectConversion.cs
+++ b/BizHawk.Client.Common/input/PolarRectConversion.cs
@@ -1,0 +1,20 @@
+using System;
+
+using DoublePair = System.Tuple<double, double>;
+
+namespace BizHawk.Client.Common
+{
+	public static class PolarRectConversion
+	{
+		/// <param name="θ">angle in degrees</param>
+		/// <returns>rectangular (Cartesian) coordinates (x, y)</returns>
+		public static DoublePair PolarDegToRect(double r, double θ) => PolarRadToRect(r, θ * Math.PI / 180);
+
+		/// <param name="θ">angle in radians</param>
+		/// <returns>rectangular (Cartesian) coordinates (x, y)</returns>
+		public static DoublePair PolarRadToRect(double r, double θ) => new DoublePair(r * Math.Cos(θ), r * Math.Sin(θ));
+
+		/// <returns>polar coordinates (r, θ) where θ is in degrees</returns>
+		public static DoublePair RectToPolarDeg(double x, double y) => new DoublePair(Math.Sqrt(x * x + y * y), Math.Atan2(y, x) * 180 / Math.PI);
+	}
+}

--- a/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
+++ b/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
@@ -241,7 +241,7 @@ namespace BizHawk.Client.EmuHawk
 			manualTheta.ValueChanged -= PolarNumeric_Changed;
 
 			var polar = PolarRectConversion.RectToPolarDeg(AnalogStick.X - rangeAverageX, AnalogStick.Y - rangeAverageY);
-			manualR.Value = Math.Min(manualR.Value, (decimal) polar.Item1); //TODO bug? if not, this can be `if (polar.Item1 < manualR.Value) manualR.Value = polar.Item1;`
+			manualR.Value = (decimal) polar.Item1;
 			manualTheta.Value = (decimal) polar.Item2;
 
 			manualR.ValueChanged += PolarNumeric_Changed;

--- a/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
+++ b/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
@@ -18,9 +18,6 @@ namespace BizHawk.Client.EmuHawk
 		private int rangeAverageX; //for coordinate transformation when non orthogonal (like PSX for example)
 		private int rangeAverageY;
 
-		private EventHandler manualXYValueChangedEventHandler;
-		private EventHandler polarNumericChangedEventHandler;
-
 		#endregion
 
 		public VirtualPadAnalogStick()
@@ -28,13 +25,10 @@ namespace BizHawk.Client.EmuHawk
 			InitializeComponent();
 			AnalogStick.ClearCallback = ClearCallback;
 
-			manualXYValueChangedEventHandler = new EventHandler(ManualXY_ValueChanged);
-			polarNumericChangedEventHandler = new EventHandler(PolarNumeric_Changed);
-
-			ManualX.ValueChanged += manualXYValueChangedEventHandler;
-			ManualY.ValueChanged += manualXYValueChangedEventHandler;
-			manualR.ValueChanged += polarNumericChangedEventHandler;
-			manualTheta.ValueChanged += polarNumericChangedEventHandler;
+			ManualX.ValueChanged += ManualXY_ValueChanged;
+			ManualY.ValueChanged += ManualXY_ValueChanged;
+			manualR.ValueChanged += PolarNumeric_Changed;
+			manualTheta.ValueChanged += PolarNumeric_Changed;
 		}
 
 		public float[] RangeX = new float[] { -128f, 0.0f, 127f };
@@ -184,8 +178,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PolarNumeric_Changed(object sender, EventArgs e)
 		{
-			ManualX.ValueChanged -= manualXYValueChangedEventHandler;
-			ManualY.ValueChanged -= manualXYValueChangedEventHandler;
+			ManualX.ValueChanged -= ManualXY_ValueChanged;
+			ManualY.ValueChanged -= ManualXY_ValueChanged;
 
 			ManualX.Value = Math.Ceiling(manualR.Value * (decimal)Math.Cos(Math.PI * (double)manualTheta.Value / 180)).Clamp(-127, 127) + rangeAverageX;
 			ManualY.Value = Math.Ceiling(manualR.Value * (decimal)Math.Sin(Math.PI * (double)manualTheta.Value / 180)).Clamp(-127, 127) + rangeAverageY;
@@ -196,8 +190,8 @@ namespace BizHawk.Client.EmuHawk
 			AnalogStick.HasValue = true;
 			AnalogStick.Refresh();
 
-			ManualX.ValueChanged += manualXYValueChangedEventHandler;
-			ManualY.ValueChanged += manualXYValueChangedEventHandler;
+			ManualX.ValueChanged += ManualXY_ValueChanged;
+			ManualY.ValueChanged += ManualXY_ValueChanged;
 		}
 
 		private void SetAnalogControlFromNumerics()
@@ -241,14 +235,14 @@ namespace BizHawk.Client.EmuHawk
 				}
 			}
 
-			manualR.ValueChanged -= polarNumericChangedEventHandler;
-			manualTheta.ValueChanged -= polarNumericChangedEventHandler;
+			manualR.ValueChanged -= PolarNumeric_Changed;
+			manualTheta.ValueChanged -= PolarNumeric_Changed;
 
 			manualR.Value =  Math.Min(manualR.Value, (decimal)Math.Sqrt(Math.Pow(AnalogStick.X - rangeAverageX, 2) + Math.Pow(AnalogStick.Y - rangeAverageY, 2)));
 			manualTheta.Value = (decimal)(Math.Atan2(AnalogStick.Y - rangeAverageY, AnalogStick.X - rangeAverageX) * (180 / Math.PI));
 
-			manualR.ValueChanged += polarNumericChangedEventHandler;
-			manualTheta.ValueChanged += polarNumericChangedEventHandler;
+			manualR.ValueChanged += PolarNumeric_Changed;
+			manualTheta.ValueChanged += PolarNumeric_Changed;
 
 			_programmaticallyUpdatingNumerics = false;
 		}


### PR DESCRIPTION
I fixed the polar magnitude only decreasing in the event handler (?), there's still the issue of the polar numboxes not being updated when the rectangular ones are. Clicking on the ellipse works fine.

Having a pre-determined mapping from polar to rect and vice-versa might be a good idea, as it stands there are fractions being cut off everywhere. Something like `static readonly (uint, uint)[,] r2p` and `static readonly (int, int)[,] p2r`, used like `(x, y) = p2r[r][θ]` should work (currently tuple boilerplate is needed, also indices are positive so rectangular coords would need to be translated first).

~~hopefully I'll get around to #581~~ will open new PR