### PR TITLE
Fix the Gambatte Palette

### DIFF
--- a/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GBColors.cs
+++ b/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/GBColors.cs
@@ -51,9 +51,15 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 		public static Triple GambatteColor(Triple c)
 		{
 			Triple ret;
-			ret.r = (c.r * 13 + c.g * 2 + c.b) >> 1;
-			ret.g = (c.g * 3 + c.b) << 1;
-			ret.b = (c.r * 3 + c.g * 2 + c.b * 11) >> 1;
+			double gammaR = Math.Pow((double)c.r / 31, 2.2);
+			double gammaG = Math.Pow((double)c.g / 31, 2.2);
+			double gammaB = Math.Pow((double)c.b / 31, 2.2);
+			ret.r = (int)(Math.Pow(gammaR * .87 + gammaG * .18 - gammaB * .05, 1/ 2.2) * 255 + .5);
+			ret.g = (int)(Math.Pow(gammaG * .66 + gammaR * .115 + gammaB * .225, 1/ 2.2) * 255 + .5);
+			ret.b = (int)(Math.Pow(gammaB * .79 + gammaR * .14 + gammaG * .07, 1/ 2.2) * 255 + .5);
+			ret.r = Math.Max(0, Math.Min(255, ret.r));
+			ret.g = Math.Max(0, Math.Min(255, ret.g));
+			ret.b = Math.Max(0, Math.Min(255, ret.b));
 			return ret;
 		}
 


### PR DESCRIPTION
New GBC LCD correction for Gambatte palette from documented shader research https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540

Extrems uses this same correction in GBI and helped port it to BizHawk-Gambatte.

I would suggest that this should at least be a new default if not replacing the Gambatte palette completely as in my repo.  We don't really know what Sinamas' Gambatte palette is trying to do, it doesn't match documented behavior of the GBC LCD.