### PR TITLE
Make waterbox consistency check ui option only skip the memory check, not the core check

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -92,7 +92,7 @@ namespace BizHawk.Client.EmuHawk
 				Config.FirmwareUserSpecifications);
 			var prefs = CoreComm.CorePreferencesFlags.None;
 			if (Config.SkipWaterboxIntegrityChecks)
-				prefs = CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck | CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck;
+				prefs = CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck;
 
 			return new CoreComm(ShowMessageCoreComm, NotifyCoreComm, cfp, prefs);
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Belogic/Uzem.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Belogic/Uzem.cs
@@ -33,7 +33,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Belogic
 				MmapHeapSizeKB = 4,
 				PlainHeapSizeKB = 4,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			_exe.AddReadonlyFile(rom, "romfile");

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Emulation.Cores.Consoles.NEC.PCFX
 				PlainHeapSizeKB = 4 * 1024,
 				MmapHeapSizeKB = 6 * 1024,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			SetCdCallbacks();

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Sameboy.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Sameboy.cs
@@ -67,7 +67,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.Gameboy
 				PlainHeapSizeKB = 4,
 				MmapHeapSizeKB = 1024,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			_cgb = (rom[0x143] & 0xc0) == 0xc0 && !sgb;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesApi.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesApi.cs
@@ -71,7 +71,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 				PlainHeapSizeKB = 2 * 1024, // TODO: wasn't there more in here?
 				SealedHeapSizeKB = 128 * 1024,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 			using (_exe.EnterExit())
 			{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 				InvisibleHeapSizeKB = 6 * 1024,
 				PlainHeapSizeKB = 64,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			if (!_core.biz_init())

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
@@ -41,7 +41,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.VB
 				InvisibleHeapSizeKB = 256,
 				PlainHeapSizeKB = 256,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			if (!_boyee.Load(rom, rom.Length, LibVirtualBoyee.NativeSyncSettings.FromFrontendSettings(_syncSettings)))

--- a/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
@@ -50,7 +50,7 @@ namespace BizHawk.Emulation.Cores.Consoles.SNK
 				PlainHeapSizeKB = 5 * 1024, // must be a bit larger than the ROM size
 				StartAddress = startAddress,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			if (!_neopop.LoadSystem(rom, rom.Length, _syncSettings.Language))

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/PicoDrive/PicoDrive.cs
@@ -58,7 +58,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.PicoDrive
 				MmapHeapSizeKB = 4096,
 				PlainHeapSizeKB = 64,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			if (has32xBios)

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
@@ -95,7 +95,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.Saturn
 				PlainHeapSizeKB = 24 * 1024, // up to 16MB of cart ram
 				StartAddress = LibSaturnus.StartAddress,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			SetFirmwareCallbacks();

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGX.cs
@@ -53,7 +53,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 				PlainHeapSizeKB = 64,
 				MmapHeapSizeKB = 1 * 1024,
 				SkipCoreConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
-				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxCoreConsistencyCheck),
+				SkipMemoryConsistencyCheck = comm.CorePreferences.HasFlag(CoreComm.CorePreferencesFlags.WaterboxMemoryConsistencyCheck),
 			});
 
 			using (_elf.EnterExit())

--- a/src/BizHawk.Emulation.Cores/Waterbox/PeRunner.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/PeRunner.cs
@@ -58,12 +58,15 @@ namespace BizHawk.Emulation.Cores.Waterbox
 		public ulong StartAddress { get; set; } = PeRunner.CanonicalStart;
 
 		/// <summary>
-		/// Skips the "core consistency check"
+		/// Skips the check that the wbx file and other associated dlls match from state save to state load.
+		/// DO NOT SET THIS TO TRUE.  A different executable most likely means different meanings for memory locations,
+		/// and nothing will make sense.
 		/// </summary>
 		public bool SkipCoreConsistencyCheck { get; set; } = false;
 
 		/// <summary>
-		/// Skips the "memory consistency check"
+		/// Skips the check that the initial memory state (after init, but before any running) matches from state save to state load.
+		/// DO NOT SET THIS TO TRUE.  The initial memory state must be the same for the XORed memory contents in the savestate to make sense.
 		/// </summary>
 		public bool SkipMemoryConsistencyCheck { get; set; } = false;
 	}


### PR DESCRIPTION
not the core check