### PR TITLE
Camhack support

### DIFF
--- a/Assets/Lua/GBA/SonicAdvance_CamHack.lua
+++ b/Assets/Lua/GBA/SonicAdvance_CamHack.lua
@@ -1,0 +1,30 @@
+local offX, offY, camX, camY
+local addr_offX = 0x5B96
+local addr_offY = 0x5B98
+local addr_camX = 0x59D0
+local addr_camY = 0x59D2
+
+while true do
+	client.invisibleemulation(true)
+	local memorystate = memorysavestate.savecorestate()
+	
+	offX = mainmemory.read_u16_le(addr_offX)
+	offY = mainmemory.read_u16_le(addr_offY)
+	camX = mainmemory.read_u16_le(addr_camX)
+	camY = mainmemory.read_u16_le(addr_camY)
+	
+	Xval = camX + offX - 128
+	Yval = camY + offY - 80
+	
+	mainmemory.write_u16_le(addr_camX, Xval)
+	mainmemory.write_u16_le(addr_camY, Yval)
+	
+	client.seekframe(emu.framecount()+1)
+	client.invisibleemulation(false)
+	client.seekframe(emu.framecount()+1)
+	client.invisibleemulation(true)
+	memorysavestate.loadcorestate(memorystate)
+	memorysavestate.removestate(memorystate)
+--	client.invisibleemulation(false)
+	emu.frameadvance()
+end

--- a/Assets/Lua/GBA/SonicAdvance_CamHack.lua
+++ b/Assets/Lua/GBA/SonicAdvance_CamHack.lua
@@ -1,3 +1,5 @@
+-- feos, 2019
+
 local offX, offY, camX, camY
 local addr_offX = 0x5B96
 local addr_offY = 0x5B98

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2805,7 +2805,7 @@ namespace BizHawk.Client.EmuHawk
 
 			if (runFrame || force)
 			{
-				var isFastForwarding = Global.ClientControls["Fast Forward"] || IsTurboing;
+				var isFastForwarding = Global.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
 				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || _unthrottled;
 
 				if (isFastForwardingOrRewinding != _lastFastForwardingOrRewinding)
@@ -2829,7 +2829,7 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.LuaConsole.LuaImp.CallFrameBeforeEvent();
 				}
 
-				if (IsTurboing || InvisibleEmulation)
+				if (IsTurboing)
 				{
 					GlobalWin.Tools.FastUpdateBefore();
 				}
@@ -2877,7 +2877,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 				// why not skip audio if the user doesn't want sound
-				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing && !InvisibleEmulation)
+				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing)
 					|| (_currAviWriter?.UsesAudio ?? false);
 				if (!renderSound)
 				{
@@ -2915,7 +2915,7 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.LuaConsole.LuaImp.CallFrameAfterEvent();
 				}
 
-				if (IsTurboing || InvisibleEmulation)
+				if (IsTurboing)
 				{
 					GlobalWin.Tools.FastUpdateAfter(SuppressLua);
 				}

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -585,6 +585,27 @@ namespace BizHawk.Client.EmuHawk
 		public bool HoldFrameAdvance { get; set; } // necessary for tastudio > button
 		public bool PressRewind { get; set; } // necessary for tastudio < button
 		public bool FastForward { get; set; }
+
+		/// <summary>
+		/// Disables updates for video/audio, and enters "turbo" mode.
+		/// Can be used to replicate Gens-rr's "latency compensation" that involves:
+		/// <list type="bullet">
+		/// <item><description>Saving a no-framebuffer state that is stored in RAM</description></item>
+		/// <item><description>Emulating forth for some frames with updates disabled</description></item>
+		/// <item><list type="bullet">
+		/// <item><description>Optionally hacking in-game memory
+		/// (like camera position, to show off-screen areas)</description></item>
+		/// </list></item>
+		/// <item><description>Updating the screen</description></item>
+		/// <item><description>Loading the no-framebuffer state from RAM</description></item>
+		/// </list>
+		/// The most common usecase is CamHack for Sonic games.
+		/// Accessing this from Lua allows to keep internal code hacks to minimum.
+		/// <list type="bullet">
+		/// <item><description><see cref="EmuHawkLuaLibrary.InvisibleEmulation(bool)"/></description></item>
+		/// <item><description><see cref="EmuHawkLuaLibrary.SeekFrame(int)"/></description></item>
+		/// </list>
+		/// </summary>
 		public bool InvisibleEmulation { get; set; }
 
 		// runloop won't exec lua

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -585,6 +585,7 @@ namespace BizHawk.Client.EmuHawk
 		public bool HoldFrameAdvance { get; set; } // necessary for tastudio > button
 		public bool PressRewind { get; set; } // necessary for tastudio < button
 		public bool FastForward { get; set; }
+		public bool InvisibleEmulation { get; set; }
 
 		// runloop won't exec lua
 		public bool SuppressLua { get; set; }
@@ -2828,7 +2829,7 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.LuaConsole.LuaImp.CallFrameBeforeEvent();
 				}
 
-				if (IsTurboing)
+				if (IsTurboing || InvisibleEmulation)
 				{
 					GlobalWin.Tools.FastUpdateBefore();
 				}
@@ -2873,13 +2874,13 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 				// why not skip audio if the user doesn't want sound
-				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing) || (_currAviWriter?.UsesAudio ?? false);
+				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing && !InvisibleEmulation) || (_currAviWriter?.UsesAudio ?? false);
 				if (!renderSound)
 				{
 					atten = 0;
 				}
 
-				bool render = !_throttle.skipNextFrame || (_currAviWriter?.UsesVideo ?? false);
+				bool render = !InvisibleEmulation && (!_throttle.skipNextFrame || (_currAviWriter?.UsesVideo ?? false));
 				bool new_frame = Emulator.FrameAdvance(Global.ControllerOutput, render, renderSound);
 
 				Global.MovieSession.HandleMovieAfterFrameLoop();
@@ -2910,7 +2911,7 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.LuaConsole.LuaImp.CallFrameAfterEvent();
 				}
 
-				if (IsTurboing)
+				if (IsTurboing || InvisibleEmulation)
 				{
 					GlobalWin.Tools.FastUpdateAfter(SuppressLua);
 				}
@@ -2919,7 +2920,7 @@ namespace BizHawk.Client.EmuHawk
 					UpdateToolsAfter(SuppressLua);
 				}
 
-				if (!PauseAvi && new_frame)
+				if (!PauseAvi && new_frame && !InvisibleEmulation)
 				{
 					AvFrameAdvance();
 				}

--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2838,10 +2838,13 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.Tools.UpdateToolsBefore();
 				}
 
-				CaptureRewind(isRewinding);
+				if (!InvisibleEmulation)
+				{
+					CaptureRewind(isRewinding);
+				}
 
 				// Set volume, if enabled
-				if (Global.Config.SoundEnabledNormal)
+				if (Global.Config.SoundEnabledNormal && !InvisibleEmulation)
 				{
 					atten = Global.Config.SoundVolume / 100.0f;
 
@@ -2874,7 +2877,8 @@ namespace BizHawk.Client.EmuHawk
 					}
 				}
 				// why not skip audio if the user doesn't want sound
-				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing && !InvisibleEmulation) || (_currAviWriter?.UsesAudio ?? false);
+				bool renderSound = (Global.Config.SoundEnabled && !IsTurboing && !InvisibleEmulation)
+					|| (_currAviWriter?.UsesAudio ?? false);
 				if (!renderSound)
 				{
 					atten = 0;

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
@@ -120,6 +120,10 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		/// <summary>
+		/// Use with <see cref="SeekFrame(int)"/> for CamHack.
+		/// Refer to <see cref="MainForm.InvisibleEmulation"/> for the workflow details.
+		/// </summary>
 		[LuaMethodExample("client.invisibleemulation( true );")]
 		[LuaMethod("invisibleemulation", "Disables and enables emulator updates")]
 		public void InvisibleEmulation(bool invisible)
@@ -127,6 +131,10 @@ namespace BizHawk.Client.EmuHawk
 			GlobalWin.MainForm.InvisibleEmulation = invisible;
 		}
 
+		/// <summary>
+		/// Use with <see cref="InvisibleEmulation(bool)"/> for CamHack.
+		/// Refer to <see cref="MainForm.InvisibleEmulation"/> for the workflow details.
+		/// </summary>
 		[LuaMethodExample("client.seekframe( 100 );")]
 		[LuaMethod("seekframe", "Makes the emulator seek to the frame specified")]
 		public void SeekFrame(int frame)

--- a/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
+++ b/BizHawk.Client.EmuHawk/tools/Lua/Libraries/EmuLuaLibrary.Client.cs
@@ -120,6 +120,34 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		[LuaMethodExample("client.invisibleemulation( true );")]
+		[LuaMethod("invisibleemulation", "Disables and enables emulator updates")]
+		public void InvisibleEmulation(bool invisible)
+		{
+			GlobalWin.MainForm.InvisibleEmulation = invisible;
+		}
+
+		[LuaMethodExample("client.seekframe( 100 );")]
+		[LuaMethod("seekframe", "Makes the emulator seek to the frame specified")]
+		public void SeekFrame(int frame)
+		{
+			bool wasPaused = GlobalWin.MainForm.EmulatorPaused;
+
+			// can't re-enter lua while doing this
+			GlobalWin.MainForm.SuppressLua = true;
+			while (Emulator.Frame != frame)
+			{
+				GlobalWin.MainForm.SeekFrameAdvance();
+			}
+
+			GlobalWin.MainForm.SuppressLua = false;
+
+			if (!wasPaused)
+			{
+				GlobalWin.MainForm.UnpauseEmulator();
+			}
+		}
+
 		[LuaMethodExample("local incliget = client.gettargetscanlineintensity( );")]
 		[LuaMethod("gettargetscanlineintensity", "Gets the current scanline intensity setting, used for the scanline display filter")]
 		public static int GetTargetScanlineIntensity()

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.ISoundProvider.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.ISoundProvider.cs
@@ -6,6 +6,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 	public partial class MGBAHawk : ISoundProvider
 	{
 		private readonly short[] _soundbuff = new short[2048];
+		private readonly short[] _dummysoundbuff = new short[2048];
 		private int _nsamp;
 
 		public bool CanProvideAsync => false;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IVideoProvider.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IVideoProvider.cs
@@ -23,5 +23,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 		public int VsyncDenominator => 4389;
 
 		private readonly int[] _videobuff = new int[240 * 160];
+
+		private readonly int[] _dummyvideobuff = new int[240 * 160];
 	}
 }

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
@@ -81,9 +81,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			IsLagFrame = LibmGBA.BizAdvance(
 				_core,
 				VBANext.GetButtons(controller),
-				_videobuff,
+				render ? _videobuff : _dummyvideobuff,
 				ref _nsamp,
-				_soundbuff,
+				rendersound ? _soundbuff : _dummysoundbuff,
 				RTCTime(),
 				(short)controller.GetFloat("Tilt X"),
 				(short)controller.GetFloat("Tilt Y"),

--- a/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IEmulator.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IEmulator.cs
@@ -58,8 +58,12 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			_drivelight = false;
 
 			Core.gpgx_advance();
-			UpdateVideo();
-			update_audio();
+
+			if (render)
+				UpdateVideo();
+
+			if (rendersound)
+				update_audio();
 
 			if (IsLagFrame)
 				LagCount++;


### PR DESCRIPTION
https://www.youtube.com/watch?v=uFl0ax-GYk8

For a test, mGBA core uses fake video and audio buffers and renders to them when we want to "skip" rendering. Proper setup would involve actually skipping rendering those inside the core.

For the camhack to work we have to save a state, hack memory, advance twice to see the changes, then load the state to prevent desync. Since we can omit the framebuffer in savestates, loading them can happen without updating the screen, so the hacked camera remains visible.

Advancing 2 frames automatically is done like tastudio does it when it seeks to a frame, only from lua now.

And the most questionable part is "invisible emulation", which is how Gens calls this IIRC, when everything that can distract or slow us down is skipped: sound, video, tools updates.

AVI dumping works as expected BTW. Couldn't make fps update while unpaused tho. Only updates if you press/hold frame advance.

New lua functions:
- `client.invisibleemulation()`
- `client.seekframe()`

Script for Sonic Advance:
```lua
local offX, offY, camX, camY
local addr_offX = 0x5B96
local addr_offY = 0x5B98
local addr_camX = 0x59D0
local addr_camY = 0x59D2

while true do
	client.invisibleemulation(true)
	local memorystate = memorysavestate.savecorestate()
	
	offX = mainmemory.read_u16_le(addr_offX)
	offY = mainmemory.read_u16_le(addr_offY)
	camX = mainmemory.read_u16_le(addr_camX)
	camY = mainmemory.read_u16_le(addr_camY)
	
	Xval = camX + offX - 128
	Yval = camY + offY - 80
	
	mainmemory.write_u16_le(addr_camX, Xval)
	mainmemory.write_u16_le(addr_camY, Yval)
	
	client.seekframe(emu.framecount()+1)
	client.invisibleemulation(false)
	client.seekframe(emu.framecount()+1)
	client.invisibleemulation(true)
	memorysavestate.loadcorestate(memorystate)
	memorysavestate.removestate(memorystate)
--	client.invisibleemulation(false)
	emu.frameadvance()
end
```

Tested with the first level of this movie 
[sonicadvance_test.zip](https://github.com/TASVideos/BizHawk/files/3829011/sonicadvance_test.zip)
