### PR TITLE
Fixes joypad.set() method in Lua Console

### DIFF
--- a/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -44,6 +44,8 @@ namespace BizHawk.Client.Common
 
 		public void Set(Dictionary<string, bool> buttons, int? controller = null)
 		{
+			// If a controller is specified, we need to iterate over unique button names. If not, we iterate over
+			// ALL button names with P{controller} prefixes
 			foreach (var button in Global.InputManager.ActiveController.ToBoolButtonNameList(controller))
 			{
 				Set(button, buttons.TryGetValue(button, out var state) ? state : (bool?) null, controller);

--- a/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
+++ b/BizHawk.Client.Common/Api/Classes/JoypadApi.cs
@@ -44,7 +44,7 @@ namespace BizHawk.Client.Common
 
 		public void Set(Dictionary<string, bool> buttons, int? controller = null)
 		{
-			foreach (var button in Global.InputManager.ActiveController.Definition.BoolButtons)
+			foreach (var button in Global.InputManager.ActiveController.ToBoolButtonNameList(controller))
 			{
 				Set(button, buttons.TryGetValue(button, out var state) ? state : (bool?) null, controller);
 			}

--- a/BizHawk.Client.Common/lua/EmuLuaLibrary.Joypad.cs
+++ b/BizHawk.Client.Common/lua/EmuLuaLibrary.Joypad.cs
@@ -45,7 +45,7 @@ namespace BizHawk.Client.Common
 		public void Set(LuaTable buttons, int? controller = null)
 		{
 			var dict = new Dictionary<string, bool>();
-			foreach (var k in buttons.Keys) dict[k.ToString()] = (bool) buttons[k];
+			foreach (var k in buttons.Keys) dict[k.ToString()] = Convert.ToBoolean(buttons[k]); // Accepts 1/0 or true/false
 			APIs.Joypad.Set(dict, controller);
 		}
 

--- a/BizHawk.Emulation.Common/Extensions.cs
+++ b/BizHawk.Emulation.Common/Extensions.cs
@@ -314,6 +314,47 @@ namespace BizHawk.Emulation.Common
 			return !info.GetCustomAttributes(false).Any(a => a is FeatureNotImplementedAttribute);
 		}
 
+		/// <summary>
+		/// Gets a list of boolean button names. If a controller number is specified, only returns button names
+		/// (without the "P" prefix) that match that controller number. If a controller number is NOT specified,
+		/// then all button names are returned.
+		/// 
+		/// For example, consider example "P1 A", "P1 B", "P2 A", "P2 B". See below for sample outputs:
+		///   - ToBoolButtonNameList(controller, 1) -> [A, B]
+		///   - ToBoolButtonNameList(controller, 2) -> [A, B]
+		///   - ToBoolButtonNameList(controller, null) -> [P1 A, P1 B, P2 A, P2 B]
+		/// </summary>
+		public static List<string> ToBoolButtonNameList(this IController controller, int? controllerNum = null)
+		{
+			return ToControlNameList(controller.Definition.BoolButtons, controllerNum);
+		}
+
+		/// <summary>
+		/// See ToBoolButtonNameList(). Works the same except with float controls
+		/// </summary>
+		public static List<string> ToFloatControlNameList(this IController controller, int? controllerNum = null)
+		{
+			return ToControlNameList(controller.Definition.FloatControls, controllerNum);
+		}
+
+		private static List<string> ToControlNameList(List<string> buttonList, int? controllerNum = null)
+		{
+			var buttons = new List<string>();
+			foreach (var button in buttonList)
+			{
+				if (controllerNum != null && button.Length > 2 && button.Substring(0, 2) == $"P{controllerNum}")
+				{
+					var sub = button.Substring(3);
+					buttons.Add(sub);
+				}
+				else if (controllerNum == null)
+				{
+					buttons.Add(button);
+				}
+			}
+			return buttons;
+		}
+
 		public static IDictionary<string, dynamic> ToDictionary(this IController controller, int? controllerNum = null)
 		{
 			var buttons = new Dictionary<string, dynamic>();


### PR DESCRIPTION
See https://github.com/TASVideos/BizHawk/issues/1897

At some point from 2.2.1 to now, joypad.set() no longer works properly. The following no longer works when it used to:

```
-- Example #1
local input =  {["A"] = true}
joypad.set(input, 1) -- Does nothing when it used to work in 2.2.1

-- Example #2
local input = {["A"] = 1}
joypad.set(input, 1) -- Throws exception when it used to work in 2.2.1

local input = {["P1 A"] = true}
joypad.set(input) -- Interestingly, this still works
```

This pull request fixes the first two scenarios. The main issue was with this block of code:
```
public void Set(Dictionary<string, bool> buttons, int? controller = null)
{
  foreach (var button in Global.InputManager.ActiveController.Definition.BoolButtons)
  {
    Set(button, buttons.TryGetValue(button, out var state) ? state : (bool?) null, controller);
  }
}
```
I've observed that `button` will ALWAYS be prefixed with "P{n}" (not sure why, but I assume this is the way the emulator is supposed to work), but the keys in `buttons` may not be (as in Example #1 above). Therefore, in the case of Example #1, `buttons` will contain {A: true} but the logic above will be looking for "P1 A", "P2 A", "P3 A", etc. This means that A's state will be set to null when it should be set to true.

Therefore, my solution was to change the Set() method to iterate over button names WITHOUT prefixes if a controller is specified. This (hopefully) preserves the existing `joypad.set({["P1 A"] = true})` syntax, but also fixes the bug that prevents `joypad.set({["A"] = true}, 1)` from working