### PR TITLE
Fix hex editor bulk multibyte reads

### DIFF
--- a/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/MemoryDomain.cs
@@ -125,18 +125,20 @@ namespace BizHawk.Emulation.Common
 			{
 				throw new ArgumentException();
 			}
+			var start = addresses.Start;
+			var end  = addresses.EndInclusive + 1;
 
-			var nAddresses = (long) addresses.Count();
-			if (nAddresses != values.Length)
+			if ((start & 1) != 0 || (end & 1) != 0)
+				throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
+			
+			if (values.LongLength * 2 != end - start)
 			{
+				// a longer array could be valid, but nothing needs that so don't support it for now
 				throw new InvalidOperationException("Invalid length of values array");
 			}
 
-			var start = addresses.Start;
-			for (var i = 0; i < nAddresses; i++)
-			{
-				values[i] = PeekUshort(start + i*2, bigEndian);
-			}
+			for (var i = 0; i < values.Length; i++, start += 2)
+				values[i] = PeekUshort(start, bigEndian);
 		}
 
 		public virtual void BulkPeekUint(Range<long> addresses, bool bigEndian, uint[] values)
@@ -145,18 +147,20 @@ namespace BizHawk.Emulation.Common
 			{
 				throw new ArgumentException();
 			}
+			var start = addresses.Start;
+			var end  = addresses.EndInclusive + 1;
 
-			var nAddresses = (long) addresses.Count();
-			if (nAddresses != values.Length)
+			if ((start & 3) != 0 || (end & 3) != 0)
+				throw new InvalidOperationException("The API contract doesn't define what to do for unaligned reads and writes!");
+			
+			if (values.LongLength * 4 != end - start)
 			{
+				// a longer array could be valid, but nothing needs that so don't support it for now
 				throw new InvalidOperationException("Invalid length of values array");
 			}
 
-			var start = addresses.Start;
-			for (var i = 0; i<nAddresses; i++)
-			{
-				values[i] = PeekUint(start + i*4, bigEndian);
-			}
+			for (var i = 0; i < values.Length; i++, start += 4)
+				values[i] = PeekUshort(start, bigEndian);
 		}
 	}
 }


### PR DESCRIPTION
The existing API was such that BulkPeekUint(Start: 20, EndInclusive: 39) would actually read from the address range [20, 100) instead of [20, 40).  That's completely broken.  The hex editor, the only consumer of the API, made the same exact mistake in reverse so the problem wasn't immediately apparent, but it was a giant land mine waiting to happen.  Fix them both.