### PR TITLE
All Memory Execute

### DIFF
--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
@@ -185,7 +185,7 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("local steveonm = event.onmemoryexecute(\r\n\tfunction()\r\n\t\tconsole.log( \"Fires after the given address is executed by the core. If no address is given, it will attach to every memory read\" );\r\n\tend\r\n\t, 0x200, \"Frame name\", \"System Bus\" );")]
 		[LuaMethod("onmemoryexecute", "Fires after the given address is executed by the core. If no address is given, it will attach to every memory read")]
-		public string OnMemoryExecute(LuaFunction luaf, uint address = null, string name = null, string domain = null)
+		public string OnMemoryExecute(LuaFunction luaf, uint? address = null, string name = null, string domain = null)
 		{
 			try
 			{

--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
@@ -183,9 +183,9 @@ namespace BizHawk.Client.Common
 			return nlf.Guid.ToString();
 		}
 
-		[LuaMethodExample("local steveonm = event.onmemoryexecute(\r\n\tfunction()\r\n\t\tconsole.log( \"Fires after the given address is executed by the core. If no address is given, it will attach to every memory read\" );\r\n\tend\r\n\t, 0x200, \"Frame name\", \"System Bus\" );")]
-		[LuaMethod("onmemoryexecute", "Fires after the given address is executed by the core. If no address is given, it will attach to every memory read")]
-		public string OnMemoryExecute(LuaFunction luaf, uint? address = null, string name = null, string domain = null)
+		[LuaMethodExample("local steveonm = event.onmemoryexecute(\r\n\tfunction()\r\n\t\tconsole.log( \"Fires after the given address is executed by the core. If is explicitly nil, it will attach to every memory read\" );\r\n\tend\r\n\t, 0x200, \"Frame name\", \"System Bus\" );")]
+		[LuaMethod("onmemoryexecute", "Fires after the given address is executed by the core. If the address is explicitly nil, it will attach to every memory read")]
+		public string OnMemoryExecute(LuaFunction luaf, uint? address, string name = null, string domain = null)
 		{
 			try
 			{

--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Events.cs
@@ -183,9 +183,9 @@ namespace BizHawk.Client.Common
 			return nlf.Guid.ToString();
 		}
 
-		[LuaMethodExample("local steveonm = event.onmemoryexecute(\r\n\tfunction()\r\n\t\tconsole.log( \"Fires after the given address is executed by the core\" );\r\n\tend\r\n\t, 0x200, \"Frame name\", \"System Bus\" );")]
-		[LuaMethod("onmemoryexecute", "Fires after the given address is executed by the core")]
-		public string OnMemoryExecute(LuaFunction luaf, uint address, string name = null, string domain = null)
+		[LuaMethodExample("local steveonm = event.onmemoryexecute(\r\n\tfunction()\r\n\t\tconsole.log( \"Fires after the given address is executed by the core. If no address is given, it will attach to every memory read\" );\r\n\tend\r\n\t, 0x200, \"Frame name\", \"System Bus\" );")]
+		[LuaMethod("onmemoryexecute", "Fires after the given address is executed by the core. If no address is given, it will attach to every memory read")]
+		public string OnMemoryExecute(LuaFunction luaf, uint address = null, string name = null, string domain = null)
 		{
 			try
 			{

--- a/BizHawk.Emulation.Common/Base Implementations/MemoryCallbackSystem.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/MemoryCallbackSystem.cs
@@ -295,11 +295,6 @@ namespace BizHawk.Emulation.Common
 	{
 		public MemoryCallback(string scope, MemoryCallbackType type, string name, MemoryCallbackDelegate callback, uint? address, uint? mask)
 		{
-			if (type == MemoryCallbackType.Execute && !address.HasValue)
-			{
-				throw new InvalidOperationException("When assigning an execute callback, an address must be specified");
-			}
-
 			Type = type;
 			Name = name;
 			Callback = callback;


### PR DESCRIPTION
I'm trying to get this [arcane cycle-counting Lua script](https://cdn.discordapp.com/attachments/606046567232831500/653498902967746570/rm1delay_bizhawk.lua) working on BizHawk so we can get guaranteed console-valid Mega Man TASes. There's a race condition that lets you execute arbitrary code, and this script needs a callback on every cycle to determine when it will happen.

I find it suspicious that this behavior was specifically checked for and blocked. But whatever problems it has, it can't be worse than when I tried to individually register 65,536 callbacks! Right...?

For reference, here's the [original script](https://cdn.discordapp.com/attachments/516260276425981952/653457271006691334/rm1delay_rev6.lua), as seen on FCEUX, and my [refactor](https://cdn.discordapp.com/attachments/516260276425981952/653479310039973898/rm1delay_cabin.lua) of it.
