### PR TITLE
Fix Octoshock crash when playing back movies with different input settings (fixes #1842)

### DIFF
--- a/psx/octoshock/psx/psx.cpp
+++ b/psx/octoshock/psx/psx.cpp
@@ -1094,6 +1094,7 @@ struct {
 		for(int i=0;i<10;i++)
 		{
 			ports[i].type = ePeripheralType_None;
+			ports[i].device = nullptr;	// devices are freed in reconstruct
 			memset(ports[i].buffer,0,sizeof(ports[i].buffer));
 		}
 		reconstruct(FIO);


### PR DESCRIPTION
During movie loading, the input data structures in Octoshock are recreated. This did not initially involve nulling the device objects of the ports. If a port had a controller in it (psx config had two dual shocks), and a movie was getting loaded that had only one dual shock configured, the second dualshocks type and buffer got cleared, but not the device. When assigning to the port from FIO, if it was getting assigned none, then the device was just skipped, leaving the old, disposed device hanging around.

It gets called later and crashes Octoshock during movie playback.

This seems suspiciously simple to me, but it does fix the issue for me in debug and release builds. Also I'm not sure why it required AVI dumping in 2.4 to get the crash to happen but in debug builds just trying to play the movie at all would result in a crash.