### PR TITLE
Make Binary states default and Textstates opt-in for cores

### DIFF
--- a/BizHawk.Client.Common/SavestateManager.cs
+++ b/BizHawk.Client.Common/SavestateManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 
 using BizHawk.Common;
+using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Common.IEmulatorExtensions;
 
 namespace BizHawk.Client.Common

--- a/BizHawk.Client.Common/SavestateManager.cs
+++ b/BizHawk.Client.Common/SavestateManager.cs
@@ -16,8 +16,7 @@ namespace BizHawk.Client.Common
 			// the old method of text savestate save is now gone.
 			// a text savestate is just like a binary savestate, but with a different core lump
 			using var bs = new BinaryStateSaver(filename);
-			if (Global.Config.SaveStateType == SaveStateTypeE.Text
-				|| (Global.Config.SaveStateType == SaveStateTypeE.Default && !core.BinarySaveStatesPreferred))
+			if (Global.Config.SaveStateType == SaveStateTypeE.Text)
 			{
 				// text savestate format
 				using (new SimpleTime("Save Core"))

--- a/BizHawk.Client.Common/config/Config.cs
+++ b/BizHawk.Client.Common/config/Config.cs
@@ -136,7 +136,7 @@ namespace BizHawk.Client.Common
 		public RewindConfig Rewind { get; set; } = new RewindConfig();
 
 		// Savestate settings
-		public SaveStateTypeE SaveStateType { get; set; } = SaveStateTypeE.Default;
+		public SaveStateTypeE SaveStateType { get; set; } = SaveStateTypeE.Binary;
 		public const int DefaultSaveStateCompressionLevelNormal = 1;
 		public int SaveStateCompressionLevelNormal { get; set; } = DefaultSaveStateCompressionLevelNormal;
 		public const int DefaultSaveStateCompressionLevelRewind = 0; // this isn't actually used yet 

--- a/BizHawk.Client.Common/config/ConfigEnums.cs
+++ b/BizHawk.Client.Common/config/ConfigEnums.cs
@@ -29,7 +29,7 @@
 
 	public enum SaveStateTypeE
 	{
-		Default, Binary, Text
+		Binary, Text
 	}
 
 	public enum ClientProfile

--- a/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
+++ b/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
@@ -84,7 +84,6 @@
             this.groupBox6 = new System.Windows.Forms.GroupBox();
             this.rbStatesText = new System.Windows.Forms.RadioButton();
             this.rbStatesBinary = new System.Windows.Forms.RadioButton();
-            this.rbStatesDefault = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.btnResetCompression = new System.Windows.Forms.Button();
             this.trackBarCompression = new System.Windows.Forms.TrackBar();
@@ -762,7 +761,6 @@
             // 
             this.groupBox6.Controls.Add(this.rbStatesText);
             this.groupBox6.Controls.Add(this.rbStatesBinary);
-            this.groupBox6.Controls.Add(this.rbStatesDefault);
             this.groupBox6.Location = new System.Drawing.Point(22, 78);
             this.groupBox6.Name = "groupBox6";
             this.groupBox6.Size = new System.Drawing.Size(215, 48);
@@ -773,7 +771,7 @@
             // rbStatesText
             // 
             this.rbStatesText.AutoSize = true;
-            this.rbStatesText.Location = new System.Drawing.Point(163, 18);
+            this.rbStatesText.Location = new System.Drawing.Point(88, 18);
             this.rbStatesText.Name = "rbStatesText";
             this.rbStatesText.Size = new System.Drawing.Size(46, 17);
             this.rbStatesText.TabIndex = 1;
@@ -784,24 +782,13 @@
             // rbStatesBinary
             // 
             this.rbStatesBinary.AutoSize = true;
-            this.rbStatesBinary.Location = new System.Drawing.Point(88, 18);
+            this.rbStatesBinary.Location = new System.Drawing.Point(6, 18);
             this.rbStatesBinary.Name = "rbStatesBinary";
             this.rbStatesBinary.Size = new System.Drawing.Size(54, 17);
             this.rbStatesBinary.TabIndex = 1;
             this.rbStatesBinary.TabStop = true;
             this.rbStatesBinary.Text = "Binary";
             this.rbStatesBinary.UseVisualStyleBackColor = true;
-            // 
-            // rbStatesDefault
-            // 
-            this.rbStatesDefault.AutoSize = true;
-            this.rbStatesDefault.Location = new System.Drawing.Point(6, 18);
-            this.rbStatesDefault.Name = "rbStatesDefault";
-            this.rbStatesDefault.Size = new System.Drawing.Size(59, 17);
-            this.rbStatesDefault.TabIndex = 0;
-            this.rbStatesDefault.TabStop = true;
-            this.rbStatesDefault.Text = "Default";
-            this.rbStatesDefault.UseVisualStyleBackColor = true;
             // 
             // btnResetCompression
             // 
@@ -1088,7 +1075,6 @@
 				private System.Windows.Forms.GroupBox groupBox6;
 				private System.Windows.Forms.RadioButton rbStatesText;
 				private System.Windows.Forms.RadioButton rbStatesBinary;
-				private System.Windows.Forms.RadioButton rbStatesDefault;
 				private System.Windows.Forms.ToolTip toolTip1;
 				private System.Windows.Forms.TrackBar trackBarCompression;
 				private System.Windows.Forms.NumericUpDown nudCompression;

--- a/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -74,8 +74,7 @@ namespace BizHawk.Client.EmuHawk
 
 			nudCompression.Value = _config.SaveStateCompressionLevelNormal;
 
-			rbStatesDefault.Checked = _config.SaveStateType == SaveStateTypeE.Default;
-			rbStatesBinary.Checked = _config.SaveStateType == SaveStateTypeE.Binary;
+			rbStatesBinary.Checked = _config.SaveStateType == SaveStateTypeE.Binary || _config.SaveStateType == SaveStateTypeE.Default;
 			rbStatesText.Checked = _config.SaveStateType == SaveStateTypeE.Text;
 
 			BackupSavestatesCheckbox.Checked = _config.BackupSavestates;
@@ -182,7 +181,6 @@ namespace BizHawk.Client.EmuHawk
 			// These settings are not used by DoRewindSettings
 			_config.Rewind.SpeedMultiplier = (int)RewindSpeedNumeric.Value;
 			_config.SaveStateCompressionLevelNormal = (int)nudCompression.Value;
-			if (rbStatesDefault.Checked) _config.SaveStateType = SaveStateTypeE.Default;
 			if (rbStatesBinary.Checked) _config.SaveStateType = SaveStateTypeE.Binary;
 			if (rbStatesText.Checked) _config.SaveStateType = SaveStateTypeE.Text;
 			_config.BackupSavestates = BackupSavestatesCheckbox.Checked;

--- a/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -74,7 +74,7 @@ namespace BizHawk.Client.EmuHawk
 
 			nudCompression.Value = _config.SaveStateCompressionLevelNormal;
 
-			rbStatesBinary.Checked = _config.SaveStateType == SaveStateTypeE.Binary || _config.SaveStateType == SaveStateTypeE.Default;
+			rbStatesBinary.Checked = _config.SaveStateType == SaveStateTypeE.Binary;
 			rbStatesText.Checked = _config.SaveStateType == SaveStateTypeE.Text;
 
 			BackupSavestatesCheckbox.Checked = _config.BackupSavestates;

--- a/BizHawk.Client.EmuHawk/movie/RecordMovie.cs
+++ b/BizHawk.Client.EmuHawk/movie/RecordMovie.cs
@@ -108,7 +108,7 @@ namespace BizHawk.Client.EmuHawk
 					movieToRecord.StartsFromSavestate = true;
 					movieToRecord.StartsFromSaveRam = false;
 
-					if (core.BinarySaveStatesPreferred)
+					if (_config.SaveStateType == SaveStateTypeE.Binary)
 					{
 						movieToRecord.BinarySavestate = (byte[])core.SaveStateBinary().Clone();
 					}

--- a/BizHawk.Emulation.Common/Interfaces/Services/IStatable.cs
+++ b/BizHawk.Emulation.Common/Interfaces/Services/IStatable.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using BizHawk.Common.BufferExtensions;
 
 namespace BizHawk.Emulation.Common
 {
@@ -19,13 +20,54 @@ namespace BizHawk.Emulation.Common
 	/// </summary>
 	public interface IStatable : IBinaryStateable, IEmulatorService
 	{
-		void SaveStateText(TextWriter writer);
-		void LoadStateText(TextReader reader);
-
 		/// <summary>
 		/// save state binary to a byte buffer
 		/// </summary>
 		/// <returns>you may NOT modify this.  if you call SaveStateBinary() again with the same core, the old data MAY be overwritten.</returns>
 		byte[] SaveStateBinary();
+	}
+
+	/// <summary>
+	/// Allows a core to opt into text savestates.
+	/// If a core does not implement this interface, a default implementation
+	/// will be used that doesn't yield anything useful in the states, just binary as text
+	/// </summary>
+	public interface ITextStatable : IStatable
+	{
+		void SaveStateText(TextWriter writer);
+
+		void LoadStateText(TextReader reader);
+	}
+
+	public static class StatableExtensions
+	{
+		public static void SaveStateText(this IStatable core, TextWriter writer)
+		{
+			if (core is ITextStatable textCore)
+			{
+				textCore.SaveStateText(writer);
+			}
+
+			var temp = core.SaveStateBinary();
+			temp.SaveAsHexFast(writer);
+		}
+
+		public static void LoadStateText(this IStatable core, TextReader reader)
+		{
+			if (core is ITextStatable textCore)
+			{
+				textCore.LoadStateText(reader);
+			}
+
+			string hex = reader.ReadLine();
+			if (hex != null)
+			{
+				var state = new byte[hex.Length / 2];
+				state.ReadFromHexFast(hex);
+				using var ms = new MemoryStream(state);
+				using var br = new BinaryReader(ms);
+				core.LoadStateBinary(br);
+			}
+		}
 	}
 }

--- a/BizHawk.Emulation.Common/Interfaces/Services/IStatable.cs
+++ b/BizHawk.Emulation.Common/Interfaces/Services/IStatable.cs
@@ -19,11 +19,6 @@ namespace BizHawk.Emulation.Common
 	/// </summary>
 	public interface IStatable : IBinaryStateable, IEmulatorService
 	{
-		/// <summary>
-		/// Gets a value indicating whether the core would rather give a binary savestate than a text one. Both must function regardless
-		/// </summary>
-		bool BinarySaveStatesPreferred { get; }
-
 		void SaveStateText(TextWriter writer);
 		void LoadStateText(TextReader reader);
 

--- a/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Calculators
 {
 	public partial class TI83 : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Calculators
 {
-	public partial class TI83 : IStatable
+	public partial class TI83 : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 	/// CPCHawk: Core Class
 	/// * IStatable *
 	/// </summary>
-	public partial class AmstradCPC : IStatable
+	public partial class AmstradCPC : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
@@ -10,8 +10,6 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 	/// </summary>
 	public partial class AmstradCPC : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IStatable.cs
@@ -32,8 +32,6 @@ namespace BizHawk.Emulation.Cores.Computers.AppleII
 			}
 		}
 
-		public bool BinarySaveStatesPreferred => true;
-
 		private void SerializeEverything(JsonWriter w)
 		{
 			// this is much faster than other possibilities for serialization

--- a/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/AppleII/AppleII.IStatable.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace BizHawk.Emulation.Cores.Computers.AppleII
 {
-	public partial class AppleII : IStatable
+	public partial class AppleII : ITextStatable
 	{
 		private class CoreConverter : JsonConverter
 		{

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 {
 	public sealed partial class C64 : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void LoadStateBinary(BinaryReader br)
 		{
 			SyncState(new Serializer(br));

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.Commodore64
 {
-	public sealed partial class C64 : IStatable
+	public sealed partial class C64 : ITextStatable
 	{
 		public void LoadStateBinary(BinaryReader br)
 		{

--- a/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 {
 	public partial class MSX : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.MSX
 {
-	public partial class MSX : IStatable
+	public partial class MSX : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
@@ -8,7 +8,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// ZXHawk: Core Class
 	/// * IStatable *
 	/// </summary>
-	public partial class ZXSpectrum : IStatable
+	public partial class ZXSpectrum : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
@@ -10,8 +10,6 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// </summary>
 	public partial class ZXSpectrum : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.Atari2600
 {
-	public partial class Atari2600 : IStatable
+	public partial class Atari2600 : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 {
 	public partial class Atari2600 : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(Serializer.CreateTextWriter(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 {
-	public partial class A7800Hawk : IStatable
+	public partial class A7800Hawk : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 {
 	public partial class A7800Hawk : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.Lynx
 {
-	public partial class Lynx : IStatable
+	public partial class Lynx : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{
@@ -19,8 +19,6 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 			s.ExtraData.Frame = Frame;
 
 			_ser.Serialize(writer, s);
-
-			////Console.WriteLine(BizHawk.Common.BufferExtensions.BufferExtensions.HashSHA1(SaveStateBinary()));
 		}
 
 		public void LoadStateText(TextReader reader)

--- a/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/lynx/Lynx.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Atari.Lynx
 {
 	public partial class Lynx : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var s = new TextState<TextStateData>();

--- a/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.ColecoVision
 {
-	public partial class ColecoVision : IStatable
+	public partial class ColecoVision : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 {
 	public partial class ColecoVision : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 {
-	public partial class ChannelF : IStatable
+	public partial class ChannelF : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 {
 	public partial class ChannelF : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
-	public partial class VectrexHawk : IStatable
+	public partial class VectrexHawk : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
 	public partial class VectrexHawk : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Intellivision
 {
 	public partial class Intellivision : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(Serializer.CreateTextWriter(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Intellivision
 {
-	public partial class Intellivision : IStatable
+	public partial class Intellivision : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
-	public partial class O2Hawk : IStatable
+	public partial class O2Hawk : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
 	public partial class O2Hawk : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IStatable.cs
@@ -10,19 +10,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 		private byte[] _savebuff = new byte[0];
 		private byte[] _savebuff2 = new byte[13];
 
-		public void SaveStateText(TextWriter writer)
-		{
-			var tmp = SaveStateBinary();
-			BizHawk.Common.BufferExtensions.BufferExtensions.SaveAsHexFast(tmp, writer);
-		}
-		public void LoadStateText(TextReader reader)
-		{
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			BizHawk.Common.BufferExtensions.BufferExtensions.ReadFromHexFast(state, hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
-
 		private void StartSaveStateBinaryInternal()
 		{
 			IntPtr p = IntPtr.Zero;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IStatable.cs
@@ -10,8 +10,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 		private byte[] _savebuff = new byte[0];
 		private byte[] _savebuff2 = new byte[13];
 
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var tmp = SaveStateBinary();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/VBANext.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/VBANext.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBA
 {
-	public partial class VBANext : IStatable
+	public partial class VBANext : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{
@@ -19,8 +19,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			s.ExtraData.Frame = Frame;
 
 			ser.Serialize(writer, s);
-
-			//Console.WriteLine(BizHawk.Common.BufferExtensions.BufferExtensions.HashSHA1(SaveStateBinary()));
 		}
 
 		public void LoadStateText(TextReader reader)

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/VBANext.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/VBANext.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 {
 	public partial class VBANext : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var s = new TextState<TextStateData>();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 {
 	public partial class GBHawk : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 {
-	public partial class GBHawk : IStatable
+	public partial class GBHawk : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
@@ -1,16 +1,12 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
 
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Nintendo.GBHawk;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 {
 	public partial class GBHawkLink : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			L.SaveStateText(writer);
@@ -49,8 +45,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 			bw.Flush();
 			return ms.ToArray();
 		}
-
-		//private JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
 		private void SyncState(Serializer ser)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 {
-	public partial class GBHawkLink : IStatable
+	public partial class GBHawkLink : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
@@ -4,7 +4,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 {
-	public partial class GBHawkLink3x : IStatable
+	public partial class GBHawkLink3x : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
@@ -1,16 +1,11 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
-
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Nintendo.GBHawk;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 {
 	public partial class GBHawkLink3x : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			L.SaveStateText(writer);
@@ -53,8 +48,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 			bw.Flush();
 			return ms.ToArray();
 		}
-
-		//private JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
 		private void SyncState(Serializer ser)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
@@ -1,16 +1,12 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
 
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
-using BizHawk.Emulation.Cores.Nintendo.GBHawk;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 {
 	public partial class GBHawkLink4x : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			A.SaveStateText(writer);

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 {
-	public partial class GBHawkLink4x : IStatable
+	public partial class GBHawkLink4x : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 {
 	public partial class Gameboy : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var s = SaveState();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 {
-	public partial class Gameboy : IStatable
+	public partial class Gameboy : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
@@ -8,8 +8,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 {
 	public partial class GambatteLink : IStatable
 	{
-		public bool BinarySaveStatesPreferred { get { return true; } }
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var s = new DGBSerialized

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Nintendo.N64.NativeApi;
 
@@ -9,22 +8,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 {
 	public partial class N64 : IStatable
 	{
-		// these functions are all exact copy paste from gambatte.
-		// if something's wrong here, it's probably wrong there too
-		public void SaveStateText(TextWriter writer)
-		{
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			var hex = reader.ReadLine();
-			var state = new byte[hex.Length / 2];
-			state.ReadFromHexFast(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
-
 		public void SaveStateBinary(BinaryWriter writer)
 		{
 			byte[] data = SaveStatePrivateBuff;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
@@ -9,8 +9,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 {
 	public partial class N64 : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		// these functions are all exact copy paste from gambatte.
 		// if something's wrong here, it's probably wrong there too
 		public void SaveStateText(TextWriter writer)

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	public partial class NES : IStatable
+	public partial class NES : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
 	public partial class NES : IStatable
 	{
-		public bool BinarySaveStatesPreferred => false;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(Serializer.CreateTextWriter(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IStatable.cs
@@ -1,28 +1,11 @@
 ﻿using System;
 using System.IO;
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 {
 	public partial class QuickNES : IStatable
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			CheckDisposed();
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			CheckDisposed();
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			state.ReadFromHexFast(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
-
 		public void SaveStateBinary(BinaryWriter writer)
 		{
 			CheckDisposed();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/QuickNES/QuickNES.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.QuickNES
 {
 	public partial class QuickNES : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			CheckDisposed();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
@@ -1,25 +1,10 @@
 ﻿using System.IO;
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.SNES
 {
 	public unsafe partial class LibsnesCore : IStatable
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			state.ReadFromHexFast(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
-
 		public void SaveStateBinary(BinaryWriter writer)
 		{
 			Api.SaveStateBinary(writer);

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
@@ -6,8 +6,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 {
 	public unsafe partial class LibsnesCore : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var temp = SaveStateBinary();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 {
 	public partial class SubNESHawk : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			subnes.SaveStateText(writer);
@@ -43,8 +41,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 			bw.Flush();
 			return ms.ToArray();
 		}
-
-		//private JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
 		private void SyncState(Serializer ser)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 {
-	public partial class SubNESHawk : IStatable
+	public partial class SubNESHawk : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.PCEngine
 {
 	public sealed partial class PCEngine : IStatable
 	{
-		public bool BinarySaveStatesPreferred => false;
-
 		public void SaveStateBinary(BinaryWriter bw)
 		{
 			SyncState(Serializer.CreateBinaryWriter(bw));

--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.PCEngine
 {
-	public sealed partial class PCEngine : IStatable
+	public sealed partial class PCEngine : ITextStatable
 	{
 		public void SaveStateBinary(BinaryWriter bw)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
 
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
@@ -8,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 {
 	public partial class GGHawkLink : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			L.SaveStateText(writer);
@@ -48,8 +45,6 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 			bw.Flush();
 			return ms.ToArray();
 		}
-
-		//private JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
 		private void SyncState(Serializer ser)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 {
-	public partial class GGHawkLink : IStatable
+	public partial class GGHawkLink : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
@@ -5,7 +5,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
-	public partial class SMS : IStatable
+	public partial class SMS : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
 	public partial class SMS : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			SyncState(new Serializer(writer));

--- a/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IStatable.cs
@@ -1,26 +1,10 @@
 ﻿using System.IO;
-
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 {
 	public partial class GPGX : IStatable
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			state.ReadFromHexFast(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
-
 		public void LoadStateBinary(BinaryReader reader)
 		{
 			_elf.LoadStateBinary(reader);

--- a/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.IStatable.cs
@@ -7,8 +7,6 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 {
 	public partial class GPGX : IStatable
 	{
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var temp = SaveStateBinary();

--- a/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -1072,62 +1072,6 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 		#region Savestates
 		//THIS IS STILL AWFUL
 
-		JsonSerializer ser = new JsonSerializer() { Formatting = Formatting.Indented };
-
-		class TextStateData
-		{
-			public int Frame;
-			public int LagCount;
-			public bool IsLagFrame;
-			public bool CurrentDiscEjected;
-			public int CurrentDiscIndexMounted;
-		}
-
-		public void SaveStateText(TextWriter writer)
-		{
-			var s = new TextState<TextStateData>();
-			s.Prepare();
-
-			var transaction = new OctoshockDll.ShockStateTransaction()
-			{
-				transaction = OctoshockDll.eShockStateTransaction.TextSave,
-				ff = s.GetFunctionPointersSave()
-			};
-			int result = OctoshockDll.shock_StateTransaction(psx, ref transaction);
-			if (result != OctoshockDll.SHOCK_OK)
-				throw new InvalidOperationException($"{nameof(OctoshockDll.eShockStateTransaction)}.{nameof(OctoshockDll.eShockStateTransaction.TextSave)} returned error!");
-
-			s.ExtraData.IsLagFrame = IsLagFrame;
-			s.ExtraData.LagCount = LagCount;
-			s.ExtraData.Frame = Frame;
-			s.ExtraData.CurrentDiscEjected = CurrentTrayOpen;
-			s.ExtraData.CurrentDiscIndexMounted = CurrentDiscIndexMounted;
-
-			ser.Serialize(writer, s);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			var s = (TextState<TextStateData>)ser.Deserialize(reader, typeof(TextState<TextStateData>));
-			s.Prepare();
-			var transaction = new OctoshockDll.ShockStateTransaction()
-			{
-				transaction = OctoshockDll.eShockStateTransaction.TextLoad,
-				ff = s.GetFunctionPointersLoad()
-			};
-
-			int result = OctoshockDll.shock_StateTransaction(psx, ref transaction);
-			if (result != OctoshockDll.SHOCK_OK)
-				throw new InvalidOperationException($"{nameof(OctoshockDll.eShockStateTransaction)}.{nameof(OctoshockDll.eShockStateTransaction.TextLoad)} returned error!");
-
-			IsLagFrame = s.ExtraData.IsLagFrame;
-			LagCount = s.ExtraData.LagCount;
-			Frame = s.ExtraData.Frame;
-			CurrentTrayOpen = s.ExtraData.CurrentDiscEjected;
-			CurrentDiscIndexMounted = s.ExtraData.CurrentDiscIndexMounted;
-			PokeDisc();
-		}
-
 		byte[] savebuff;
 		byte[] savebuff2;
 

--- a/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -1208,8 +1208,6 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 			return savebuff2;
 		}
 
-		public bool BinarySaveStatesPreferred => true;
-
 		#endregion
 
 		#region Settings

--- a/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace BizHawk.Emulation.Cores.WonderSwan
 {
-	partial class WonderSwan: IStatable
+	partial class WonderSwan: ITextStatable
 	{
 		private void InitIStatable()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.IStatable.cs
@@ -97,7 +97,5 @@ namespace BizHawk.Emulation.Cores.WonderSwan
 			ms.Close();
 			return savebuff2;
 		}
-
-		public bool BinarySaveStatesPreferred => true;
 	}
 }

--- a/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
+++ b/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
@@ -426,8 +426,6 @@ namespace BizHawk.Emulation.Cores.Libretro
 			return savebuff2;
 		}
 
-		public bool BinarySaveStatesPreferred { get { return true; } }
-
 		#endregion
 
 

--- a/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
+++ b/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
@@ -4,15 +4,9 @@
 //Since it's an IEmulator.. but... I dont know. Yeah, that's probably best
 
 using System;
-using System.Linq;
-using System.Xml;
-using System.Xml.Linq;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-
-using BizHawk.Common;
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Libretro
@@ -363,20 +357,6 @@ namespace BizHawk.Emulation.Cores.Libretro
 		#region savestates
 
 		private byte[] savebuff, savebuff2;
-
-		public void SaveStateText(System.IO.TextWriter writer)
-		{
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(System.IO.TextReader reader)
-		{
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			state.ReadFromHex(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
 
 		public void SaveStateBinary(System.IO.BinaryWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
+++ b/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
@@ -1,14 +1,10 @@
 ﻿using BizHawk.Common;
 using BizHawk.BizInvoke;
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BizHawk.Emulation.Cores.Waterbox
 {
@@ -253,20 +249,6 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		#endregion
 
 		#region IStatable
-
-		public void SaveStateText(TextWriter writer)
-		{
-			var temp = SaveStateBinary();
-			temp.SaveAsHexFast(writer);
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			string hex = reader.ReadLine();
-			byte[] state = new byte[hex.Length / 2];
-			state.ReadFromHexFast(hex);
-			LoadStateBinary(new BinaryReader(new MemoryStream(state)));
-		}
 
 		public void LoadStateBinary(BinaryReader reader)
 		{

--- a/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
+++ b/BizHawk.Emulation.Cores/Waterbox/WaterboxCore.cs
@@ -254,8 +254,6 @@ namespace BizHawk.Emulation.Cores.Waterbox
 
 		#region IStatable
 
-		public bool BinarySaveStatesPreferred => true;
-
 		public void SaveStateText(TextWriter writer)
 		{
 			var temp = SaveStateBinary();


### PR DESCRIPTION
Due to some IRC feedback about https://github.com/TASVideos/BizHawk/pull/1847, I created this more mature handling of text states.

zeromus wanted text states as a feature and thinks it is valuable for core devs and other advanced users (I agree, though I don't think they are utilizing it).

This PR instead:
1) Removes BinaryStatesPreferred and makes Binary the default for all cores, the "Default" config option is removed as well and binary is the default setting
2) Create a default implementation of text states that's just binary as text
3) Create an ITextState interface a core can use if they want to opt into text states (and presumeably implement them properly as readable text)
4) all cores that use the Serializer opt into ITextState since this class properly does text states
5) rip out all the junk from cores that did not use Serializer since none of them produced readable text states

The advantages of this approach are that we retain backwards compatibility with the cores that had text states as the default previously, NesHawk (and consequently SubNesHawk), and PCEHawk, while still retaining the freedom of not requiring cores to implement text state methods