### PR TITLE
Remove infinity movies

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/MovieApi.cs
@@ -98,7 +98,7 @@ namespace BizHawk.Client.Common
 
 		public bool IsLoaded() => Global.MovieSession.Movie.IsActive();
 
-		public double Length() => Global.MovieSession.Movie.FrameCount;
+		public int Length() => Global.MovieSession.Movie.FrameCount;
 
 		public string Mode() => Global.MovieSession.Movie.Mode.ToString().ToUpper();
 

--- a/src/BizHawk.Client.Common/Api/Interfaces/IInputMovie.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IInputMovie.cs
@@ -13,7 +13,7 @@ namespace BizHawk.Client.Common
 		ulong GetRerecordCount();
 		bool GetRerecordCounting();
 		bool IsLoaded();
-		double Length();
+		int Length();
 		string Mode();
 		void Save(string filename = "");
 		void SetReadOnly(bool readOnly);

--- a/src/BizHawk.Client.Common/movie/HeaderKeys.cs
+++ b/src/BizHawk.Client.Common/movie/HeaderKeys.cs
@@ -18,7 +18,6 @@ namespace BizHawk.Client.Common
 		public const string Pal = "PAL";
 		public const string BoardName = "BoardName";
 		public const string SyncSettings = "SyncSettings";
-		public const string LoopOffset = "LoopOffset";
 		public const string VBlankCount = "VBlankCount";
 		public const string CycleCount = "CycleCount";
 		public const string Core = "Core";

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
@@ -190,32 +190,6 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		protected int? LoopOffset
-		{
-			get
-			{
-				var offsetStr = Header[HeaderKeys.LoopOffset];
-				if (!string.IsNullOrWhiteSpace(offsetStr))
-				{
-					return int.Parse(offsetStr);
-				}
-
-				return null;
-			}
-
-			set
-			{
-				if (value.HasValue)
-				{
-					Header[HeaderKeys.LoopOffset] = value.ToString();
-				}
-				else
-				{
-					Header.Remove(HeaderKeys.LoopOffset);
-				}
-			}
-		}
-
 		protected string CommentsString()
 		{
 			var sb = new StringBuilder();

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.InputLog.cs
@@ -28,30 +28,9 @@ namespace BizHawk.Client.Common
 
 		public string GetInputLogEntry(int frame)
 		{
-			if (frame < FrameCount && frame >= 0)
-			{
-				int getFrame;
-
-				if (LoopOffset.HasValue)
-				{
-					if (frame < Log.Count)
-					{
-						getFrame = frame;
-					}
-					else
-					{
-						getFrame = ((frame - LoopOffset.Value) % (Log.Count - LoopOffset.Value)) + LoopOffset.Value;
-					}
-				}
-				else
-				{
-					getFrame = frame;
-				}
-
-				return Log[getFrame];
-			}
-
-			return "";
+			return frame < FrameCount && frame >= 0
+				? Log[frame]
+				: "";
 		}
 
 		public virtual bool ExtractInputLog(TextReader reader, out string errorMessage)

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
@@ -44,19 +44,7 @@ namespace BizHawk.Client.Common
 			return new Bk2LogEntryGenerator(Global.Emulator.SystemId, source);
 		}
 
-		public double FrameCount
-		{
-			get
-			{
-				if (LoopOffset.HasValue)
-				{
-					return double.PositiveInfinity;
-				}
-				
-				return Log.Count;
-			}
-		}
-
+		public int FrameCount => Log.Count;
 		public int InputLogLength => Log.Count;
 
 		public ulong TimeLength
@@ -123,26 +111,7 @@ namespace BizHawk.Client.Common
 			if (frame < FrameCount && frame >= 0)
 			{
 				_adapter ??= new Bk2Controller(Global.MovieSession.MovieController.Definition);
-
-				int getFrame;
-
-				if (LoopOffset.HasValue)
-				{
-					if (frame < Log.Count)
-					{
-						getFrame = frame;
-					}
-					else
-					{
-						getFrame = ((frame - LoopOffset.Value) % (Log.Count - LoopOffset.Value)) + LoopOffset.Value;
-					}
-				}
-				else
-				{
-					getFrame = frame;
-				}
-
-				_adapter.SetFromMnemonic(Log[getFrame]);
+				_adapter.SetFromMnemonic(Log[frame]);
 				return _adapter;
 			}
 

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -46,12 +46,12 @@ namespace BizHawk.Client.Common
 
 		/// <summary>
 		/// Gets the total number of frames that count towards the completion time of the movie
-		/// Possibly (but unlikely different from InputLogLength (could be infinity, or maybe an implementation automatically discounts empty frames at the end of a movie, etc)
 		/// </summary>
-		double FrameCount { get; }
+		int FrameCount { get; }
 
 		/// <summary>
-		/// Gets the actual length of the input log, should only be used by code that iterates or needs a real length
+		/// Gets the actual length of the input log, should only be used by code that needs a the input log length
+		/// specifically, not the frame count
 		/// </summary>
 		int InputLogLength { get; }
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.FileLoader.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.FileLoader.cs
@@ -25,7 +25,7 @@ namespace BizHawk.Client.EmuHawk
 			LegacyMovieFile
 		}
 
-		public struct FileInformation
+		private readonly struct FileInformation
 		{
 			public string DirectoryName { get; }
 			public string FileName { get; }


### PR DESCRIPTION
This was a gimmick feature a long time ago, and has only been used twice to my knowledge.  It's a feature that would never lead to a tasvideos publication. 

It isn't that much code, but it does complicate the api (such as frame count being a double).  If we were to expand capabilities to include subframe input, this feature would actively complicate the implementation.

It was fun, but I think maybe it is time to go, what do people think?