### PR TITLE
Reading gameDB include files on background threads. 

### DIFF
--- a/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/BizHawk.Client.EmuHawk/MainForm.cs
@@ -31,6 +31,7 @@ using BizHawk.Emulation.Common.Base_Implementations;
 using BizHawk.Emulation.Cores.Nintendo.SNES9X;
 using BizHawk.Emulation.Cores.Consoles.SNK;
 using BizHawk.Emulation.Cores.Consoles.Nintendo.Gameboy;
+using System.Threading.Tasks;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -258,7 +259,7 @@ namespace BizHawk.Client.EmuHawk
 				MessageBox.Show(e.Message);
 			}
 
-			Database.LoadDatabase(Path.Combine(PathUtils.ExeDirectoryPath, "gamedb", "gamedb.txt"));
+			var dbLoadingTask = Task.Factory.StartNew(() => Database.LoadDatabase(Path.Combine(PathUtils.ExeDirectoryPath, "gamedb", "gamedb.txt")));
 
 			// TODO GL - a lot of disorganized wiring-up here
 			// installed separately on Unix (via package manager or from https://developer.nvidia.com/cg-toolkit-download), look in $PATH
@@ -365,6 +366,9 @@ namespace BizHawk.Client.EmuHawk
 				Location = new Point(Config.MainWndx, Config.MainWndy);
 			}
 
+			//This is the earliest the application will need the gameDB to be fully populated. 
+			while (!dbLoadingTask.IsCompleted) ;
+			
 			if (_argParser.cmdRom != null)
 			{
 				// Commandline should always override auto-load

--- a/BizHawk.Emulation.Common/Database/Database.cs
+++ b/BizHawk.Emulation.Common/Database/Database.cs
@@ -56,7 +56,7 @@ namespace BizHawk.Emulation.Common
 			if (File.Exists(filename))
 			{
 				Console.WriteLine("loading external game database {0}", line);
-				ThreadPool.QueueUserWorkItem((s) => LoadDatabase(filename));
+				LoadDatabase(filename);
 			}
 			else
 			{

--- a/BizHawk.Emulation.Common/Database/Database.cs
+++ b/BizHawk.Emulation.Common/Database/Database.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Emulation.Common
 			if (File.Exists(filename))
 			{
 				Console.WriteLine("loading external game database {0}", line);
-				LoadDatabase(filename);
+				ThreadPool.QueueUserWorkItem((s) => LoadDatabase(filename));
 			}
 			else
 			{

--- a/BizHawk.Emulation.Common/Database/Database.cs
+++ b/BizHawk.Emulation.Common/Database/Database.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -12,7 +13,7 @@ namespace BizHawk.Emulation.Common
 {
 	public static class Database
 	{
-		private static readonly Dictionary<string, CompactGameInfo> DB = new Dictionary<string, CompactGameInfo>();
+		private static readonly ConcurrentDictionary<string, CompactGameInfo> DB = new ConcurrentDictionary<string, CompactGameInfo>();
 
 		private static string RemoveHashType(string hash)
 		{


### PR DESCRIPTION
Client starts up a little faster this way. (saves 350-500ms on my machine, likely more on slower PCs). 