### PR TITLE
Fix InvalidCastException in JoypadLuaLibrary.SetAnalog

### DIFF
--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Joypad.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Joypad.cs
@@ -54,7 +54,7 @@ namespace BizHawk.Client.Common
 		public void SetAnalog(LuaTable controls, object controller = null)
 		{
 			var dict = new Dictionary<string, float>();
-			foreach (var k in controls.Keys) dict[k.ToString()] = (float) controls[k];
+			foreach (var k in controls.Keys) dict[k.ToString()] = Convert.ToSingle(controls[k]);
 			APIs.Joypad.SetAnalog(dict, controller);
 		}
 	}


### PR DESCRIPTION
The current implementation for this function tries to coerce passed values into floats:
https://github.com/TASVideos/BizHawk/blob/096277122553d38d87fa11c0cfe4d45e2682b939/BizHawk.Client.Common/lua/EmuLuaLibrary.Joypad.cs#L52-L59

However, the indexing operator for LuaTable returns `object`, causing this line to be interpreted as *unboxing* the table value to a `float`.

By [old](https://www.lua.org/pil/2.3.html) and [new](https://www.lua.org/manual/5.3/manual.html#lua_Number) spec, Lua numbers are expected to be implemented to double precision by default, and this is true for the `NLua+KopiLua` and `Lua+LuaInterface` implementations, so the value returned by `controls[k]` ends up being a `double` boxed as `object`.

Attempting to unbox `double` as `float` throws a `System.InvalidCastException: Specified cast is not valid.`, making it impossible to use this method, since Lua only has the single numeric type.

![image](https://user-images.githubusercontent.com/8049998/75269973-237f0e00-583d-11ea-8609-b027997cbde6.png)

Another potential implementation of this fix would be:
```csharp
foreach (var k in controls.Keys) dict[k.ToString()] = (float) (double) controls[k];
```
which explicitly unboxes to double and then casts, but this solution serves as more of a catchall if an implementation does end up customized to single precision floats.