### PR TITLE
Fix Macro Functionality (fixes #1838)

### DIFF
--- a/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
+++ b/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
@@ -268,7 +268,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DummyLoadMacro(string path)
 		{
-			MovieZone loadZone = new MovieZone(path);
+			MovieZone loadZone = new MovieZone(path, Emulator, Tools);
 			_zones.Add(loadZone);
 			ZonesList.Items.Add($"{loadZone.Name} - length: {loadZone.Length}");
 		}
@@ -316,7 +316,7 @@ namespace BizHawk.Client.EmuHawk
 			return true;
 		}
 
-		public MovieZone LoadMacro()
+		public MovieZone LoadMacro(IEmulator emulator = null, ToolManager tools = null)
 		{
 			using var dialog = new OpenFileDialog
 			{
@@ -331,7 +331,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			Config.RecentMacros.Add(dialog.FileName);
-			return new MovieZone(dialog.FileName);
+			return new MovieZone(dialog.FileName, emulator ?? Emulator, tools ?? Tools);
 		}
 	}
 }

--- a/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -214,7 +214,7 @@ namespace BizHawk.Client.EmuHawk
 			File.AppendAllLines(fileName, _log);
 		}
 
-		public MovieZone(string fileName, IEmulator emulator = null, ToolManager tools = null)
+		public MovieZone(string fileName, IEmulator emulator, ToolManager tools)
 		{
 			if (!File.Exists(fileName))
 			{

--- a/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -49,6 +49,8 @@ namespace BizHawk.Client.EmuHawk
 				else
 				{
 					d.FloatControls.Add(k);
+					int rangeIndex = _emulator.ControllerDefinition.FloatControls.IndexOf(k);
+					d.FloatRanges.Add(_emulator.ControllerDefinition.FloatRanges[rangeIndex]);
 				}
 			}
 
@@ -212,12 +214,15 @@ namespace BizHawk.Client.EmuHawk
 			File.AppendAllLines(fileName, _log);
 		}
 
-		public MovieZone(string fileName)
+		public MovieZone(string fileName, IEmulator emulator = null, ToolManager tools = null)
 		{
 			if (!File.Exists(fileName))
 			{
 				return;
 			}
+
+			_emulator = emulator;
+			_tools = tools;
 
 			string[] readText = File.ReadAllLines(fileName);
 

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -218,7 +218,9 @@ namespace BizHawk.Client.EmuHawk
 				TasView.FirstSelectedIndex ?? 0,
 				TasView.LastSelectedIndex ?? 0 - TasView.FirstSelectedIndex ?? 0 + 1);
 
-			new MacroInputTool().SaveMacroAs(macro);
+			//var macroTool = Tools.Load<MacroInputTool>(false);
+			var macroTool = new MacroInputTool() { Config = Global.Config };
+			macroTool.SaveMacroAs(macro);
 		}
 
 		private void PlaceMacroAtSelectionMenuItem_Click(object sender, EventArgs e)
@@ -228,7 +230,9 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			var macro = new MacroInputTool().LoadMacro();
+			//var macroTool = Tools.Load<MacroInputTool>(false);
+			var macroTool = new MacroInputTool() { Config = Global.Config };
+			var macro = macroTool.LoadMacro(Emulator, Tools);
 			if (macro != null)
 			{
 				macro.Start = TasView.FirstSelectedIndex ?? 0;

--- a/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -787,7 +787,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			var loadZone = new MovieZone(path)
+			var loadZone = new MovieZone(path, Emulator, Tools)
 			{
 				Start = TasView.FirstSelectedIndex ?? 0
 			};


### PR DESCRIPTION
All macro tools will fail due to the `MovieZone` class not populating the `FloatRanges` property of the `ControllerDefinition` objects it creates (if the current core has float inputs). If this issue is fixed, more issues arise however.

The second major issue is that the `MovieZone` constructor that is used for macros uses fields (`_emulator`, `_tools`) does not supply these fields.

Related to the last problem is that the menu items in TAStudio that perform macro functionality basically bypass actually showing the macro tool form, but call functions on the form. Since the form is not instantiated correctly via a standard `Load` call, some more stuff breaks. Creating the form with the `Load` calls however causes the macro tool form to show when clicking on menu items.

All of this is to say that this PR in its initial form, though it does fix the problems, is not a very good solution, because a proper solution would involve separating the macro functionality out of the macro tool form into its own class. I am creating it as a draft as a kind of extension to the related issue, so that the main devs can weigh in on if they have specific plans for how to fix this problem or if this is good enough. I'm happy to do a better fix if there is agreement that my proposal is a good one.

See issue #1838 