### PR TITLE
RFC: GitHub templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,40 +1,35 @@
 ---
-name: Bug report
-about: Crashes, inaccurate emulation, nitpicks, or regressions
-title: '(issue title -- summarise the summary)'
-labels: ''
-assignees: ''
-
+name: Bug Report
+about: Report broken or incorrect behavior
 ---
 
-[//]: # "This issue description supports Markdown syntax (this is what comments look like). There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
-[//]: # "You can leave these comments here or delete them. Also, please remember to search for similar issues before writing anything, including in closed issues!"
+### Summary
 
-## Summary
-[//]: # "Briefly describe what's broken. Include relevant details: loaded core, loaded rom's hash, open tools, running scripts... You can embed a screenshot if it's easier to show the bug, but if you need more than one please put them at the end."
-Games run faster than I can push buttons whenever my cat sits on the left side of my keyboard.
+<!-- A summary of your bug report. -->
 
-## Repro
-[//]: # "If you can't figure out the list of steps, delete this section and put 'heisenbug' in the summary somewhere. If a Lua script can cause the bug, you can embed that instead (as simple as possible please)."
-1. first step
-2. second step
-3. et cetera
+### Reproduction Steps
 
-## Output
-[//]: # "Paste the contents of the error dialog if there is one (Ctrl+C works even if it looks like it doesn't), or paste the output from the Lua Console, or delete this section."
-```
-o noes
-  at BizHawk.Client.EmuHawk.HawkBiz.RunWithoutCrashing()
-```
+<!-- What you were doing that caused the issue. Consider adding screenshots to help others reproduce the bug. -->
 
-## Host env.
-[//]: # "List the computers you've seen the bug happen on. You'll probably need to provide more detailed specs for graphical/driver issues. Here are some examples:"
-- BizHawk 2.3.2; Win10 Pro 1903; Intel/AMD
-- BizHawk 2.3.2; Win10 Home 1809; AMD/NVIDIA
-- BizHawk 2.3.2; Fedora 30; AMD/AMD
-- BizHawk 2.3.2; macOS 10.15; Intel/AMD
-- BizHawk 1.13.2; Win7 SP1; Intel/NVIDIA
+### Expected Results
 
-[//]: # "If you know the bug does *not* occur on a certain version of EmuHawk, or on a certain OS, please list those too and add 'unaffected'."
+<!-- What you expected to happen. -->
 
-[//]: # "(screenshots, if applicable)"
+### Actual Resutls
+
+<!-- What actually happened. If an exception occurred or a crash dump was produced, please include it. -->
+
+### Checklist
+
+<!-- Put an x inside [ ] to check the box, like so: [x] -->
+
+- [ ] This issue is related to EmuHawk.
+- [ ] This issue is related to DiscoHawk.
+- [ ] This issue is related to an emulation core.
+- [ ] I have checked that this issue is reproducable on the latest version.
+
+### Environment information
+
+<!-- Information about the environment you are running in. -->
+<!-- Add information about your platform, distro (if applicable), commit hash or version number, and IDE/compiler versions. -->
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,10 @@
 ---
 name: Bug Report
 about: Report broken or incorrect behavior
+title: '(Issue title -- summarise issue content)'
+labels: ''
+assignees: ''
+
 ---
 
 ### Summary
@@ -10,12 +14,13 @@ about: Report broken or incorrect behavior
 ### Reproduction Steps
 
 <!-- What you were doing that caused the issue. Consider adding screenshots to help others reproduce the bug. -->
+<!-- Include relevant details: loaded core, loaded ROM's hash, open tools, running scripts.. -->
 
 ### Expected Results
 
 <!-- What you expected to happen. -->
 
-### Actual Resutls
+### Actual Results
 
 <!-- What actually happened. If an exception occurred or a crash dump was produced, please include it. -->
 
@@ -26,10 +31,10 @@ about: Report broken or incorrect behavior
 - [ ] This issue is related to EmuHawk.
 - [ ] This issue is related to DiscoHawk.
 - [ ] This issue is related to an emulation core.
-- [ ] I have checked that this issue is reproducable on the latest version.
+- [ ] I have checked that this issue is reproducable on the latest development build (found in the README).
 
 ### Environment information
 
 <!-- Information about the environment you are running in. -->
 <!-- Add information about your platform, distro (if applicable), commit hash or version number, and IDE/compiler versions. -->
-
+<!-- If you know that this issue does *not* occur with a certain version of BizHawk, please mention this here as well. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,12 @@
 ---
 name: Question/Support
 about: Ask a question or get support
+title: '(Issue title -- summarise question here)'
+labels: ''
+assignees: ''
+
 ---
 
 ### Question/Support
 
 <!-- Please write your question here. Check the existing issues to see if your question has already been answered before. The more information you include about your question, the easier it will be to answer. -->
-

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question/Support
+about: Ask a question or get support
+---
+
+### Question/Support
+
+<!-- Please write your question here. Check the existing issues to see if your question has already been answered before. The more information you include about your question, the easier it will be to answer. -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,3 @@
 - [ ] This PR fixes an issue.
 - [ ] This PR adds something new (e.g. new feature or compatibility).
 - [ ] This PR is **not** a code change (e.g. documentation, repository management).
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+### Summary
+
+<!-- What is this pull request for? Does it fix any issues? -->
+
+### Checklist
+
+<!-- Put an x inside [ ] to check the box, like so: [x] -->
+
+- [ ] If code changes were made then they have been tested.
+- [ ] This PR fixes an issue.
+- [ ] This PR adds something new (e.g. new feature or compatibility).
+- [ ] This PR is **not** a code change (e.g. documentation, repository management).
+


### PR DESCRIPTION
This PR adds Markdown templates for bug report/support issues and pull requests.

When on `master`, GitHub will read the contents of these files (excluding the metadata at the top) into the editor when people create new issues or pull requests to the repository, helping people unfamiliar with the repository format their issue descriptions.

There is no requirement to follow the template if the user doesn't want to, so there should be no downsides to this, although you may want to adjust the templates.