### PR TITLE
Fix ffmpeg race condition.

### DIFF
--- a/BizHawk.Client.EmuHawk/AVOut/FFmpegWriter.cs
+++ b/BizHawk.Client.EmuHawk/AVOut/FFmpegWriter.cs
@@ -94,7 +94,7 @@ namespace BizHawk.Client.EmuHawk
 
 				_commandline = $"ffmpeg {_ffmpeg.StartInfo.Arguments}";
 
-				_ffmpeg.ErrorDataReceived += new DataReceivedEventHandler(StderrHandler);
+				_ffmpeg.ErrorDataReceived += StderrHandler;
 
 				_stderr = new Queue<string>(Consolebuffer);
 
@@ -137,7 +137,12 @@ namespace BizHawk.Client.EmuHawk
 			//ffmpeg.StandardInput.Close();
 
 			// how long should we wait here?
-			_ffmpeg.WaitForExit(20000);
+			if (_ffmpeg.WaitForExit(20000))
+			{
+				// Known MS bug: WaitForExit(time) waits for the process to exit but doesn't wait for event handling to finish.
+				//               If WaitForExit(time) returns true, this call waits for message pump to clear out events.
+				_ffmpeg.WaitForExit();
+			}
 			_ffmpeg.Dispose();
 			_ffmpeg = null;
 			_stderr = null;


### PR DESCRIPTION
There is a known bug in the `Process.WaitForExit(time)` overload ([see remarks here](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.8#System_Diagnostics_Process_WaitForExit_System_Int32_)). This method will wait for the process to exit but it will _not_ wait for the message pump for that process to finish dealing with events. This was causing a race condition for ffmpeg processes that were trying to write to stderr around the same time that the process variables are being nulled in `CloseFileSegment()`. 

This problem occurs much more frequently with hardcore debug mode due to switching resolutions causing file segments to get opened/closed frequently. The bug is still frustratingly inconsistent to reproduce though.

To my understanding, a second call to `WaitForExit()` after receiving true from `WaitForExit(time)` _should_ only be waiting for any remaining events to be handled on a process after it has been closed by the OS (ie not forever), but I can't confirm this, so there is risk.

Other solutions involve giving each ffmpeg process that is spawned its own instance variables, making the stderr handler just check for nulls when accessing stderr, or the nuclear option of manual thread handling with kill timers.

Submitting as a draft because this fix may not be good enough / needs independent testing.