### PR TITLE
create StateSerializer as a base implementation of IStatable

### DIFF
--- a/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
@@ -36,23 +36,23 @@ namespace BizHawk.Emulation.Common
 
 		public void SaveStateText(TextWriter writer)
 		{
-			_syncState(new Serializer(writer));
+			_syncState(Serializer.CreateTextWriter(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			_syncState(new Serializer(reader));
+			_syncState(Serializer.CreateTextReader(reader));
 			LoadStateCallback?.Invoke();
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			_syncState(new Serializer(bw));
+			_syncState(Serializer.CreateBinaryWriter(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			_syncState(new Serializer(br));
+			_syncState(Serializer.CreateBinaryReader(br));
 			LoadStateCallback?.Invoke();
 		}
 

--- a/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using BizHawk.Common;
+namespace BizHawk.Emulation.Common
+{
+	/// <summary>
+	/// A generic implementation of <see cref="IStatable" /> that also
+	/// implements <see cref="ITextStatable" /> using the <see cref="Serializer" /> class
+	/// </summary>
+	public class StateSerializer : ITextStatable
+	{
+		private readonly Action<Serializer> _syncState;
+
+		public StateSerializer(Action<Serializer> syncState)
+		{
+			_syncState = syncState;
+		}
+
+		public void SaveStateText(TextWriter writer)
+		{
+			_syncState(new Serializer(writer));
+		}
+
+		public void LoadStateText(TextReader reader)
+		{
+			_syncState(new Serializer(reader));
+		}
+
+		public void SaveStateBinary(BinaryWriter bw)
+		{
+			_syncState(new Serializer(bw));
+		}
+
+		public void LoadStateBinary(BinaryReader br)
+		{
+			_syncState(new Serializer(br));
+		}
+
+		public byte[] SaveStateBinary()
+		{
+			using var ms = new MemoryStream();
+			using var bw = new BinaryWriter(ms);
+			SaveStateBinary(bw);
+			bw.Flush();
+			return ms.ToArray();
+		}
+	}
+}

--- a/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
+++ b/BizHawk.Emulation.Common/Base Implementations/StateSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using BizHawk.Common;
+
 namespace BizHawk.Emulation.Common
 {
 	/// <summary>
@@ -16,6 +17,11 @@ namespace BizHawk.Emulation.Common
 			_syncState = syncState;
 		}
 
+		/// <summary>
+		/// If provided, will be called after a loadstate call
+		/// </summary>
+		public Action LoadStateCallback { get; set; }
+
 		public void SaveStateText(TextWriter writer)
 		{
 			_syncState(new Serializer(writer));
@@ -24,6 +30,7 @@ namespace BizHawk.Emulation.Common
 		public void LoadStateText(TextReader reader)
 		{
 			_syncState(new Serializer(reader));
+			LoadStateCallback?.Invoke();
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
@@ -34,6 +41,7 @@ namespace BizHawk.Emulation.Common
 		public void LoadStateBinary(BinaryReader br)
 		{
 			_syncState(new Serializer(br));
+			LoadStateCallback?.Invoke();
 		}
 
 		public byte[] SaveStateBinary()

--- a/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Calculator/TI83.IStatable.cs
@@ -1,41 +1,11 @@
 ﻿using System.IO;
 
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Calculators
 {
-	public partial class TI83 : ITextStatable
+	public partial class TI83
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			if (ser.IsWriter)

--- a/BizHawk.Emulation.Cores/Calculator/TI83.cs
+++ b/BizHawk.Emulation.Cores/Calculator/TI83.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Calculators
 
 			ser.Register<ITraceable>(_tracer);
 			ser.Register<IDisassemblable>(_cpu);
-			ser.Register<ITextStatable>(new StateSerializer(SyncState));
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 		}
 
 		private readonly TraceBuffer _tracer;

--- a/BizHawk.Emulation.Cores/Calculator/TI83.cs
+++ b/BizHawk.Emulation.Cores/Calculator/TI83.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Globalization;
-
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Components.Z80A;
 
@@ -13,7 +11,7 @@ namespace BizHawk.Emulation.Cores.Calculators
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(ISoundProvider), typeof(ISaveRam), typeof(IRegionable), typeof(IDriveLight), typeof(IBoardInfo))]
-	public partial class TI83 : IEmulator, IVideoProvider, IStatable, IDebuggable, IInputPollable, ISettable<TI83.TI83Settings, object>
+	public partial class TI83 : IEmulator, IVideoProvider, IDebuggable, IInputPollable, ISettable<TI83.TI83Settings, object>
 	{
 		[CoreConstructor("TI83")]
 		public TI83(CoreComm comm, GameInfo game, byte[] rom, object settings)
@@ -42,6 +40,7 @@ namespace BizHawk.Emulation.Cores.Calculators
 
 			ser.Register<ITraceable>(_tracer);
 			ser.Register<IDisassemblable>(_cpu);
+			ser.Register<ITextStatable>(new StateSerializer(SyncState));
 		}
 
 		private readonly TraceBuffer _tracer;

--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.IStatable.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 {
@@ -8,37 +7,8 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 	/// CPCHawk: Core Class
 	/// * IStatable *
 	/// </summary>
-	public partial class AmstradCPC : ITextStatable
+	public partial class AmstradCPC
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.cs
+++ b/BizHawk.Emulation.Cores/Computers/AmstradCPC/AmstradCPC.cs
@@ -74,6 +74,7 @@ namespace BizHawk.Emulation.Cores.Computers.AmstradCPC
 			ser.Register<ITraceable>(_tracer);
 			ser.Register<IDisassemblable>(_cpu);
 			ser.Register<IVideoProvider>(_machine.GateArray);
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 
 			// initialize sound mixer and attach the various ISoundProvider devices
 			SoundMixer = new SoundProviderMixer((int)(32767 / 10), "Tape Audio", (ISoundProvider)_machine.TapeBuzzer);

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.IStatable.cs
@@ -1,41 +1,9 @@
-﻿using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.Commodore64
 {
-	public sealed partial class C64 : ITextStatable
+	public sealed partial class C64
 	{
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			ser.BeginSection("core");

--- a/BizHawk.Emulation.Cores/Computers/Commodore64/C64.cs
+++ b/BizHawk.Emulation.Cores/Computers/Commodore64/C64.cs
@@ -60,6 +60,7 @@ namespace BizHawk.Emulation.Cores.Computers.Commodore64
 
 			_tracer = new TraceBuffer { Header = _board.Cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 
 			if (_board.CartPort.IsConnected)
 			{

--- a/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/MSX/MSX.IStatable.cs
@@ -1,42 +1,9 @@
-﻿using System;
-using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.MSX
 {
-	public partial class MSX : ITextStatable
+	public partial class MSX
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			ser.BeginSection("MSX");

--- a/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
+++ b/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 		isPorted: false,
 		isReleased: false)]
 	[ServiceNotApplicable(typeof(IDriveLight))]
-	public partial class MSX : IEmulator, IVideoProvider, ISoundProvider, ISaveRam, IStatable, IInputPollable, IRegionable, ISettable<MSX.MSXSettings, MSX.MSXSyncSettings>
+	public partial class MSX : IEmulator, IVideoProvider, ISoundProvider, ISaveRam, IInputPollable, IRegionable, ISettable<MSX.MSXSettings, MSX.MSXSyncSettings>
 	{
 		[CoreConstructor("MSX")]
 		public MSX(CoreComm comm, GameInfo game, byte[] rom, object settings, object syncSettings)
@@ -92,6 +92,7 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 
 			var serviceProvider = ServiceProvider as BasicServiceProvider;
 			serviceProvider.Register<ITraceable>(Tracer);
+			serviceProvider.Register<IStatable>(new StateSerializer(SyncState));
 
 			current_controller = SyncSettings.Contr_Setting == MSXSyncSettings.ContrType.Keyboard ? MSXControllerKB : MSXControllerJS;
 		}

--- a/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.IStatable.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 {
@@ -8,37 +7,8 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 	/// ZXHawk: Core Class
 	/// * IStatable *
 	/// </summary>
-	public partial class ZXSpectrum : ITextStatable
+	public partial class ZXSpectrum
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.cs
+++ b/BizHawk.Emulation.Cores/Computers/SinclairSpectrum/ZXSpectrum.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BizHawk.Emulation.Cores.Components;
-using BizHawk.Emulation.Cores.Sound;
 
 namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 {
@@ -145,7 +144,7 @@ namespace BizHawk.Emulation.Cores.Computers.SinclairSpectrum
 
 			DCFilter dc = new DCFilter(SoundMixer, 512);
 			ser.Register<ISoundProvider>(dc);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			HardReset();
 			SetupMemoryDomains();
 		}

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.IStatable.cs
@@ -1,41 +1,9 @@
-﻿using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.Atari2600
 {
-	public partial class Atari2600 : ITextStatable
+	public partial class Atari2600
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(Serializer.CreateTextWriter(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(Serializer.CreateTextReader(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(Serializer.CreateBinaryWriter(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(Serializer.CreateBinaryReader(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			ser.BeginSection("A2600");

--- a/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(ISaveRam), typeof(IDriveLight))]
-	public partial class Atari2600 : IEmulator, IStatable, IDebuggable, IInputPollable, IBoardInfo,
+	public partial class Atari2600 : IEmulator, IDebuggable, IInputPollable, IBoardInfo,
 		IRegionable, ICreateGameDBEntries, ISettable<Atari2600.A2600Settings, Atari2600.A2600SyncSettings>
 	{
 		[CoreConstructor("A26")]
@@ -58,6 +58,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			ser.Register<ITraceable>(Tracer);
 			ser.Register<IVideoProvider>(_tia);
 			ser.Register<ISoundProvider>(_dcfilter);
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 		}
 
 		private readonly Atari2600ControllerDeck _controllerDeck;

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.ISettable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 {
-	public partial class A7800Hawk : IEmulator, IStatable, ISettable<A7800Hawk.A7800Settings, A7800Hawk.A7800SyncSettings>
+	public partial class A7800Hawk : IEmulator, ISettable<A7800Hawk.A7800Settings, A7800Hawk.A7800SyncSettings>
 	{
 		public A7800Settings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.IStatable.cs
@@ -1,41 +1,9 @@
-﻿using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 {
-	public partial class A7800Hawk : ITextStatable
+	public partial class A7800Hawk
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			cpu.SyncState(ser);

--- a/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800Hawk.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(ISettable<,>), typeof(IDriveLight))]
-	public partial class A7800Hawk : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable,
+	public partial class A7800Hawk : IEmulator, ISaveRam, IDebuggable, IInputPollable,
 		IRegionable, IBoardInfo, ISettable<A7800Hawk.A7800Settings, A7800Hawk.A7800SyncSettings>
 	{
 		// this register selects between 2600 and 7800 mode in the A7800
@@ -255,7 +255,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 			_tracer = new TraceBuffer { Header = cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 			ser.Register<IDisassemblable>(cpu);
 			HardReset();

--- a/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.ISettable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.ColecoVision
 {
-	public partial class ColecoVision : IEmulator, IStatable, ISettable<ColecoVision.ColecoSettings, ColecoVision.ColecoSyncSettings>
+	public partial class ColecoVision : IEmulator, ISettable<ColecoVision.ColecoSettings, ColecoVision.ColecoSyncSettings>
 	{
 		public ColecoSettings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.IStatable.cs
@@ -1,41 +1,11 @@
 ﻿using System.IO;
 
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.ColecoVision
 {
-	public partial class ColecoVision : ITextStatable
+	public partial class ColecoVision
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoVision.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(ISaveRam), typeof(IDriveLight))]
-	public sealed partial class ColecoVision : IEmulator, IDebuggable, IInputPollable, IStatable, ISettable<ColecoVision.ColecoSettings, ColecoVision.ColecoSyncSettings>
+	public sealed partial class ColecoVision : IEmulator, IDebuggable, IInputPollable, ISettable<ColecoVision.ColecoSettings, ColecoVision.ColecoSyncSettings>
 	{
 		[CoreConstructor("Coleco")]
 		public ColecoVision(CoreComm comm, GameInfo game, byte[] rom, object syncSettings)
@@ -40,6 +40,7 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 
 			_vdp = new TMS9918A(_cpu);
 			ser.Register<IVideoProvider>(_vdp);
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 
 			// TODO: hack to allow bios-less operation would be nice, no idea if its feasible
 			_biosRom = CoreComm.CoreFileProvider.GetFirmware("Coleco", "Bios", true, "Coleco BIOS file is required.");

--- a/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.IStatable.cs
@@ -1,42 +1,9 @@
-﻿using System;
-using System.IO;
-using BizHawk.Common;
-using BizHawk.Common.BufferExtensions;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 {
-	public partial class ChannelF : ITextStatable
+	public partial class ChannelF
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			ser.BeginSection("ChannelF");

--- a/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Fairchild/ChannelF/ChannelF.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using BizHawk.Common;
-using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.ChannelF
@@ -48,7 +46,7 @@ namespace BizHawk.Emulation.Cores.Consoles.ChannelF
 			ser.Register<ITraceable>(_tracer);
 			ser.Register<IDisassemblable>(CPU);
 			ser.Register<ISoundProvider>(this);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISettable.cs
@@ -8,7 +8,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
-	public partial class VectrexHawk : IEmulator, IStatable, ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>
+	public partial class VectrexHawk : IEmulator, ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>
 	{
 		public VectrexSettings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.IStatable.cs
@@ -1,41 +1,10 @@
 ﻿using System.IO;
-
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
-	public partial class VectrexHawk : ITextStatable
+	public partial class VectrexHawk
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(IDriveLight))]
-	public partial class VectrexHawk : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable, 
+	public partial class VectrexHawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, 
 	ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>
 	{
 		public byte[] RAM = new byte[0x400];
@@ -117,7 +117,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 
 			_tracer = new TraceBuffer { Header = cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 			HardReset();
 

--- a/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.ISettable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Intellivision
 {
-	public partial class Intellivision : IEmulator, IStatable, ISettable<Intellivision.IntvSettings, Intellivision.IntvSyncSettings>
+	public partial class Intellivision : IEmulator, ISettable<Intellivision.IntvSettings, Intellivision.IntvSyncSettings>
 	{
 		public IntvSettings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.IStatable.cs
@@ -1,43 +1,9 @@
-﻿using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.Intellivision
 {
-	public partial class Intellivision : ITextStatable
+	public partial class Intellivision
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(Serializer.CreateTextWriter(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(Serializer.CreateTextReader(reader));
-			SetupMemoryDomains(); // resync the memory domains
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(Serializer.CreateBinaryWriter(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(Serializer.CreateBinaryReader(br));
-			SetupMemoryDomains(); // resync the memory domains
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			var ms = new MemoryStream();
-			var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			int version = 1;

--- a/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Intellivision/Intellivision.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Emulation.Cores.Intellivision
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(ISaveRam), typeof(IDriveLight), typeof(IRegionable))]
-	public sealed partial class Intellivision : IEmulator, IStatable, IInputPollable, IDisassemblable,
+	public sealed partial class Intellivision : IEmulator, IInputPollable, IDisassemblable,
 		IBoardInfo, IDebuggable, ISettable<Intellivision.IntvSettings, Intellivision.IntvSyncSettings>
 	{
 		[CoreConstructor("INTV")]
@@ -68,7 +68,7 @@ namespace BizHawk.Emulation.Cores.Intellivision
 
 			_tracer = new TraceBuffer { Header = _cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.ISettable.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.ComponentModel;
-
-using Newtonsoft.Json;
-
+﻿using System.ComponentModel;
 using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
-	public partial class O2Hawk : IEmulator, IStatable, ISettable<O2Hawk.O2Settings, O2Hawk.O2SyncSettings>
+	public partial class O2Hawk : IEmulator, ISettable<O2Hawk.O2Settings, O2Hawk.O2SyncSettings>
 	{
 		public O2Settings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.IStatable.cs
@@ -1,41 +1,10 @@
 ﻿using System.IO;
-
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
-	public partial class O2Hawk : ITextStatable
+	public partial class O2Hawk
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
@@ -4,8 +4,6 @@ using BizHawk.Common.BufferExtensions;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Components.I8048;
 
-using System.Runtime.InteropServices;
-
 namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 {
 	[Core(
@@ -14,7 +12,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 		isPorted: false,
 		isReleased: false)]
 	[ServiceNotApplicable(typeof(IDriveLight))]
-	public partial class O2Hawk : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable, ISettable<O2Hawk.O2Settings, O2Hawk.O2SyncSettings>
+	public partial class O2Hawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, ISettable<O2Hawk.O2Settings, O2Hawk.O2SyncSettings>
 	{
 		// memory domains
 		public byte[] RAM = new byte[0x80];
@@ -99,7 +97,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 
 			_tracer = new TraceBuffer { Header = cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 			HardReset();
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.ISettable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.ISettable.cs
@@ -8,7 +8,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 {
-	public partial class GBHawk : IEmulator, IStatable, ISettable<GBHawk.GBSettings, GBHawk.GBSyncSettings>
+	public partial class GBHawk : IEmulator, ISettable<GBHawk.GBSettings, GBHawk.GBSyncSettings>
 	{
 		public GBSettings GetSettings()
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.IStatable.cs
@@ -1,41 +1,10 @@
 ﻿using System.IO;
-
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 {
-	public partial class GBHawk : ITextStatable
+	public partial class GBHawk
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawk.cs
@@ -15,7 +15,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(IDriveLight))]
-	public partial class GBHawk : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable, IGameboyCommon,
+	public partial class GBHawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, IGameboyCommon,
 	ISettable<GBHawk.GBSettings, GBHawk.GBSyncSettings>
 	{
 		// this register controls whether or not the GB BIOS is mapped into memory
@@ -188,7 +188,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 
 			_tracer = new TraceBuffer { Header = cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
-
+			ser.Register<IStatable>(new StateSerializer(SyncState, false));
 			SetupMemoryDomains();
 			HardReset();
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.IStatable.cs
@@ -7,40 +7,43 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 {
 	public partial class GBHawkLink : ITextStatable
 	{
+		private readonly ITextStatable _lStates;
+		private readonly ITextStatable _rStates;
+
 		public void SaveStateText(TextWriter writer)
 		{
-			L.SaveStateText(writer);
-			R.SaveStateText(writer);
+			_lStates.SaveStateText(writer);
+			_rStates.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			L.LoadStateText(reader);
-			R.LoadStateText(reader);
+			_lStates.LoadStateText(reader);
+			_rStates.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			L.SaveStateBinary(bw);
-			R.SaveStateBinary(bw);
+			_lStates.SaveStateBinary(bw);
+			_rStates.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			L.LoadStateBinary(br);
-			R.LoadStateBinary(br);
+			_lStates.LoadStateBinary(br);
+			_rStates.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}
 
 		public byte[] SaveStateBinary()
 		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
+			using var ms = new MemoryStream();
+			using var bw = new BinaryWriter(ms);
 			SaveStateBinary(bw);
 			bw.Flush();
 			return ms.ToArray();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
@@ -74,6 +74,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 
 			ServiceProvider = ser;
 
+			_lStates = (ITextStatable)L.ServiceProvider.GetService<IStatable>();
+			_rStates = (ITextStatable)R.ServiceProvider.GetService<IStatable>();
+
 			SetupMemoryDomains();
 
 			HardReset();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.IStatable.cs
@@ -6,36 +6,40 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 {
 	public partial class GBHawkLink3x : ITextStatable
 	{
+		private readonly ITextStatable _lStates;
+		private readonly ITextStatable _cStates;
+		private readonly ITextStatable _rStates;
+
 		public void SaveStateText(TextWriter writer)
 		{
-			L.SaveStateText(writer);
-			C.SaveStateText(writer);
-			R.SaveStateText(writer);
+			_lStates.SaveStateText(writer);
+			_cStates.SaveStateText(writer);
+			_rStates.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			L.LoadStateText(reader);
-			C.LoadStateText(reader);
-			R.LoadStateText(reader);
+			_lStates.LoadStateText(reader);
+			_cStates.LoadStateText(reader);
+			_rStates.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			L.SaveStateBinary(bw);
-			C.SaveStateBinary(bw);
-			R.SaveStateBinary(bw);
+			_lStates.SaveStateBinary(bw);
+			_cStates.SaveStateBinary(bw);
+			_rStates.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			L.LoadStateBinary(br);
-			C.LoadStateBinary(br);
-			R.LoadStateBinary(br);
+			_lStates.LoadStateBinary(br);
+			_cStates.LoadStateBinary(br);
+			_rStates.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
@@ -1,8 +1,4 @@
-﻿using System;
-
-using BizHawk.Emulation.Common;
-
-using BizHawk.Emulation.Cores.Nintendo.GBHawk;
+﻿using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 {
@@ -81,7 +77,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 			_tracer = new TraceBuffer { Header = L.cpu.TraceHeader };
 			ser.Register<ITraceable>(_tracer);
 
-			ServiceProvider = ser;
+			_lStates = (ITextStatable)L.ServiceProvider.GetService<IStatable>();
+			_cStates = (ITextStatable)C.ServiceProvider.GetService<IStatable>();
+			_rStates = (ITextStatable)R.ServiceProvider.GetService<IStatable>();
 
 			SetupMemoryDomains();
 

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.IStatable.cs
@@ -7,40 +7,45 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 {
 	public partial class GBHawkLink4x : ITextStatable
 	{
+		private readonly ITextStatable _aStates;
+		private readonly ITextStatable _bStates;
+		private readonly ITextStatable _cStates;
+		private readonly ITextStatable _dStates;
+
 		public void SaveStateText(TextWriter writer)
 		{
-			A.SaveStateText(writer);
-			B.SaveStateText(writer);
-			C.SaveStateText(writer);
-			D.SaveStateText(writer);
+			_aStates.SaveStateText(writer);
+			_bStates.SaveStateText(writer);
+			_cStates.SaveStateText(writer);
+			_dStates.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			A.LoadStateText(reader);
-			B.LoadStateText(reader);
-			C.LoadStateText(reader);
-			D.LoadStateText(reader);
+			_aStates.LoadStateText(reader);
+			_bStates.LoadStateText(reader);
+			_cStates.LoadStateText(reader);
+			_dStates.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			A.SaveStateBinary(bw);
-			B.SaveStateBinary(bw);
-			C.SaveStateBinary(bw);
-			D.SaveStateBinary(bw);
+			_aStates.SaveStateBinary(bw);
+			_bStates.SaveStateBinary(bw);
+			_cStates.SaveStateBinary(bw);
+			_dStates.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			A.LoadStateBinary(br);
-			B.LoadStateBinary(br);
-			C.LoadStateBinary(br);
-			D.LoadStateBinary(br);
+			_aStates.LoadStateBinary(br);
+			_bStates.LoadStateBinary(br);
+			_cStates.LoadStateBinary(br);
+			_dStates.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}
@@ -53,8 +58,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 			bw.Flush();
 			return ms.ToArray();
 		}
-
-		//private JsonSerializer ser = new JsonSerializer { Formatting = Formatting.Indented };
 
 		private void SyncState(Serializer ser)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
@@ -94,6 +94,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 
 			ServiceProvider = ser;
 
+			_aStates = (ITextStatable)A.ServiceProvider.GetService<IStatable>();
+			_bStates = (ITextStatable)B.ServiceProvider.GetService<IStatable>();
+			_cStates = (ITextStatable)C.ServiceProvider.GetService<IStatable>();
+			_dStates = (ITextStatable)D.ServiceProvider.GetService<IStatable>();
+
 			SetupMemoryDomains();
 
 			HardReset();

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GambatteLink.IStatable.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 {
-	public partial class GambatteLink : IStatable
+	public partial class GambatteLink : ITextStatable
 	{
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IStatable.cs
@@ -1,43 +1,10 @@
 ﻿using System;
-using System.IO;
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.NES
 {
-	public partial class NES : ITextStatable
+	public partial class NES
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(Serializer.CreateTextWriter(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(Serializer.CreateTextReader(reader));
-			SetupMemoryDomains(); // resync the memory domains
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(Serializer.CreateBinaryWriter(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(Serializer.CreateBinaryReader(br));
-			SetupMemoryDomains(); // resync the memory domains
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			int version = 4;

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		"zeromus, natt, alyosha, adelikat",
 		isPorted: false,
 		isReleased: true)]
-	public partial class NES : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable,
+	public partial class NES : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable,
 		IBoardInfo, ISettable<NES.NESSettings, NES.NESSyncSettings>, ICodeDataLogger
 	{
 		[CoreConstructor("NES")]
@@ -63,6 +63,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			ser.Register<ITraceable>(Tracer);
 			ser.Register<IVideoProvider>(videoProvider);
 			ser.Register<ISoundProvider>(this);
+			ser.Register<IStatable>(new StateSerializer(SyncState)
+			{
+				LoadStateCallback = SetupMemoryDomains
+			});
 
 			if (Board is BANDAI_FCG_1)
 			{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
@@ -7,28 +7,30 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 {
 	public partial class SubNESHawk : ITextStatable
 	{
+		private readonly IStatable _nesStatable;
+
 		public void SaveStateText(TextWriter writer)
 		{
-			subnes.SaveStateText(writer);
+			_nesStatable.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			subnes.LoadStateText(reader);
+			_nesStatable.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			subnes.SaveStateBinary(bw);
+			_nesStatable.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			subnes.LoadStateBinary(br);
+			_nesStatable.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.IStatable.cs
@@ -7,7 +7,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 {
 	public partial class SubNESHawk : ITextStatable
 	{
-		private readonly IStatable _nesStatable;
+		private readonly ITextStatable _nesStatable;
 
 		public void SaveStateText(TextWriter writer)
 		{

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
@@ -48,6 +48,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 			current_cycle = 0;
 			subnes.cpu.ext_ppu_cycle = current_cycle;
 			VBL_CNT = 0;
+
+			_nesStatable = subnes.ServiceProvider.GetService<IStatable>();
 		}
 
 		public void HardReset()

--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/SubNESHawk/SubNESHawk.cs
@@ -49,7 +49,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubNESHawk
 			subnes.cpu.ext_ppu_cycle = current_cycle;
 			VBL_CNT = 0;
 
-			_nesStatable = subnes.ServiceProvider.GetService<IStatable>();
+			_nesStatable = (ITextStatable)subnes.ServiceProvider.GetService<IStatable>();
 		}
 
 		public void HardReset()

--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.IStatable.cs
@@ -1,57 +1,9 @@
-﻿using System.IO;
-
-using BizHawk.Common;
-using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
 
 namespace BizHawk.Emulation.Cores.PCEngine
 {
-	public sealed partial class PCEngine : ITextStatable
+	public sealed partial class PCEngine
 	{
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(Serializer.CreateBinaryWriter(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(Serializer.CreateBinaryReader(br));
-		}
-
-		public void SaveStateText(TextWriter tw)
-		{
-			SyncState(Serializer.CreateTextWriter(tw));
-		}
-
-		public void LoadStateText(TextReader tr)
-		{
-			SyncState(Serializer.CreateTextReader(tr));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			if (_stateBuffer == null)
-			{
-				var stream = new MemoryStream();
-				var writer = new BinaryWriter(stream);
-				SaveStateBinary(writer);
-				writer.Flush();
-				_stateBuffer = stream.ToArray();
-				writer.Close();
-				return _stateBuffer;
-			}
-			else
-			{
-				var stream = new MemoryStream(_stateBuffer);
-				var writer = new BinaryWriter(stream);
-				SaveStateBinary(writer);
-				writer.Flush();
-				writer.Close();
-				return _stateBuffer;
-			}
-		}
-
-		private byte[] _stateBuffer;
-
 		private void SyncState(Serializer ser)
 		{
 			ser.BeginSection(nameof(PCEngine));

--- a/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
+++ b/BizHawk.Emulation.Cores/Consoles/PC Engine/PCEngine.cs
@@ -16,7 +16,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 		"Vecna",
 		isPorted: false,
 		isReleased: true)]
-	public sealed partial class PCEngine : IEmulator, ISaveRam, IStatable, IInputPollable,
+	public sealed partial class PCEngine : IEmulator, ISaveRam, IInputPollable,
 		IDebuggable, ISettable<PCEngine.PCESettings, PCEngine.PCESyncSettings>, IDriveLight, ICodeDataLogger
 	{
 		[CoreConstructor("PCE", "SGX")]
@@ -321,6 +321,7 @@ namespace BizHawk.Emulation.Cores.PCEngine
 			ser.Register<IDisassemblable>(Cpu);
 			ser.Register<IVideoProvider>((IVideoProvider)VPC ?? VDC1);
 			ser.Register<ISoundProvider>(_soundProvider);
+			ser.Register<IStatable>(new StateSerializer(SyncState));
 			SetupMemoryDomains();
 		}
 

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
@@ -7,35 +7,35 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 {
 	public partial class GGHawkLink : ITextStatable
 	{
-		private readonly ITextStatable _leftStatable;
-		private readonly ITextStatable _rightStatable;
+		private readonly ITextStatable _lStates;
+		private readonly ITextStatable _rStates;
 
 		public void SaveStateText(TextWriter writer)
 		{
-			_leftStatable.SaveStateText(writer);
-			_rightStatable.SaveStateText(writer);
+			_lStates.SaveStateText(writer);
+			_rStates.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			_leftStatable.LoadStateText(reader);
-			_rightStatable.LoadStateText(reader);
+			_lStates.LoadStateText(reader);
+			_rStates.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			_leftStatable.SaveStateBinary(bw);
-			_rightStatable.SaveStateBinary(bw);
+			_lStates.SaveStateBinary(bw);
+			_rStates.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			_leftStatable.LoadStateBinary(br);
-			_rightStatable.LoadStateBinary(br);
+			_lStates.LoadStateBinary(br);
+			_rStates.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.IStatable.cs
@@ -7,40 +7,43 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 {
 	public partial class GGHawkLink : ITextStatable
 	{
+		private readonly ITextStatable _leftStatable;
+		private readonly ITextStatable _rightStatable;
+
 		public void SaveStateText(TextWriter writer)
 		{
-			L.SaveStateText(writer);
-			R.SaveStateText(writer);
+			_leftStatable.SaveStateText(writer);
+			_rightStatable.SaveStateText(writer);
 			SyncState(new Serializer(writer));
 		}
 
 		public void LoadStateText(TextReader reader)
 		{
-			L.LoadStateText(reader);
-			R.LoadStateText(reader);
+			_leftStatable.LoadStateText(reader);
+			_rightStatable.LoadStateText(reader);
 			SyncState(new Serializer(reader));
 		}
 
 		public void SaveStateBinary(BinaryWriter bw)
 		{
-			L.SaveStateBinary(bw);
-			R.SaveStateBinary(bw);
+			_leftStatable.SaveStateBinary(bw);
+			_rightStatable.SaveStateBinary(bw);
 			// other variables
 			SyncState(new Serializer(bw));
 		}
 
 		public void LoadStateBinary(BinaryReader br)
 		{
-			L.LoadStateBinary(br);
-			R.LoadStateBinary(br);
+			_leftStatable.LoadStateBinary(br);
+			_rightStatable.LoadStateBinary(br);
 			// other variables
 			SyncState(new Serializer(br));
 		}
 
 		public byte[] SaveStateBinary()
 		{
-			MemoryStream ms = new MemoryStream();
-			BinaryWriter bw = new BinaryWriter(ms);
+			using var ms = new MemoryStream();
+			using var bw = new BinaryWriter(ms);
 			SaveStateBinary(bw);
 			bw.Flush();
 			return ms.ToArray();

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
@@ -60,6 +60,9 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 
 			L.stand_alone = false;
 			R.stand_alone = false;
+
+			_leftStatable = (ITextStatable)L.ServiceProvider.GetService<IStatable>();
+			_rightStatable = (ITextStatable)R.ServiceProvider.GetService<IStatable>();
 		}
 
 		public void HardReset()

--- a/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
@@ -61,8 +61,8 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 			L.stand_alone = false;
 			R.stand_alone = false;
 
-			_leftStatable = (ITextStatable)L.ServiceProvider.GetService<IStatable>();
-			_rightStatable = (ITextStatable)R.ServiceProvider.GetService<IStatable>();
+			_lStates = (ITextStatable)L.ServiceProvider.GetService<IStatable>();
+			_rStates = (ITextStatable)R.ServiceProvider.GetService<IStatable>();
 		}
 
 		public void HardReset()

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IStatable.cs
@@ -1,41 +1,10 @@
 ﻿using System.IO;
-
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
-	public partial class SMS : ITextStatable
+	public partial class SMS
 	{
-		public void SaveStateText(TextWriter writer)
-		{
-			SyncState(new Serializer(writer));
-		}
-
-		public void LoadStateText(TextReader reader)
-		{
-			SyncState(new Serializer(reader));
-		}
-
-		public void SaveStateBinary(BinaryWriter bw)
-		{
-			SyncState(new Serializer(bw));
-		}
-
-		public void LoadStateBinary(BinaryReader br)
-		{
-			SyncState(new Serializer(br));
-		}
-
-		public byte[] SaveStateBinary()
-		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			SaveStateBinary(bw);
-			bw.Flush();
-			return ms.ToArray();
-		}
-
 		private void SyncState(Serializer ser)
 		{
 			byte[] core = null;

--- a/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.cs
@@ -21,7 +21,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 		isPorted: false,
 		isReleased: true)]
 	[ServiceNotApplicable(typeof(IDriveLight))]
-	public partial class SMS : IEmulator, ISaveRam, IStatable, IInputPollable, IRegionable,
+	public partial class SMS : IEmulator, ISaveRam, IInputPollable, IRegionable,
 		IDebuggable, ISettable<SMS.SmsSettings, SMS.SmsSyncSettings>, ICodeDataLogger
 	{
 		[CoreConstructor("SMS", "SG", "GG")]
@@ -201,6 +201,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 			var serviceProvider = ServiceProvider as BasicServiceProvider;
 			serviceProvider.Register<ITraceable>(Tracer);
 			serviceProvider.Register<IDisassemblable>(Cpu);
+			serviceProvider.Register<IStatable>(new StateSerializer(SyncState));
 			Vdp.ProcessOverscan();
 
 			Cpu.ReadMemory = ReadMemory;


### PR DESCRIPTION
StateSerializer does all the operations of IStatable and ITextStatable using the Serializer class and can be registered with the ServiceProvider of a core.  This reduces a lot of the boiler plate in cores that use Serializer and ensures consistency