### PR TITLE
Allow informing the core that we're bulk-accessing the memory domain

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -512,6 +512,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 			var rowStr = new StringBuilder();
 
+			_domain.SetBulkAccess?.Invoke(true);
+
 			for (var i = 0; i < _rowsVisible; i++)
 			{
 				_row = i + HexScrollBar.Value;
@@ -568,6 +570,7 @@ namespace BizHawk.Client.EmuHawk
 				rowStr.AppendLine();
 			}
 
+			_domain.SetBulkAccess?.Invoke(false);
 			return rowStr.ToString();
 		}
 

--- a/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -1,4 +1,6 @@
-﻿namespace BizHawk.Emulation.Common
+﻿using System;
+
+namespace BizHawk.Emulation.Common
 {
 	/// <summary>
 	/// A memory region and the functionality to read/write from it
@@ -21,6 +23,8 @@
 		public Endian EndianType { get; protected set; }
 
 		public bool Writable { get; protected set; }
+
+		public Action<bool> SetBulkAccess { get; set; }
 
 		public abstract byte PeekByte(long addr);
 

--- a/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -29,7 +29,7 @@ namespace BizHawk.Emulation.Common
 			_poke?.Invoke(addr, val);
 		}
 
-		public MemoryDomainDelegate(string name, long size, Endian endian, Func<long, byte> peek, Action<long, byte> poke, int wordSize)
+		public MemoryDomainDelegate(string name, long size, Endian endian, Func<long, byte> peek, Action<long, byte> poke, int wordSize, Action<bool> bulkAccess = null)
 		{
 			Name = name;
 			EndianType = endian;
@@ -38,6 +38,7 @@ namespace BizHawk.Emulation.Common
 			_poke = poke;
 			Writable = poke != null;
 			WordSize = wordSize;
+			SetBulkAccess = bulkAccess;
 		}
 	}
 


### PR DESCRIPTION
If the core runs a bunch of its own threads, we have to wait for them to be ready to access the memory. Hex editor and ram search read a ton of addresses at once, and we have to wait for the core for every single read.

With this new callback we set the flag once before bulk-accessing, hawk waits once for the core threads to get ready, then reads all the addresses in one go, and lets the core threads go.

Speeds up hex editor with mame, even tho its mem reading is slow in general. RAM search is more complex, not touching for now.

The callback is optional.

Aggressive review is required, since this looks like a huge thing, even tho it's surprisingly little new code.

`<natt> feos:  I haven't looked at your commit at all, but just from reading the commit message, this may be something that helps waterbox as well`