### PR TITLE
Prepare for Lua API to be refactored to call C# API

### DIFF
--- a/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
+++ b/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
@@ -88,7 +88,7 @@
     <Compile Include="Interfaces\Api\ISaveState.cs" />
     <Compile Include="Interfaces\Api\IUserData.cs" />
     <Compile Include="Interfaces\Api\ISql.cs" />
-    <Compile Include="Interfaces\Api\IMovie.cs" />
+    <Compile Include="Interfaces\Api\IInputMovie.cs" />
     <Compile Include="Interfaces\Api\IMemorySavestate.cs" />
     <Compile Include="Interfaces\Api\IMemEvents.cs" />
     <Compile Include="Interfaces\Api\IEmu.cs" />

--- a/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
+++ b/BizHawk.Client.ApiHawk/BizHawk.Client.ApiHawk.csproj
@@ -56,17 +56,7 @@
     <Compile Include="Attributes\BizHawkExternalToolUsageAttribute.cs" />
     <Compile Include="Attributes\BizHawkExternalToolAttribute.cs" />
     <Compile Include="Classes\ApiInjector.cs" />
-    <Compile Include="Classes\Api\EmuApi.cs" />
-    <Compile Include="Classes\Api\GameInfoApi.cs" />
-    <Compile Include="Classes\Api\MemApi.cs" />
-    <Compile Include="Classes\Api\MemApiBase.cs" />
     <Compile Include="Classes\Api\PluginBase.cs" />
-    <Compile Include="Classes\Api\JoypadApi.cs" />
-    <Compile Include="Classes\Api\MemEventsApi.cs" />
-    <Compile Include="Classes\Api\MemorySaveStateApi.cs" />
-    <Compile Include="Classes\Api\MovieApi.cs" />
-    <Compile Include="Classes\Api\SqlApi.cs" />
-    <Compile Include="Classes\Api\UserDataApi.cs" />
     <Compile Include="Classes\BasicApiProvider.cs" />
     <Compile Include="Classes\BizHawkSystemIdToCoreSystemEnumConverter.cs" />
     <Compile Include="Classes\Events\EventArgs\BeforeQuickLoadEventArgs.cs" />
@@ -82,25 +72,9 @@
     <Compile Include="Enums\BizHawkExternalToolUsage.cs" />
     <Compile Include="Classes\ClientApi.cs" />
     <Compile Include="Classes\ExternalToolManager.cs" />
-    <Compile Include="Interfaces\Api\IComm.cs" />
-    <Compile Include="Interfaces\Api\IInput.cs" />
-    <Compile Include="Interfaces\Api\ITool.cs" />
-    <Compile Include="Interfaces\Api\ISaveState.cs" />
-    <Compile Include="Interfaces\Api\IUserData.cs" />
-    <Compile Include="Interfaces\Api\ISql.cs" />
-    <Compile Include="Interfaces\Api\IInputMovie.cs" />
-    <Compile Include="Interfaces\Api\IMemorySavestate.cs" />
-    <Compile Include="Interfaces\Api\IMemEvents.cs" />
-    <Compile Include="Interfaces\Api\IEmu.cs" />
-    <Compile Include="Interfaces\Api\IExternalApi.cs" />
-    <Compile Include="Interfaces\Api\IJoypad.cs" />
     <Compile Include="Interfaces\IExternalApiProvider.cs" />
     <Compile Include="Interfaces\IExternalToolForm.cs" />
-    <Compile Include="Interfaces\Api\IGameInfo.cs" />
-    <Compile Include="Interfaces\Api\IGui.cs" />
-    <Compile Include="Interfaces\Api\IMem.cs" />
     <Compile Include="Interfaces\IPlugin.cs" />
-    <Compile Include="Interfaces\Api\IApiContainer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/BizHawk.Client.ApiHawk/Classes/Api/MovieApi.cs
+++ b/BizHawk.Client.ApiHawk/Classes/Api/MovieApi.cs
@@ -6,7 +6,7 @@ using BizHawk.Client.Common;
 
 namespace BizHawk.Client.ApiHawk
 {
-	public sealed class MovieApi : IMovie
+	public sealed class MovieApi : IInputMovie
 	{
 		private static class MoviePluginStatic
 		{

--- a/BizHawk.Client.ApiHawk/Classes/Api/PluginBase.cs
+++ b/BizHawk.Client.ApiHawk/Classes/Api/PluginBase.cs
@@ -1,4 +1,5 @@
-﻿using BizHawk.Emulation.Common;
+﻿using BizHawk.Client.Common;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.ApiHawk
 {

--- a/BizHawk.Client.ApiHawk/Classes/BasicApiProvider.cs
+++ b/BizHawk.Client.ApiHawk/Classes/BasicApiProvider.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using BizHawk.Client.Common;
+
 namespace BizHawk.Client.ApiHawk
 {
 	/// <summary>

--- a/BizHawk.Client.ApiHawk/Interfaces/Api/IInputMovie.cs
+++ b/BizHawk.Client.ApiHawk/Interfaces/Api/IInputMovie.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 namespace BizHawk.Client.ApiHawk
 {
-	public interface IMovie : IExternalApi
+	public interface IInputMovie : IExternalApi
 	{
 		bool StartsFromSavestate();
 		bool StartsFromSaveram();

--- a/BizHawk.Client.ApiHawk/Interfaces/IExternalApiProvider.cs
+++ b/BizHawk.Client.ApiHawk/Interfaces/IExternalApiProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using BizHawk.Client.Common;
+
 namespace BizHawk.Client.ApiHawk
 {
 	/// <summary>

--- a/BizHawk.Client.ApiHawk/Interfaces/IPlugin.cs
+++ b/BizHawk.Client.ApiHawk/Interfaces/IPlugin.cs
@@ -1,4 +1,6 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿using BizHawk.Client.Common;
+
+namespace BizHawk.Client.ApiHawk
 {
 	interface IPlugin
 	{

--- a/BizHawk.Client.Common/Api/Classes/EmuApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/EmuApi.cs
@@ -13,7 +13,7 @@ using BizHawk.Emulation.Cores.Sega.MasterSystem;
 using BizHawk.Emulation.Cores.WonderSwan;
 using BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	[Description("A library for interacting with the currently loaded emulator core")]
 	public sealed class EmuApi : IEmu

--- a/BizHawk.Client.Common/Api/Classes/GameInfoApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/GameInfoApi.cs
@@ -3,7 +3,7 @@
 using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class GameInfoApi : IGameInfo
 	{

--- a/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 using BizHawk.Client.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class JoypadApi : IJoypad
 	{

--- a/BizHawk.Client.Common/Api/Classes/MemApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/MemApi.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Common.IEmulatorExtensions;
 using BizHawk.Common.BufferExtensions;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class MemApi : MemApiBase, IMem
 	{

--- a/BizHawk.Client.Common/Api/Classes/MemApiBase.cs
+++ b/BizHawk.Client.Common/Api/Classes/MemApiBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Common.IEmulatorExtensions;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// Base class for the Memory and MainMemory plugin libraries

--- a/BizHawk.Client.Common/Api/Classes/MemEventsApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/MemEventsApi.cs
@@ -3,7 +3,7 @@
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Common.IEmulatorExtensions;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class MemEventsApi : IMemEvents
 	{

--- a/BizHawk.Client.Common/Api/Classes/MemorySaveStateApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/MemorySaveStateApi.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 using BizHawk.Emulation.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class MemorySaveStateApi : IMemorySaveState
 	{

--- a/BizHawk.Client.Common/Api/Classes/MovieApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/MovieApi.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 using BizHawk.Client.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class MovieApi : IInputMovie
 	{

--- a/BizHawk.Client.Common/Api/Classes/SqlApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/SqlApi.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Data.SQLite;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class SqlApi : ISql
 	{

--- a/BizHawk.Client.Common/Api/Classes/UserDataApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/UserDataApi.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using BizHawk.Client.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public sealed class UserDataApi : IUserData
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IApiContainer.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IApiContainer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IApiContainer
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IComm.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IComm.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	public interface IComm : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IEmu.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IEmu.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IEmu : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IExternalApi.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IExternalApi.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// This interface specifies that a client exposes a given interface, such as <see cref="BizHawk.Emulation.Common.IDebuggable"/>,

--- a/BizHawk.Client.Common/Api/Interfaces/IGameInfo.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IGameInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IGameInfo : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IGui.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IGui.cs
@@ -2,7 +2,7 @@
 using System.Drawing.Imaging;
 using System.Windows.Forms;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IGui : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IInput.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IInput.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IInput : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IInputMovie.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IInputMovie.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IInputMovie : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IJoypad.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IJoypad.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IJoypad : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IMem.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IMem.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IMem : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IMemEvents.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IMemEvents.cs
@@ -2,7 +2,7 @@
 
 using BizHawk.Emulation.Common;
 
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface IMemEvents : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IMemorySavestate.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IMemorySavestate.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	public interface IMemorySaveState : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/ISaveState.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/ISaveState.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	public interface ISaveState : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/ISql.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/ISql.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	public interface ISql : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/ITool.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/ITool.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace BizHawk.Client.ApiHawk
+namespace BizHawk.Client.Common
 {
 	public interface ITool : IExternalApi
 	{

--- a/BizHawk.Client.Common/Api/Interfaces/IUserData.cs
+++ b/BizHawk.Client.Common/Api/Interfaces/IUserData.cs
@@ -1,4 +1,4 @@
-﻿namespace BizHawk.Client.ApiHawk
+﻿namespace BizHawk.Client.Common
 {
 	public interface IUserData : IExternalApi
 	{

--- a/BizHawk.Client.Common/BizHawk.Client.Common.csproj
+++ b/BizHawk.Client.Common/BizHawk.Client.Common.csproj
@@ -82,7 +82,33 @@
     <Compile Include="..\Version\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Api\Classes\EmuApi.cs" />
+    <Compile Include="Api\Classes\GameInfoApi.cs" />
+    <Compile Include="Api\Classes\JoypadApi.cs" />
+    <Compile Include="Api\Classes\MemApi.cs" />
+    <Compile Include="Api\Classes\MemApiBase.cs" />
+    <Compile Include="Api\Classes\MemEventsApi.cs" />
+    <Compile Include="Api\Classes\MemorySaveStateApi.cs" />
+    <Compile Include="Api\Classes\MovieApi.cs" />
+    <Compile Include="Api\Classes\SqlApi.cs" />
+    <Compile Include="Api\Classes\UserDataApi.cs" />
     <Compile Include="Api\CoreSystem.cs" />
+    <Compile Include="Api\Interfaces\IApiContainer.cs" />
+    <Compile Include="Api\Interfaces\IComm.cs" />
+    <Compile Include="Api\Interfaces\IEmu.cs" />
+    <Compile Include="Api\Interfaces\IExternalApi.cs" />
+    <Compile Include="Api\Interfaces\IGameInfo.cs" />
+    <Compile Include="Api\Interfaces\IGui.cs" />
+    <Compile Include="Api\Interfaces\IInput.cs" />
+    <Compile Include="Api\Interfaces\IInputMovie.cs" />
+    <Compile Include="Api\Interfaces\IJoypad.cs" />
+    <Compile Include="Api\Interfaces\IMem.cs" />
+    <Compile Include="Api\Interfaces\IMemEvents.cs" />
+    <Compile Include="Api\Interfaces\IMemorySavestate.cs" />
+    <Compile Include="Api\Interfaces\ISaveState.cs" />
+    <Compile Include="Api\Interfaces\ISql.cs" />
+    <Compile Include="Api\Interfaces\ITool.cs" />
+    <Compile Include="Api\Interfaces\IUserData.cs" />
     <Compile Include="Api\JoypadButton.cs" />
     <Compile Include="BinarySaveStates.cs" />
     <Compile Include="BitmapBufferVideoProvider.cs" />

--- a/BizHawk.Client.EmuHawk/Api/ApiContainer.cs
+++ b/BizHawk.Client.EmuHawk/Api/ApiContainer.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Linq;
 
 using BizHawk.Client.ApiHawk;
+using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 {

--- a/BizHawk.Client.EmuHawk/Api/ApiContainer.cs
+++ b/BizHawk.Client.EmuHawk/Api/ApiContainer.cs
@@ -18,7 +18,7 @@ namespace BizHawk.Client.EmuHawk
 		public IMem Mem => (IMem)Libraries[typeof(MemApi)];
 		public IMemEvents MemEvents => (IMemEvents)Libraries[typeof(MemEventsApi)];
 		public IMemorySaveState MemorySaveState => (IMemorySaveState)Libraries[typeof(MemorySaveStateApi)];
-		public IMovie Movie => (IMovie)Libraries[typeof(MovieApi)];
+		public IInputMovie Movie => (IInputMovie)Libraries[typeof(MovieApi)];
 		public ISaveState SaveState => (ISaveState)Libraries[typeof(SaveStateApi)];
 		public ISql Sql => (ISql)Libraries[typeof(SqlApi)];
 		public ITool Tool => (ITool)Libraries[typeof(ToolApi)];

--- a/BizHawk.Client.EmuHawk/Api/ApiManager.cs
+++ b/BizHawk.Client.EmuHawk/Api/ApiManager.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using BizHawk.Common.ReflectionExtensions;
 using BizHawk.Emulation.Common;
 using BizHawk.Client.ApiHawk;
+using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 

--- a/BizHawk.Client.EmuHawk/Api/Libraries/CommApi.cs
+++ b/BizHawk.Client.EmuHawk/Api/Libraries/CommApi.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Windows.Forms;
 
+using BizHawk.Client.Common;
+
 
 namespace BizHawk.Client.EmuHawk
 {

--- a/BizHawk.Client.EmuHawk/Api/Libraries/GuiApi.cs
+++ b/BizHawk.Client.EmuHawk/Api/Libraries/GuiApi.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using System.IO;
 
 using BizHawk.Client.ApiHawk;
+using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk

--- a/BizHawk.Client.EmuHawk/Api/Libraries/SaveStateAPI.cs
+++ b/BizHawk.Client.EmuHawk/Api/Libraries/SaveStateAPI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 
 using BizHawk.Client.ApiHawk;
+using BizHawk.Client.Common;
 
 namespace BizHawk.Client.EmuHawk
 {


### PR DESCRIPTION
ApiHawk shares a lot of duplicate code with the Lua libraries, so why not use it. With the actual APIs in the `BizHawk.Client.Common` NS, they're accessible to the Lua libraries via an `APIContainer`... almost. Each API class is initialised by reflection without parameters, but they need to take an `Action<string>` so they can log to the Lua Console instead of stdout. You can see the hack I came up with to solve that [here](https://github.com/TASVideos/BizHawk/blob/lua-via-apihawk-temp/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.cs#L60-L61), but as it's outside the scope of this PR, please discuss that with me on IRC.