### PR TITLE
NESHawk: make game genie compare cheats work

### DIFF
--- a/src/BizHawk.Client.Common/tools/Cheat.cs
+++ b/src/BizHawk.Client.Common/tools/Cheat.cs
@@ -1,4 +1,5 @@
 ﻿using BizHawk.Emulation.Common;
+using System;
 
 namespace BizHawk.Client.Common
 {
@@ -229,6 +230,20 @@ namespace BizHawk.Client.Common
 						case WatchSize.DWord:
 							_watch.Poke(((DWordWatch)_watch).FormatValue((uint)_val));
 							break;
+					}
+				}
+
+				// This will take effect only for NES, and will pulse the cheat with compare option directly to the core
+				// Only works for byte cheats currently
+				if (_watch.Size == WatchSize.Byte && _watch.Domain.Name == "System Bus")
+				{
+					if (Compare.HasValue)
+					{
+						_watch.Domain.SendCheatToCore((int)Address.Value, (byte)Value, Compare.Value, (int)ComparisonType);						
+					}
+					else
+					{
+						_watch.Domain.SendCheatToCore((int)Address.Value, (byte)Value, -1, 0);
 					}
 				}
 			}

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -158,5 +158,7 @@ namespace BizHawk.Emulation.Common
 				values[i] = PeekUint(start + i*4, bigEndian);
 			}
 		}
+
+		public virtual void SendCheatToCore(int addr, byte value, int compare, int compare_type) { }
 	}
 }

--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomainImpls.cs
@@ -318,4 +318,105 @@ namespace BizHawk.Emulation.Common
 			_monitor = monitor;
 		}
 	}
+
+	public class MemoryDomainDelegateSysBusNES : MemoryDomain
+	{
+		private Action<long, byte> _poke;
+
+		// TODO: use an array of Ranges
+		private Action<Range<long>, byte[]> _bulkPeekByte { get; set; }
+		private Action<Range<long>, bool, ushort[]> _bulkPeekUshort { get; set; }
+		private Action<Range<long>, bool, uint[]> _bulkPeekUint { get; set; }
+
+		public Func<long, byte> Peek { get; set; }
+
+		public Action<long, byte> Poke
+		{
+			get => _poke;
+			set
+			{
+				_poke = value;
+				Writable = value != null;
+			}
+		}
+
+		private Action<int, byte, int, int> sendcheattocore { get; set; }
+
+		public override byte PeekByte(long addr)
+		{
+			return Peek(addr);
+		}
+
+		public override void PokeByte(long addr, byte val)
+		{
+			_poke?.Invoke(addr, val);
+		}
+
+		public override void BulkPeekByte(Range<long> addresses, byte[] values)
+		{
+			if (_bulkPeekByte != null)
+			{
+				_bulkPeekByte.Invoke(addresses, values);
+			}
+			else
+			{
+				base.BulkPeekByte(addresses, values);
+			}
+		}
+
+		public override void BulkPeekUshort(Range<long> addresses, bool bigEndian, ushort[] values)
+		{
+			if (_bulkPeekUshort != null)
+			{
+				_bulkPeekUshort.Invoke(addresses, EndianType == Endian.Big, values);
+			}
+			else
+			{
+				base.BulkPeekUshort(addresses, EndianType == Endian.Big, values);
+			}
+		}
+
+		public override void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
+		{
+			if (_bulkPeekUint != null)
+			{
+				_bulkPeekUint.Invoke(addresses, EndianType == Endian.Big, values);
+			}
+			else
+			{
+				base.BulkPeekUint(addresses, EndianType == Endian.Big, values);
+			}
+		}
+
+		public override void SendCheatToCore(int addr, byte value, int compare, int comparetype)
+		{
+			if (sendcheattocore != null)
+			{
+				sendcheattocore.Invoke(addr, value, compare, comparetype);
+			}
+			else
+			{
+				base.SendCheatToCore(addr, value, compare, comparetype);
+			}		
+		}
+
+		public MemoryDomainDelegateSysBusNES(
+			string name,
+			long size,
+			Endian endian,
+			Func<long, byte> peek,
+			Action<long, byte> poke,
+			int wordSize,
+			Action<int, byte, int, int> nescheatpoke = null)
+		{
+			Name = name;
+			EndianType = endian;
+			Size = size;
+			Peek = peek;
+			_poke = poke;
+			Writable = poke != null;
+			WordSize = wordSize;
+			sendcheattocore = nescheatpoke;
+		}
+	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.IMemoryDomains.cs
@@ -12,8 +12,12 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		{
 			var domains = new List<MemoryDomain>();
 			var RAM = new MemoryDomainByteArray("RAM", MemoryDomain.Endian.Little, ram, true, 1);
-			var SystemBus = new MemoryDomainDelegate("System Bus", 0x10000, MemoryDomain.Endian.Little,
-				addr => PeekMemory((ushort)addr), (addr, value) => ApplySystemBusPoke((int)addr, value), 1);
+
+			// System bus gets it's own class in order to send compare values to cheats
+			var SystemBus = new MemoryDomainDelegateSysBusNES("System Bus", 0x10000, MemoryDomain.Endian.Little,
+				addr => PeekMemory((ushort)addr), (addr, value) => ApplySystemBusPoke((int)addr, value), 1,
+				(addr, value, compare, comparetype) => ApplyCompareCheat(addr, value, compare, comparetype));
+
 			var PPUBus = new MemoryDomainDelegate("PPU Bus", 0x4000, MemoryDomain.Endian.Little,
 				addr => ppu.ppubus_peek((int)addr), (addr, value) => ppu.ppubus_write((int)addr, value), 1);
 			var CIRAMdomain = new MemoryDomainByteArray("CIRAM (nametables)", MemoryDomain.Endian.Little, CIRAM, true, 1);


### PR DESCRIPTION
Here is a PR that gets Game Genie compare cheats working properly in NESHawk.

It's applicability is limited to this specific case. Other compare cases (ex greater then) still do not work, as do other cheats outside of this scope (ex RAM.)

But having said that, I think the implementation is reasonably clean for what it does. I needed to make a new memory domain builder class specifically for NESHawk sys. bus so that no other cores are effected by this change, but other then that not many changes were needed.

Also performance isn't so bad. Even though it checks every ROM access, it only loses about 5% performance, so still can run comfortably at at least double speed for a small number of cheats (at least on my laptop.)

I purposely made the scope of this very narrow, but I think that's fine as other cores are way behind NESHawk in terms of cheats anyway.

Feedback welcome.