### PR TITLE
Emergency patch to fix and/or workaround changes in Mono

### DIFF
--- a/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
+++ b/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
@@ -1545,6 +1545,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <LogicalName>$(RootNamespace).Properties.Resources.resources</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="RomStatusPicker.resx">
       <DependentUpon>RomStatusPicker.cs</DependentUpon>

--- a/BizHawk.Client.EmuHawk/DisplayManager/DisplayManager.cs
+++ b/BizHawk.Client.EmuHawk/DisplayManager/DisplayManager.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Drawing;
 
 using BizHawk.Emulation.Common;
+using BizHawk.Common;
 using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.FilterManager;
 using BizHawk.Bizware.BizwareGL;
@@ -56,13 +57,15 @@ namespace BizHawk.Client.EmuHawk
 				ShaderChainFrugalizers[i] = new RenderTargetFrugalizer(GL);
 			}
 
-			using (var xml = typeof(Program).Assembly.GetManifestResourceStream("BizHawk.Client.EmuHawk.Resources.courier16px.fnt"))
-			using (var tex = typeof(Program).Assembly.GetManifestResourceStream("BizHawk.Client.EmuHawk.Resources.courier16px_0.png"))
+			var resourcePrefix = OSTailoredCode.CurrentOS == OSTailoredCode.DistinctOS.Windows ? "BizHawk.Client.EmuHawk.Resources." : "BizHawk.Client.EmuHawk."; // Mono update broke this somehow? There may be a way to explicitly name the "path" to whatever we want, fixing the issue properly. --yoshi
+
+			using (var xml = typeof(Program).Assembly.GetManifestResourceStream($"{resourcePrefix}courier16px.fnt"))
+			using (var tex = typeof(Program).Assembly.GetManifestResourceStream($"{resourcePrefix}courier16px_0.png"))
 				TheOneFont = new StringRenderer(GL, xml, tex);
 
-			using (var gens = typeof(Program).Assembly.GetManifestResourceStream("BizHawk.Client.EmuHawk.Resources.gens.ttf"))
+			using (var gens = typeof(Program).Assembly.GetManifestResourceStream($"{resourcePrefix}gens.ttf"))
 				LoadCustomFont(gens);
-			using (var fceux = typeof(Program).Assembly.GetManifestResourceStream("BizHawk.Client.EmuHawk.Resources.fceux.ttf"))
+			using (var fceux = typeof(Program).Assembly.GetManifestResourceStream($"{resourcePrefix}fceux.ttf"))
 				LoadCustomFont(fceux);
 
 			if (GL is BizHawk.Bizware.BizwareGL.Drivers.OpenTK.IGL_TK || GL is BizHawk.Bizware.BizwareGL.Drivers.SlimDX.IGL_SlimDX9)

--- a/BizHawk.Client.EmuHawk/Program.cs
+++ b/BizHawk.Client.EmuHawk/Program.cs
@@ -96,7 +96,8 @@ namespace BizHawk.Client.EmuHawk
 			// this check has to be done VERY early.  i stepped through a debug build with wrong .dll versions purposely used,
 			// and there was a TypeLoadException before the first line of SubMain was reached (some static ColorType init?)
 			// zero 25-dec-2012 - only do for public builds. its annoying during development
-			if (!VersionInfo.DeveloperBuild)
+			// and don't bother when installed from a package manager i.e. not Windows --yoshi
+			if (!VersionInfo.DeveloperBuild && EXE_PROJECT.OSTailoredCode.CurrentOS == EXE_PROJECT.OSTailoredCode.DistinctOS.Windows)
 			{
 				var thisversion = typeof(Program).Assembly.GetName().Version;
 				var utilversion = Assembly.Load(new AssemblyName("Bizhawk.Client.Common")).GetName().Version;


### PR DESCRIPTION
Assembly version check shouldn't be necessary if installed with a package manager.

I have no idea how `GetManifestResourceStream` works so I can't comment on how good the new code is.