### PR TITLE
Refactor of ControllerDefinition axes

### DIFF
--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -14,8 +14,8 @@ namespace BizHawk.Client.Common
 			Definition = definition;
 			foreach (var kvp in Definition.Axes)
 			{
-				_axes[kvp.Key] = kvp.Value.Range.Mid;
-				_axisRanges[kvp.Key] = kvp.Value.Range;
+				_axes[kvp.Key] = kvp.Value.Mid;
+				_axisRanges[kvp.Key] = kvp.Value;
 			}
 		}
 
@@ -28,7 +28,7 @@ namespace BizHawk.Client.Common
 		private readonly WorkingDictionary<string, List<string>> _bindings = new WorkingDictionary<string, List<string>>();
 		private readonly WorkingDictionary<string, bool> _buttons = new WorkingDictionary<string, bool>();
 		private readonly WorkingDictionary<string, int> _axes = new WorkingDictionary<string, int>();
-		private readonly Dictionary<string, ControllerDefinition.AxisRange> _axisRanges = new WorkingDictionary<string, ControllerDefinition.AxisRange>();
+		private readonly Dictionary<string, ControllerDefinition.AxisSpec> _axisRanges = new WorkingDictionary<string, ControllerDefinition.AxisSpec>();
 		private readonly Dictionary<string, AnalogBind> _axisBindings = new Dictionary<string, AnalogBind>();
 
 		/// <summary>don't do this</summary>

--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -12,10 +12,10 @@ namespace BizHawk.Client.Common
 		public Controller(ControllerDefinition definition)
 		{
 			Definition = definition;
-			for (int i = 0; i < Definition.AxisControls.Count; i++)
+			foreach (var kvp in Definition.Axes)
 			{
-				_axes[Definition.AxisControls[i]] = Definition.AxisRanges[i].Mid;
-				_axisRanges[Definition.AxisControls[i]] = Definition.AxisRanges[i];
+				_axes[kvp.Key] = kvp.Value.Range.Mid;
+				_axisRanges[kvp.Key] = kvp.Value.Range;
 			}
 		}
 

--- a/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
+++ b/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
@@ -37,14 +37,11 @@ namespace BizHawk.Client.Common
 				{
 					foreach (var button in group)
 					{
-						if (_source.Definition.AxisControls.Contains(button))
+						if (_source.Definition.Axes.TryGetValue(button, out var range))
 						{
-							int i = _source.Definition.AxisControls.IndexOf(button);
-							var mid = _source.Definition.AxisRanges[i].Mid;
-
 							var val = (int)_source.AxisValue(button);
 
-							if (val == mid)
+							if (val == range.Range.Mid)
 							{
 								sb.Append("      ");
 							}

--- a/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
+++ b/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
@@ -41,7 +41,7 @@ namespace BizHawk.Client.Common
 						{
 							var val = (int)_source.AxisValue(button);
 
-							if (val == range.Range.Mid)
+							if (val == range.Mid)
 							{
 								sb.Append("      ");
 							}

--- a/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
+++ b/src/BizHawk.Client.Common/inputAdapters/InputManager.cs
@@ -89,7 +89,7 @@ namespace BizHawk.Client.Common
 
 			if (analogBinds.TryGetValue(def.Name, out var aBinds))
 			{
-				foreach (var btn in def.AxisControls)
+				foreach (var btn in def.Axes.Keys)
 				{
 					if (aBinds.TryGetValue(btn, out var bind))
 					{

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
@@ -69,7 +69,7 @@ namespace BizHawk.Client.Common
 			// axes don't have sticky logic, so latch default value
 			foreach (var kvp in Definition.Axes)
 			{
-				_myAxisControls[kvp.Key] = kvp.Value.Range.Mid;
+				_myAxisControls[kvp.Key] = kvp.Value.Mid;
 			}
 		}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
@@ -36,7 +36,7 @@ namespace BizHawk.Client.Common
 				{
 					Name = c,
 					IsBool = _type.BoolButtons.Contains(c),
-					IsAxis = _type.AxisControls.Contains(c)
+					IsAxis = _type.Axes.ContainsKey(c)
 				})
 				.ToList();
 		}
@@ -53,7 +53,7 @@ namespace BizHawk.Client.Common
 				_myBoolButtons[button] = source.IsPressed(button);
 			}
 
-			foreach (var name in Definition.AxisControls)
+			foreach (var name in Definition.Axes.Keys)
 			{
 				_myAxisControls[name] = source.AxisValue(name);
 			}
@@ -67,9 +67,9 @@ namespace BizHawk.Client.Common
 			}
 
 			// axes don't have sticky logic, so latch default value
-			for (int i = 0; i < Definition.AxisControls.Count; i++)
+			foreach (var kvp in Definition.Axes)
 			{
-				_myAxisControls[Definition.AxisControls[i]] = Definition.AxisRanges[i].Mid;
+				_myAxisControls[kvp.Key] = kvp.Value.Range.Mid;
 			}
 		}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
@@ -79,7 +79,7 @@ namespace BizHawk.Client.Common
 
 							if (createEmpty)
 							{
-								val = range.Range.Mid;
+								val = range.Mid;
 							}
 							else
 							{

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
@@ -51,7 +51,7 @@ namespace BizHawk.Client.Common
 					{
 						dict.Add(button, Bk2MnemonicLookup.Lookup(button, _systemId).ToString());
 					}
-					else if (_source.Definition.AxisControls.Contains(button))
+					else if (_source.Definition.Axes.ContainsKey(button))
 					{
 						dict.Add(button, Bk2MnemonicLookup.LookupAxis(button, _systemId));
 					}
@@ -73,15 +73,13 @@ namespace BizHawk.Client.Common
 				{
 					foreach (var button in group)
 					{
-						if (_source.Definition.AxisControls.Contains(button))
+						if (_source.Definition.Axes.TryGetValue(button, out var range))
 						{
 							int val;
-							int i = _source.Definition.AxisControls.IndexOf(button);
-							var mid = _source.Definition.AxisRanges[i].Mid;
 
 							if (createEmpty)
 							{
-								val = mid;
+								val = range.Range.Mid;
 							}
 							else
 							{

--- a/src/BizHawk.Client.Common/movie/import/DsmImport.cs
+++ b/src/BizHawk.Client.Common/movie/import/DsmImport.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Consoles.Nintendo.NDS;
 
@@ -88,7 +90,7 @@ namespace BizHawk.Client.Common
 						"Right", "Left", "Down", "Up", "Start", "Select",
 						"B", "A", "X", "Y", "L", "R", "LidOpen", "LidClose", "Touch"
 					}
-				}.AddXYPair("Touch{0}", ControllerDefinition.AxisPairOrientation.RightAndUp, (0, 128, 255), (0, 96, 191)) //TODO verify direction against hardware
+				}.AddXYPair("Touch{0}", ControllerDefinition.AxisPairOrientation.RightAndUp, 0.RangeTo(255), 128, 0.RangeTo(191), 96) //TODO verify direction against hardware
 			};
 
 			controller["LidOpen"] = false;

--- a/src/BizHawk.Client.Common/movie/import/DsmImport.cs
+++ b/src/BizHawk.Client.Common/movie/import/DsmImport.cs
@@ -88,13 +88,8 @@ namespace BizHawk.Client.Common
 						"Right", "Left", "Down", "Up", "Start", "Select",
 						"B", "A", "X", "Y", "L", "R", "LidOpen", "LidClose", "Touch"
 					}
-				}
+				}.AddXYPair("Touch{0}", ControllerDefinition.AxisPairOrientation.RightAndUp, (0, 128, 255), (0, 96, 191)) //TODO verify direction against hardware
 			};
-
-			controller.Definition.AxisControls.Add("TouchX");
-			controller.Definition.AxisRanges.Add(new ControllerDefinition.AxisRange(0, 128, 255));
-			controller.Definition.AxisControls.Add("TouchY");
-			controller.Definition.AxisRanges.Add(new ControllerDefinition.AxisRange(0, 96, 191));
 
 			controller["LidOpen"] = false;
 			controller["LidOpen"] = false;

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -146,7 +146,7 @@ namespace BizHawk.Client.Common
 					: "";
 			}
 
-			if (adapter.Definition.AxisControls.Contains(buttonName))
+			if (adapter.Definition.Axes.ContainsKey(buttonName))
 			{
 				return adapter.AxisValue(buttonName).ToString();
 			}

--- a/src/BizHawk.Client.EmuHawk/Api/Libraries/JoypadApi.cs
+++ b/src/BizHawk.Client.EmuHawk/Api/Libraries/JoypadApi.cs
@@ -39,7 +39,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 			foreach (var button in controller.Definition.BoolButtons) GlobalWin.InputManager.ButtonOverrideAdapter.SetButton(button, controller.IsPressed(button));
-			foreach (var axis in controller.Definition.AxisControls) GlobalWin.InputManager.ButtonOverrideAdapter.SetAxis(axis, controller.AxisValue(axis));
+			foreach (var axis in controller.Definition.Axes.Keys) GlobalWin.InputManager.ButtonOverrideAdapter.SetAxis(axis, controller.AxisValue(axis));
 		}
 
 		public void Set(Dictionary<string, bool> buttons, int? controller = null)

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.cs
@@ -90,7 +90,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static readonly Regex ButtonMatchesPlayer = new Regex("^P(\\d+)\\s");
 
-		private void LoadToPanel<T>(Control dest, string controllerName, IList<string> controllerButtons, Dictionary<string,string> categoryLabels, IDictionary<string, Dictionary<string, T>> settingsBlock, T defaultValue, PanelCreator<T> createPanel)
+		private void LoadToPanel<T>(Control dest, string controllerName, IReadOnlyCollection<string> controllerButtons, Dictionary<string,string> categoryLabels, IDictionary<string, Dictionary<string, T>> settingsBlock, T defaultValue, PanelCreator<T> createPanel)
 		{
 			if (!settingsBlock.TryGetValue(controllerName, out var settings))
 			{
@@ -193,7 +193,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			LoadToPanel(NormalControlsTab, _emulator.ControllerDefinition.Name, _emulator.ControllerDefinition.BoolButtons, _emulator.ControllerDefinition.CategoryLabels, normal, "", CreateNormalPanel);
 			LoadToPanel(AutofireControlsTab, _emulator.ControllerDefinition.Name, _emulator.ControllerDefinition.BoolButtons, _emulator.ControllerDefinition.CategoryLabels, autofire, "", CreateNormalPanel);
-			LoadToPanel(AnalogControlsTab, _emulator.ControllerDefinition.Name, _emulator.ControllerDefinition.AxisControls, _emulator.ControllerDefinition.CategoryLabels, analog, new AnalogBind("", 1.0f, 0.1f), CreateAnalogPanel);
+			LoadToPanel(AnalogControlsTab, _emulator.ControllerDefinition.Name, _emulator.ControllerDefinition.Axes.Keys.ToList(), _emulator.ControllerDefinition.CategoryLabels, analog, new AnalogBind("", 1.0f, 0.1f), CreateAnalogPanel);
 
 			if (AnalogControlsTab.Controls.Count == 0)
 			{

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/TAStudioLuaLibrary.cs
@@ -385,7 +385,7 @@ namespace BizHawk.Client.EmuHawk
 						table[button] = controller.IsPressed(button);
 					}
 
-					foreach (var button in controller.Definition.AxisControls)
+					foreach (var button in controller.Definition.Axes.Keys)
 					{
 						table[button] = controller.AxisValue(button);
 					}

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.ButtonSelect.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.ButtonSelect.cs
@@ -10,18 +10,18 @@ namespace BizHawk.Client.EmuHawk
 		private void SetUpButtonBoxes()
 		{
 			var def = Emulator.ControllerDefinition;
-			int count = def.BoolButtons.Count + def.AxisControls.Count;
+			int count = def.BoolButtons.Count + def.Axes.Count;
 			_buttonBoxes = new CheckBox[count];
 
-			for (int i = 0; i < def.AxisControls.Count; i++)
+			for (int i = 0; i < def.Axes.Count; i++)
 			{
-				var box = new CheckBox { Text = def.AxisControls[i] };
+				var box = new CheckBox { Text = def.Axes[i] };
 				_buttonBoxes[i] = box;
 			}
 			for (int i = 0; i < def.BoolButtons.Count; i++)
 			{
 				var box = new CheckBox { Text = def.BoolButtons[i] };
-				_buttonBoxes[i + def.AxisControls.Count] = box;
+				_buttonBoxes[i + def.Axes.Count] = box;
 			}
 
 			foreach (var box in _buttonBoxes)

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -49,9 +49,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					d.AxisControls.Add(k);
-					int rangeIndex = _emulator.ControllerDefinition.AxisControls.IndexOf(k);
-					d.AxisRanges.Add(_emulator.ControllerDefinition.AxisRanges[rangeIndex]);
+					d.Axes.Add(k, _emulator.ControllerDefinition.Axes[k]);
 				}
 			}
 
@@ -104,7 +102,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					d.AxisControls.Add(key);
+					d.Axes.Add(key, _emulator.ControllerDefinition.Axes[key]);
 				}
 			}
 
@@ -268,7 +266,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					d.AxisControls.Add(k);
+					d.Axes.Add(k, _emulator.ControllerDefinition.Axes[key]);
 				}
 			}
 
@@ -282,7 +280,7 @@ namespace BizHawk.Client.EmuHawk
 				latching.SetBool(button, source.IsPressed(button));
 			}
 
-			foreach (string name in source.Definition.AxisControls)
+			foreach (string name in source.Definition.Axes.Keys)
 			{
 				latching.SetAxis(name, source.AxisValue(name));
 			}
@@ -295,11 +293,10 @@ namespace BizHawk.Client.EmuHawk
 				latching.SetBool(button, latching.IsPressed(button) | source.IsPressed(button));
 			}
 
-			foreach (string name in latching.Definition.AxisControls)
+			foreach (string name in latching.Definition.Axes.Keys)
 			{
 				var axisValue = source.AxisValue(name);
-				int indexRange = source.Definition.AxisControls.IndexOf(name);
-				if (axisValue == source.Definition.AxisRanges[indexRange].Mid)
+				if (axisValue == source.Definition.Axes[name].Range.Mid)
 				{
 					latching.SetAxis(name, axisValue);
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -296,7 +296,7 @@ namespace BizHawk.Client.EmuHawk
 			foreach (string name in latching.Definition.Axes.Keys)
 			{
 				var axisValue = source.AxisValue(name);
-				if (axisValue == source.Definition.Axes[name].Range.Mid)
+				if (axisValue == source.Definition.Axes[name].Mid)
 				{
 					latching.SetAxis(name, axisValue);
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/PatternsForm.cs
@@ -30,7 +30,7 @@ namespace BizHawk.Client.EmuHawk
 				ButtonBox.Items.Add(button);
 			}
 
-			foreach (var button in _tastudio.MovieSession.MovieController.Definition.AxisControls)
+			foreach (var button in _tastudio.MovieSession.MovieController.Definition.Axes.Keys)
 			{
 				ButtonBox.Items.Add(button);
 			}
@@ -203,7 +203,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 					else
 					{
-						index = _tastudio.MovieSession.MovieController.Definition.AxisControls.IndexOf(SelectedButton);
+						index = _tastudio.MovieSession.MovieController.Definition.Axes.IndexOf(SelectedButton);
 					}
 
 					LagBox.Checked = _tastudio.AxisPatterns[index].SkipsLag;
@@ -249,7 +249,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					index = _tastudio.MovieSession.MovieController.Definition.AxisControls.IndexOf(SelectedButton);
+					index = _tastudio.MovieSession.MovieController.Definition.Axes.IndexOf(SelectedButton);
 				}
 
 				var p = new List<int>();
@@ -311,7 +311,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					index = _tastudio.MovieSession.MovieController.Definition.AxisControls.IndexOf(SelectedButton);
+					index = _tastudio.MovieSession.MovieController.Definition.Axes.IndexOf(SelectedButton);
 				}
 
 				var p = _tastudio.AxisPatterns[index].Pattern;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -358,9 +358,7 @@ namespace BizHawk.Client.EmuHawk
 						if (column.Type == ColumnType.Axis)
 						{
 							// feos: this could be cached, but I don't notice any slowdown this way either
-							ControllerDefinition.AxisRange range = ControllerType.AxisRanges
-								[ControllerType.AxisControls.IndexOf(columnName)];
-							if (text == ((float) range.Mid).ToString())
+							if (text == ((float) ControllerType.Axes[columnName].Range.Mid).ToString())
 							{
 								text = "";
 							}
@@ -487,11 +485,11 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (index == 0)
 				{
-					index = ControllerType.AxisControls.IndexOf(button);
+					index = ControllerType.Axes.IndexOf(button);
 				}
 				else
 				{
-					index += ControllerType.AxisControls.Count - 1;
+					index += ControllerType.Axes.Count - 1;
 				}
 
 				int? value = null;
@@ -690,8 +688,8 @@ namespace BizHawk.Client.EmuHawk
 						if (applyPatternToPaintedInputToolStripMenuItem.Checked && (!onlyOnAutoFireColumnsToolStripMenuItem.Checked
 							|| TasView.CurrentCell.Column.Emphasis))
 						{
-							AxisPatterns[ControllerType.AxisControls.IndexOf(buttonName)].Reset();
-							CurrentTasMovie.SetAxisState(frame, buttonName, AxisPatterns[ControllerType.AxisControls.IndexOf(buttonName)].GetNextValue());
+							AxisPatterns[ControllerType.Axes.IndexOf(buttonName)].Reset();
+							CurrentTasMovie.SetAxisState(frame, buttonName, AxisPatterns[ControllerType.Axes.IndexOf(buttonName)].GetNextValue());
 							_patternPaint = true;
 						}
 						else
@@ -1173,7 +1171,7 @@ namespace BizHawk.Client.EmuHawk
 						}
 						else
 						{
-							setVal = AxisPatterns[ControllerType.AxisControls.IndexOf(_startAxisDrawColumn)].GetNextValue();
+							setVal = AxisPatterns[ControllerType.Axes.IndexOf(_startAxisDrawColumn)].GetNextValue();
 						}
 					}
 
@@ -1203,7 +1201,7 @@ namespace BizHawk.Client.EmuHawk
 					return;
 				}
 
-				var value = (_axisPaintState + increment).ConstrainWithin(ControllerType.AxisRanges[ControllerType.AxisControls.IndexOf(_axisEditColumn)].Range);
+				var value = (_axisPaintState + increment).ConstrainWithin(ControllerType.Axes[_axisEditColumn].Range.Range);
 				CurrentTasMovie.SetAxisState(_axisEditRow, _axisEditColumn, value);
 				_axisTypedValue = value.ToString();
 
@@ -1276,13 +1274,13 @@ namespace BizHawk.Client.EmuHawk
 			float prev = value;
 			string prevTyped = _axisTypedValue;
 
-			var range = ControllerType.AxisRanges[ControllerType.AxisControls.IndexOf(_axisEditColumn)];
-			var (rMin, rMax) = range.FloatRange;
+			var range = ControllerType.Axes[_axisEditColumn];
+			var (rMin, rMax) = range.Range.FloatRange;
 
 			// feos: typing past max digits overwrites existing value, not touching the sign
 			// but doesn't handle situations where the range is like -50 through 100, where minimum is negative and has less digits
 			// it just uses 3 as maxDigits there too, leaving room for typing impossible values (that are still ignored by the game and then clamped)
-			int maxDigits = range.MaxDigits;
+			int maxDigits = range.Range.MaxDigits;
 			int curDigits = _axisTypedValue.Length;
 			string curMinus;
 			if (_axisTypedValue.StartsWith("-"))

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -358,7 +358,7 @@ namespace BizHawk.Client.EmuHawk
 						if (column.Type == ColumnType.Axis)
 						{
 							// feos: this could be cached, but I don't notice any slowdown this way either
-							if (text == ((float) ControllerType.Axes[columnName].Range.Mid).ToString())
+							if (text == ((float) ControllerType.Axes[columnName].Mid).ToString())
 							{
 								text = "";
 							}
@@ -1201,7 +1201,7 @@ namespace BizHawk.Client.EmuHawk
 					return;
 				}
 
-				var value = (_axisPaintState + increment).ConstrainWithin(ControllerType.Axes[_axisEditColumn].Range.Range);
+				var value = (_axisPaintState + increment).ConstrainWithin(ControllerType.Axes[_axisEditColumn].Range);
 				CurrentTasMovie.SetAxisState(_axisEditRow, _axisEditColumn, value);
 				_axisTypedValue = value.ToString();
 
@@ -1275,12 +1275,12 @@ namespace BizHawk.Client.EmuHawk
 			string prevTyped = _axisTypedValue;
 
 			var range = ControllerType.Axes[_axisEditColumn];
-			var (rMin, rMax) = range.Range.FloatRange;
+			var (rMin, rMax) = range.FloatRange;
 
 			// feos: typing past max digits overwrites existing value, not touching the sign
 			// but doesn't handle situations where the range is like -50 through 100, where minimum is negative and has less digits
 			// it just uses 3 as maxDigits there too, leaving room for typing impossible values (that are still ignored by the game and then clamped)
-			int maxDigits = range.Range.MaxDigits;
+			int maxDigits = range.MaxDigits;
 			int curDigits = _axisTypedValue.Length;
 			string curMinus;
 			if (_axisTypedValue.StartsWith("-"))

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -424,7 +424,7 @@ namespace BizHawk.Client.EmuHawk
 				if (ControllerType.Axes.TryGetValue(kvp.Key, out var range))
 				{
 					type = ColumnType.Axis;
-					digits = Math.Max(kvp.Value.Length, range.Range.MaxDigits);
+					digits = Math.Max(kvp.Value.Length, range.MaxDigits);
 				}
 				else
 				{

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -421,12 +421,10 @@ namespace BizHawk.Client.EmuHawk
 			{
 				ColumnType type;
 				int digits;
-				if (ControllerType.AxisControls.Contains(kvp.Key))
+				if (ControllerType.Axes.TryGetValue(kvp.Key, out var range))
 				{
-					var range = ControllerType.AxisRanges
-						[ControllerType.AxisControls.IndexOf(kvp.Key)];
 					type = ColumnType.Axis;
-					digits = Math.Max(kvp.Value.Length, range.MaxDigits);
+					digits = Math.Max(kvp.Value.Length, range.Range.MaxDigits);
 				}
 				else
 				{
@@ -490,14 +488,14 @@ namespace BizHawk.Client.EmuHawk
 			if (BoolPatterns == null)
 			{
 				BoolPatterns = new AutoPatternBool[ControllerType.BoolButtons.Count + 2];
-				AxisPatterns = new AutoPatternAxis[ControllerType.AxisControls.Count + 2];
+				AxisPatterns = new AutoPatternAxis[ControllerType.Axes.Count + 2];
 			}
 			else
 			{
 				bStart = BoolPatterns.Length - 2;
 				fStart = AxisPatterns.Length - 2;
 				Array.Resize(ref BoolPatterns, ControllerType.BoolButtons.Count + 2);
-				Array.Resize(ref AxisPatterns, ControllerType.AxisControls.Count + 2);
+				Array.Resize(ref AxisPatterns, ControllerType.Axes.Count + 2);
 			}
 
 			for (int i = bStart; i < BoolPatterns.Length - 2; i++)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudioClipboard.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudioClipboard.cs
@@ -35,7 +35,7 @@ namespace BizHawk.Client.EmuHawk
 					GlobalWin.InputManager.ButtonOverrideAdapter.SetButton(button, controller.IsPressed(button));
 				}
 
-				foreach (var axisName in controller.Definition.AxisControls)
+				foreach (var axisName in controller.Definition.Axes.Keys)
 				{
 					GlobalWin.InputManager.ButtonOverrideAdapter.SetAxis(axisName, controller.AxisValue(axisName));
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualPad.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualPad.cs
@@ -96,8 +96,8 @@ namespace BizHawk.Client.EmuHawk
 						SecondaryName = analog.SecondaryName,
 						Location = UIHelper.Scale(analog.Location),
 						Size = UIHelper.Scale(new Size(180 + 79, 200 + 9)),
-						RangeX = analog.AxisRange,
-						RangeY = analog.SecondaryAxisRange
+						RangeX = analog.Spec,
+						RangeY = analog.SecondarySpec
 					},
 					TargetedPairSchema targetedPair => new VirtualPadTargetScreen
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
@@ -90,14 +90,14 @@ namespace BizHawk.Client.EmuHawk
 			if (VersionInfo.DeveloperBuild)
 			{
 				var buttonControls = Emulator.ControllerDefinition.BoolButtons;
-				var axisControls = Emulator.ControllerDefinition.AxisControls;
+				var axisControls = Emulator.ControllerDefinition.Axes;
 				foreach (var schema in padSchemata) foreach (var controlSchema in schema.Buttons)
 				{
 					Predicate<string> searchSetContains = controlSchema switch
 					{
 						ButtonSchema _ => buttonControls.Contains,
-						DiscManagerSchema _ => s => buttonControls.Contains(s) || axisControls.Contains(s),
-						_ => axisControls.Contains
+						DiscManagerSchema _ => s => buttonControls.Contains(s) || axisControls.ContainsKey(s),
+						_ => axisControls.ContainsKey
 					};
 					if (!searchSetContains(controlSchema.Name))
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
@@ -7,6 +7,8 @@ using BizHawk.Emulation.Common;
 using BizHawk.Client.Common;
 using BizHawk.Common;
 
+using static BizHawk.Emulation.Common.ControllerDefinition;
+
 namespace BizHawk.Client.EmuHawk
 {
 	public partial class VirtualPadAnalogStick : UserControl, IVirtualPadControl
@@ -30,9 +32,9 @@ namespace BizHawk.Client.EmuHawk
 			manualTheta.ValueChanged += PolarNumeric_Changed;
 		}
 
-		public ControllerDefinition.AxisRange RangeX { get; set; }
+		public AxisSpec RangeX { get; set; }
 
-		public ControllerDefinition.AxisRange RangeY { get; set; }
+		public AxisSpec RangeY { get; set; }
 
 		public string? SecondaryName { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
@@ -6,6 +6,8 @@ using BizHawk.Common;
 using BizHawk.Common.NumberExtensions;
 using BizHawk.Emulation.Common;
 
+using static BizHawk.Emulation.Common.ControllerDefinition;
+
 namespace BizHawk.Client.EmuHawk
 {
 	public sealed class AnalogStickPanel : Panel
@@ -53,7 +55,7 @@ namespace BizHawk.Client.EmuHawk
 			Refresh();
 		}
 
-		public void Init(string nameX, ControllerDefinition.AxisRange rangeX, string nameY, ControllerDefinition.AxisRange rangeY)
+		public void Init(string nameX, AxisSpec rangeX, string nameY, AxisSpec rangeY)
 		{
 			Name = XName = nameX;
 			_fullRangeX = rangeX;
@@ -64,8 +66,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private Range<int> _rangeX = 0.RangeTo(0);
 		private Range<int> _rangeY = 0.RangeTo(0);
-		private ControllerDefinition.AxisRange _fullRangeX;
-		private ControllerDefinition.AxisRange _fullRangeY;
+		private AxisSpec _fullRangeX;
+		private AxisSpec _fullRangeY;
 
 		private bool _reverseX;
 		private bool _reverseY;

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/ColecoSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/ColecoSchema.cs
@@ -56,8 +56,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(6, 14, $"P{controller} Disc X")
 					{
-						AxisRange = defAxes.SpecAtIndex(0).Range,
-						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
+						Spec = defAxes.SpecAtIndex(0),
+						SecondarySpec = defAxes.SpecAtIndex(1)
 					},
 					new ButtonSchema(6, 224, controller, "Pedal")
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/ColecoSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/ColecoSchema.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema TurboController(int controller)
 		{
-			var controllerDefRanges = new ColecoTurboController(controller).Definition.AxisRanges;
+			var defAxes = new ColecoTurboController(controller).Definition.Axes;
 			return new PadSchema
 			{
 				Size = new Size(275, 260),
@@ -56,8 +56,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(6, 14, $"P{controller} Disc X")
 					{
-						AxisRange = controllerDefRanges[0],
-						SecondaryAxisRange = controllerDefRanges[1]
+						AxisRange = defAxes.SpecAtIndex(0).Range,
+						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
 					},
 					new ButtonSchema(6, 224, controller, "Pedal")
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/IntvSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/IntvSchema.cs
@@ -79,8 +79,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(1, 121, $"P{controller} Disc X")
 					{
-						AxisRange = defAxes.SpecAtIndex(0).Range,
-						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
+						Spec = defAxes.SpecAtIndex(0),
+						SecondarySpec = defAxes.SpecAtIndex(1)
 					}
 				})
 			};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/IntvSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/IntvSchema.cs
@@ -70,7 +70,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema AnalogController(int controller)
 		{
-			var controllerDefRanges = new FakeAnalogController(controller).Definition.AxisRanges;
+			var defAxes = new FakeAnalogController(controller).Definition.Axes;
 			return new PadSchema
 			{
 				DisplayName = $"Player {controller}",
@@ -79,8 +79,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(1, 121, $"P{controller} Disc X")
 					{
-						AxisRange = controllerDefRanges[0],
-						SecondaryAxisRange = controllerDefRanges[1]
+						AxisRange = defAxes.SpecAtIndex(0).Range,
+						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
 					}
 				})
 			};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/N64Schema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/N64Schema.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Nintendo.N64;
 
@@ -59,8 +60,8 @@ namespace BizHawk.Client.EmuHawk
 					},
 					new AnalogSchema(6, 14, $"P{controller} X Axis")
 					{
-						AxisRange = new AxisRange(-128, 0, 127),
-						SecondaryAxisRange = new AxisRange(-128, 0, 127)
+						Spec = new AxisSpec((-128).RangeTo(127), 0),
+						SecondarySpec = new AxisSpec((-128).RangeTo(127), 0)
 					}
 				}
 			};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PSXSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PSXSchema.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Sony.PSX;
 
@@ -47,7 +48,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema DualShockController(int controller)
 		{
-			var stickRanges = CreateAxisRangePair(0, 128, 255, AxisPairOrientation.RightAndDown);
+			var stickRanges = new[] { new AxisSpec(0.RangeTo(255), 128), new AxisSpec(0.RangeTo(255), 128, isReversed: true) };
 			return new PadSchema
 			{
 				Size = new Size(500, 290),
@@ -90,13 +91,13 @@ namespace BizHawk.Client.EmuHawk
 					},
 					new AnalogSchema(3, 120, $"P{controller} LStick X")
 					{
-						AxisRange = stickRanges[0],
-						SecondaryAxisRange = stickRanges[1]
+						Spec = stickRanges[0],
+						SecondarySpec = stickRanges[1]
 					},
 					new AnalogSchema(260, 120, $"P{controller} RStick X")
 					{
-						AxisRange = stickRanges[0],
-						SecondaryAxisRange = stickRanges[1]
+						Spec = stickRanges[0],
+						SecondarySpec = stickRanges[1]
 					}
 				}
 			};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PadSchemaControl.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PadSchemaControl.cs
@@ -7,6 +7,8 @@ using System.Windows.Forms;
 using BizHawk.Client.EmuHawk.Properties;
 using BizHawk.Emulation.Common;
 
+using static BizHawk.Emulation.Common.ControllerDefinition;
+
 namespace BizHawk.Client.EmuHawk
 {
 	public abstract class PadSchemaControl
@@ -88,9 +90,9 @@ namespace BizHawk.Client.EmuHawk
 	/// <summary>An analog stick (X, Y) pair</summary>
 	public sealed class AnalogSchema : PadSchemaControl
 	{
-		public ControllerDefinition.AxisRange AxisRange { get; set; }
+		public AxisSpec Spec { get; set; }
 
-		public ControllerDefinition.AxisRange SecondaryAxisRange { get; set; }
+		public AxisSpec SecondarySpec { get; set; }
 
 		public string SecondaryName { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PceSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PceSchema.cs
@@ -3,9 +3,12 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.PCEngine;
 using BizHawk.Emulation.Cores.Waterbox;
+
+using static BizHawk.Emulation.Common.ControllerDefinition;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -140,7 +143,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema Mouse(int controller)
 		{
-			var range = new ControllerDefinition.AxisRange(-127, 0, 127);
+			var range = new AxisSpec((-127).RangeTo(127), 0);
 			return new PadSchema
 			{
 				Size = new Size(345, 225),
@@ -149,8 +152,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(6, 14, $"P{controller} Motion Left / Right")
 					{
 						SecondaryName = $"P{controller} Motion Up / Down",
-						AxisRange = range,
-						SecondaryAxisRange = range
+						Spec = range,
+						SecondarySpec = range
 					},
 					new ButtonSchema(275, 15, controller, "Left Button")
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PcfxSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/PcfxSchema.cs
@@ -2,8 +2,12 @@
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Waterbox;
+
+using static BizHawk.Emulation.Common.ControllerDefinition;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -69,7 +73,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema Mouse(int controller)
 		{
-			var range = new ControllerDefinition.AxisRange(-127, 0, 127);
+			var range = new AxisSpec((-127).RangeTo(127), 0);
 			return new PadSchema
 			{
 				Size = new Size(345, 225),
@@ -78,8 +82,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(6, 14, $"P{controller} Motion Left / Right")
 					{
 						SecondaryName = $"P{controller} Motion Up / Down",
-						AxisRange = range,
-						SecondaryAxisRange = range
+						Spec = range,
+						SecondarySpec = range
 					},
 					new ButtonSchema(275, 15, controller, "Left Button")
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SaturnSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SaturnSchema.cs
@@ -2,6 +2,8 @@
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Waterbox;
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -12,7 +14,7 @@ namespace BizHawk.Client.EmuHawk
 	// ReSharper disable once UnusedMember.Global
 	public class SaturnSchema : IVirtualPadSchema
 	{
-		private static readonly AxisRange AxisRange = new AxisRange(0, 0x8000, 0xffff);
+		private static readonly AxisSpec AxisRange = new AxisSpec(0.RangeTo(0xffff), 0x8000);
 
 		public IEnumerable<PadSchema> GetPadSchemas(IEmulator core)
 		{
@@ -103,8 +105,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(6, 74, $"P{controller} Analog Left / Right")
 					{
 						SecondaryName = $"P{controller} Analog Up / Down",
-						AxisRange = AxisRange,
-						SecondaryAxisRange = AxisRange
+						Spec = AxisRange,
+						SecondarySpec = AxisRange
 					},
 					new SingleAxisSchema(8, 12, controller, "L")
 					{
@@ -202,8 +204,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(195, 13, $"P{controller} Stick Left / Right")
 					{
 						SecondaryName = $"P{controller} Stick Fore / Back",
-						AxisRange = AxisRange,
-						SecondaryAxisRange = AxisRange
+						Spec = AxisRange,
+						SecondarySpec = AxisRange
 					},
 					new SingleAxisSchema(135, 13, controller, "Throttle Down / Up", isVertical: true)
 					{
@@ -227,8 +229,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(68, 13, $"P{controller} L Stick Left / Right")
 					{
 						SecondaryName = $"P{controller} L Stick Fore / Back",
-						AxisRange = AxisRange,
-						SecondaryAxisRange = AxisRange
+						Spec = AxisRange,
+						SecondarySpec = AxisRange
 					},
 					new SingleAxisSchema(8, 13, controller, "L Throttle Down / Up", isVertical: true)
 					{
@@ -251,8 +253,8 @@ namespace BizHawk.Client.EmuHawk
 					new AnalogSchema(570, 13, $"P{controller} R Stick Left / Right")
 					{
 						SecondaryName = $"P{controller} R Stick Fore / Back",
-						AxisRange = AxisRange,
-						SecondaryAxisRange = AxisRange
+						Spec = AxisRange,
+						SecondarySpec = AxisRange
 					},
 					new SingleAxisSchema(510, 13, controller, "R Throttle Down / Up", isVertical: true)
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SnesSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SnesSchema.cs
@@ -159,7 +159,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema Mouse(int controller)
 		{
-			var controllerDefRanges = new SnesMouseController().Definition.AxisRanges;
+			var defAxes = new SnesMouseController().Definition.Axes;
 			return new PadSchema
 			{
 				Size = new Size(345, 225),
@@ -167,8 +167,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(6, 14, $"P{controller} Mouse X")
 					{
-						AxisRange = controllerDefRanges[0],
-						SecondaryAxisRange = controllerDefRanges[1]
+						AxisRange = defAxes.SpecAtIndex(0).Range,
+						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
 					},
 					new ButtonSchema(275, 15, controller, "Mouse Left")
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SnesSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/SnesSchema.cs
@@ -167,8 +167,8 @@ namespace BizHawk.Client.EmuHawk
 				{
 					new AnalogSchema(6, 14, $"P{controller} Mouse X")
 					{
-						AxisRange = defAxes.SpecAtIndex(0).Range,
-						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
+						Spec = defAxes.SpecAtIndex(0),
+						SecondarySpec = defAxes.SpecAtIndex(1)
 					},
 					new ButtonSchema(275, 15, controller, "Mouse Left")
 					{

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/VECSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/VECSchema.cs
@@ -72,8 +72,8 @@ namespace BizHawk.Client.EmuHawk
 					Button(146, 34, controller, 4),
 					new AnalogSchema(2, 80, $"P{controller} Stick X")
 					{
-						AxisRange = defAxes.SpecAtIndex(0).Range,
-						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
+						Spec = defAxes.SpecAtIndex(0),
+						SecondarySpec = defAxes.SpecAtIndex(1)
 					}
 				}
 			};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/VECSchema.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/schema/VECSchema.cs
@@ -60,7 +60,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private static PadSchema AnalogController(int controller)
 		{
-			var controllerDefRanges = new AnalogControls(controller).Definition.AxisRanges;
+			var defAxes = new AnalogControls(controller).Definition.Axes;
 			return new PadSchema
 			{
 				Size = new Size(280, 300),
@@ -72,8 +72,8 @@ namespace BizHawk.Client.EmuHawk
 					Button(146, 34, controller, 4),
 					new AnalogSchema(2, 80, $"P{controller} Stick X")
 					{
-						AxisRange = controllerDefRanges[0],
-						SecondaryAxisRange = controllerDefRanges[1]
+						AxisRange = defAxes.SpecAtIndex(0).Range,
+						SecondaryAxisRange = defAxes.SpecAtIndex(1).Range
 					}
 				}
 			};

--- a/src/BizHawk.Emulation.Common/Base Implementations/ControllerDefinition.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/ControllerDefinition.cs
@@ -99,11 +99,27 @@ namespace BizHawk.Emulation.Common
 			/// </summary>
 			public readonly AxisConstraint? Constraint;
 
-			public readonly AxisRange Range;
+			public Range<float> FloatRange => ((float) Min).RangeTo(Max);
 
-			public AxisSpec(AxisRange range, AxisConstraint? constraint = null)
+			public readonly bool IsReversed;
+
+			public int Max => Range.EndInclusive;
+
+			/// <value>maximum decimal digits analog input can occupy with no-args ToString</value>
+			/// <remarks>does not include the extra char needed for a minus sign</remarks>
+			public int MaxDigits => Math.Max(Math.Abs(Min).ToString().Length, Math.Abs(Max).ToString().Length);
+
+			public readonly int Mid;
+
+			public int Min => Range.Start;
+
+			public readonly Range<int> Range;
+
+			public AxisSpec(Range<int> range, int mid, bool isReversed = false, AxisConstraint? constraint = null)
 			{
 				Constraint = constraint;
+				IsReversed = isReversed;
+				Mid = mid;
 				Range = range;
 			}
 		}
@@ -150,42 +166,6 @@ namespace BizHawk.Emulation.Common
 				}
 			}
 		}
-
-		public readonly struct AxisRange
-		{
-			public readonly bool IsReversed;
-
-			public readonly int Max;
-
-			/// <remarks>used as default/neutral/unset</remarks>
-			public readonly int Mid;
-
-			public readonly int Min;
-
-			public Range<float> FloatRange => ((float) Min).RangeTo(Max);
-
-			/// <value>maximum decimal digits analog input can occupy with no-args ToString</value>
-			/// <remarks>does not include the extra char needed for a minus sign</remarks>
-			public int MaxDigits => Math.Max(Math.Abs(Min).ToString().Length, Math.Abs(Max).ToString().Length);
-
-			public Range<int> Range => Min.RangeTo(Max);
-
-			public AxisRange(int min, int mid, int max, bool isReversed = false)
-			{
-				const string ReversedBoundsExceptionMessage = nameof(AxisRange) + " must not have " + nameof(max) + " < " + nameof(min) + ". pass " + nameof(isReversed) + ": true to ctor instead, or use " + nameof(CreateAxisRangePair);
-				if (max < min) throw new ArgumentOutOfRangeException(nameof(max), max, ReversedBoundsExceptionMessage);
-				IsReversed = isReversed;
-				Max = max;
-				Mid = mid;
-				Min = min;
-			}
-		}
-
-		public static List<AxisRange> CreateAxisRangePair(int min, int mid, int max, AxisPairOrientation pDir) => new List<AxisRange>
-		{
-			new AxisRange(min, mid, max, ((byte) pDir & 2) != 0),
-			new AxisRange(min, mid, max, ((byte) pDir & 1) != 0)
-		};
 
 		/// <summary>represents the direction of <c>(+, +)</c></summary>
 		/// <remarks>docs of individual controllers are being collected in comments of https://github.com/TASVideos/BizHawk/issues/1200</remarks>

--- a/src/BizHawk.Emulation.Common/ControllerDefinitionMerger.cs
+++ b/src/BizHawk.Emulation.Common/ControllerDefinitionMerger.cs
@@ -40,14 +40,13 @@ namespace BizHawk.Emulation.Common
 					remaps[s] = r;
 				}
 
-				foreach (string s in def.AxisControls)
+				foreach (var kvp in def.Axes)
 				{
-					string r = Allocate(s, ref plr, ref playerNext);
-					ret.AxisControls.Add(r);
-					remaps[s] = r;
+					string r = Allocate(kvp.Key, ref plr, ref playerNext);
+					ret.Axes.Add(r, kvp.Value);
+					remaps[kvp.Key] = r;
 				}
 
-				ret.AxisRanges.AddRange(def.AxisRanges);
 				plr = playerNext;
 				unmergers.Add(new ControlDefUnMerger(remaps));
 			}

--- a/src/BizHawk.Emulation.Common/SaveController.cs
+++ b/src/BizHawk.Emulation.Common/SaveController.cs
@@ -65,7 +65,7 @@ namespace BizHawk.Emulation.Common
 				_buttons.Add(k, source.IsPressed(k) ? 1 : 0);
 			}
 
-			foreach (var k in Definition.AxisControls)
+			foreach (var k in Definition.Axes.Keys)
 			{
 				if (_buttons.Keys.Contains(k))
 				{

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600ControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600ControllerDeck.cs
@@ -37,11 +37,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(Port2.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(Port2.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in Port2.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600Controllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600Controllers.cs
@@ -120,8 +120,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 				BoolButtons = BaseDefinition
 				.Select(b => $"P{PortNum} " + b)
 				.ToList()
-			}.AddAxis($"P{PortNum} Paddle X 1", -127, 0, 127)
-				.AddAxis($"P{PortNum} Paddle X 2", -127, 0, 127);
+			}.AddAxis($"P{PortNum} Paddle X 1", (-127).RangeTo(127), 0)
+				.AddAxis($"P{PortNum} Paddle X 2", (-127).RangeTo(127), 0);
 		}
 
 		public int PortNum { get; }
@@ -236,8 +236,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 				BoolButtons = BaseDefinition
 				.Select(b => $"P{PortNum} " + b)
 				.ToList()
-			}.AddAxis($"P{PortNum} Wheel X 1", -127, 0, 127)
-				.AddAxis($"P{PortNum} Wheel X 2", -127, 0, 127);
+			}.AddAxis($"P{PortNum} Wheel X 1", (-127).RangeTo(127), 0)
+				.AddAxis($"P{PortNum} Wheel X 2", (-127).RangeTo(127), 0);
 		}
 
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600Controllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600Controllers.cs
@@ -119,10 +119,9 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			{
 				BoolButtons = BaseDefinition
 				.Select(b => $"P{PortNum} " + b)
-				.ToList(),
-				AxisControls = { "P" + PortNum + " Paddle X 1" , "P" + PortNum + " Paddle X 2" },
-				AxisRanges = { new ControllerDefinition.AxisRange(-127, 0, 127), new ControllerDefinition.AxisRange(-127, 0, 127) }
-			};
+				.ToList()
+			}.AddAxis($"P{PortNum} Paddle X 1", -127, 0, 127)
+				.AddAxis($"P{PortNum} Paddle X 2", -127, 0, 127);
 		}
 
 		public int PortNum { get; }
@@ -152,7 +151,7 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 
 		public int Read_Pot(IController c, int pot)
 		{
-			int x = (int)c.AxisValue(Definition.AxisControls[pot]);			
+			int x = (int)c.AxisValue(Definition.Axes[pot]);
 			
 			x = -x;
 			x += 127;
@@ -236,10 +235,9 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 			{
 				BoolButtons = BaseDefinition
 				.Select(b => $"P{PortNum} " + b)
-				.ToList(),
-				AxisControls = { "P" + PortNum + " Wheel X 1", "P" + PortNum + " Wheel X 2" },
-				AxisRanges = { new ControllerDefinition.AxisRange(-127, 0, 127), new ControllerDefinition.AxisRange(-127, 0, 127) }
-			};
+				.ToList()
+			}.AddAxis($"P{PortNum} Wheel X 1", -127, 0, 127)
+				.AddAxis($"P{PortNum} Wheel X 2", -127, 0, 127);
 		}
 
 		public int PortNum { get; }
@@ -262,8 +260,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 
 			if (c.IsPressed($"P{PortNum} Button")) { result &= 0xF7; }
 
-			float x = c.AxisValue(Definition.AxisControls[0]);
-			float y = c.AxisValue(Definition.AxisControls[1]);
+			float x = c.AxisValue(Definition.Axes[0]);
+			float y = c.AxisValue(Definition.Axes[1]);
 
 			float angle = CalcDirection(x, y);
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllerDeck.cs
@@ -43,11 +43,8 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(Port2.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(Port2.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in Port2.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllers.cs
@@ -275,7 +275,7 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 			{
 				Name = "Light Gun Controller",
 				BoolButtons = BaseDefinition.Select(b => $"P{PortNum} {b}").ToList()
-			}.AddXYPair($"P{PortNum} {{0}}", AxisPairOrientation.RightAndUp, (1, 160, 320), (1, 121, 242)); //TODO verify direction against hardware
+			}.AddXYPair($"P{PortNum} {{0}}", AxisPairOrientation.RightAndUp, 1.RangeTo(320), 160, 1.RangeTo(242), 121); //TODO verify direction against hardware
 		}
 		
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/A7800Hawk/A7800HawkControllers.cs
@@ -313,8 +313,8 @@ namespace BizHawk.Emulation.Cores.Atari.A7800Hawk
 
 		public bool Is_LightGun(IController c, out float x, out float y)
 		{
-			x = c.AxisValue(Definition.AxisControls[0]);
-			y = c.AxisValue(Definition.AxisControls[1]);
+			x = c.AxisValue(Definition.Axes[0]);
+			y = c.AxisValue(Definition.Axes[1]);
 			return true;
 		}
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Belogic/Uzem.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Belogic/Uzem.cs
@@ -2,6 +2,8 @@
 using BizHawk.Emulation.Cores.Waterbox;
 using System;
 
+using BizHawk.Common;
+
 using static BizHawk.Emulation.Common.ControllerDefinition;
 
 namespace BizHawk.Emulation.Cores.Consoles.Belogic
@@ -62,7 +64,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Belogic
 		{
 			Name = "SNES Controller",
 			BoolButtons = { "P1 Mouse Left", "P1 Mouse Right", "Power" }
-		}.AddXYPair("P1 Mouse {0}", AxisPairOrientation.RightAndUp, -127, 0, 127); //TODO verify direction against hardware
+		}.AddXYPair("P1 Mouse {0}", AxisPairOrientation.RightAndUp, (-127).RangeTo(127), 0); //TODO verify direction against hardware
 
 		private static readonly string[] PadBits =
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllerDeck.cs
@@ -37,11 +37,8 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(Port2.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(Port2.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in Port2.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public float wheel1;

--- a/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllers.cs
@@ -133,7 +133,7 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 		{
 			PortNum = portNum;
 			Definition = new ControllerDefinition { BoolButtons = BaseBoolDefinition.Select(b => $"P{PortNum} {b}").ToList() }
-				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, -127, 0, 127); //TODO verify direction against hardware
+				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, (-127).RangeTo(127), 0); //TODO verify direction against hardware
 		}
 
 		public int PortNum { get; }
@@ -232,7 +232,7 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 		{
 			PortNum = portNum;
 			Definition = new ControllerDefinition { BoolButtons = BaseBoolDefinition.Select(b => $"P{PortNum} {b}").ToList() }
-				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, -127, 0, 127); //TODO verify direction against hardware
+				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, (-127).RangeTo(127), 0); //TODO verify direction against hardware
 		}
 
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Coleco/ColecoControllers.cs
@@ -148,8 +148,8 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 				
 				if (c.IsPressed(Definition.BoolButtons[0])) retVal &= 0x3F;
 				
-				float x = c.AxisValue(Definition.AxisControls[0]);
-				float y = c.AxisValue(Definition.AxisControls[1]);
+				float x = c.AxisValue(Definition.Axes[0]);
+				float y = c.AxisValue(Definition.Axes[1]);
 
 				var angle = updateWheel ? wheelAngle : CalcDirection(x, y);
 				
@@ -219,8 +219,8 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 
 		public float UpdateWheel(IController c)
 		{
-			float x = c.AxisValue(Definition.AxisControls[0]);
-			float y = c.AxisValue(Definition.AxisControls[1]);
+			float x = c.AxisValue(Definition.Axes[0]);
+			float y = c.AxisValue(Definition.Axes[1]);
 			return CalcDirection(x, y);
 		}
 	}
@@ -250,8 +250,8 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 				if (c.IsPressed(Definition.BoolButtons[3])) retVal &= 0xF7;
 				if (c.IsPressed(Definition.BoolButtons[4])) retVal &= 0x3F;
 
-				float x = c.AxisValue(Definition.AxisControls[0]);
-				float y = c.AxisValue(Definition.AxisControls[1]);
+				float x = c.AxisValue(Definition.Axes[0]);
+				float y = c.AxisValue(Definition.Axes[1]);
 
 				var angle = updateWheel ? wheelAngle : CalcDirection(x, y);
 
@@ -348,8 +348,8 @@ namespace BizHawk.Emulation.Cores.ColecoVision
 
 		public float UpdateWheel(IController c)
 		{
-			float x = c.AxisValue(Definition.AxisControls[0]);
-			float y = c.AxisValue(Definition.AxisControls[1]);
+			float x = c.AxisValue(Definition.Axes[0]);
+			float y = c.AxisValue(Definition.Axes[1]);
 			return CalcDirection(x, y);
 		}
 	}

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawkControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawkControllerDeck.cs
@@ -38,11 +38,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 							.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(Port2.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(Port2.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in Port2.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawkControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawkControllers.cs
@@ -81,7 +81,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 			{
 				Name = "Vectrex Analog Controller",
 				BoolButtons = BaseDefinition.Select(b => $"P{PortNum} {b}").ToList()
-			}.AddXYPair($"P{PortNum} Stick {{0}}", AxisPairOrientation.RightAndUp, -128, 0, 127);
+			}.AddXYPair($"P{PortNum} Stick {{0}}", AxisPairOrientation.RightAndUp, (-128).RangeTo(127), 0);
 		}
 
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllerDeck.cs
@@ -38,11 +38,8 @@ namespace BizHawk.Emulation.Cores.Intellivision
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(Port2.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(Port2.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in Port2.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllers.cs
@@ -142,7 +142,7 @@ namespace BizHawk.Emulation.Cores.Intellivision
 		{
 			PortNum = portNum;
 			Definition = new ControllerDefinition { BoolButtons = BaseBoolDefinition.Select(b => $"P{PortNum} {b}").ToList() }
-				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, -127, 0, 127); //TODO verify direction against hardware
+				.AddXYPair($"P{PortNum} Disc {{0}}", AxisPairOrientation.RightAndUp, (-127).RangeTo(127), 0); //TODO verify direction against hardware
 		}
 
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Intellivision/Controllers/IntellivisionControllers.cs
@@ -160,8 +160,8 @@ namespace BizHawk.Emulation.Cores.Intellivision
 				}
 			}
 
-			int x = (int)c.AxisValue(Definition.AxisControls[0]);
-			int y = (int)c.AxisValue(Definition.AxisControls[1]);
+			int x = (int)c.AxisValue(Definition.Axes[0]);
+			int y = (int)c.AxisValue(Definition.Axes[1]);
 			result |= CalcDirection(x, y);
 
 			return result;

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2HawkControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2HawkControllerDeck.cs
@@ -43,9 +43,7 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Text;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.GBA
@@ -258,7 +260,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 		{
 			Name = "GBA Controller",
 			BoolButtons = { "Up", "Down", "Left", "Right", "Start", "Select", "B", "A", "L", "R", "Power" }
-		}.AddXYZTriple("Tilt {0}", -32767, 0, 32767)
-			.AddAxis("Light Sensor", 0, 100, 200);
+		}.AddXYZTriple("Tilt {0}", (-32767).RangeTo(32767), 0)
+			.AddAxis("Light Sensor", 0.RangeTo(200), 100);
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllerDeck.cs
@@ -26,9 +26,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 					.ToList()
 			};
 
-			Definition.AxisControls.AddRange(Port1.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(Port1.Definition.AxisRanges);
+			foreach (var kvp in Port1.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		public byte ReadPort1(IController c)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllers.cs
@@ -173,8 +173,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			theta_prev = theta;
 			phi_prev = phi;
 
-			theta = (float)(c.AxisValue(Definition.AxisControls[1]) * Math.PI / 180.0);
-			phi = (float)(c.AxisValue(Definition.AxisControls[0]) * Math.PI / 180.0);
+			theta = (float)(c.AxisValue(Definition.Axes[1]) * Math.PI / 180.0);
+			phi = (float)(c.AxisValue(Definition.Axes[0]) * Math.PI / 180.0);
 
 			float temp = (float)(Math.Cos(theta) * Math.Sin(phi));
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawk/GBHawkControllers.cs
@@ -117,7 +117,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawk
 			{
 				Name = "Gameboy Controller + Tilt",
 				BoolButtons = BaseDefinition.Select(b => $"P{PortNum} {b}").ToList()
-			}.AddXYPair($"P{PortNum} Tilt {{0}}", AxisPairOrientation.RightAndUp, -45, 0, 45); //TODO verify direction against hardware
+			}.AddXYPair($"P{PortNum} Tilt {{0}}", AxisPairOrientation.RightAndUp, (-45).RangeTo(45), 0); //TODO verify direction against hardware
 		}
 
 		public int PortNum { get; }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.ISettable.cs
@@ -34,19 +34,23 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			static void AddN64StandardController(ControllerDefinition def, int player)
 			{
 				def.BoolButtons.AddRange(new[] { $"P{player} A Up", $"P{player} A Down", $"P{player} A Left", $"P{player} A Right", $"P{player} DPad U", $"P{player} DPad D", $"P{player} DPad L", $"P{player} DPad R", $"P{player} Start", $"P{player} Z", $"P{player} B", $"P{player} A", $"P{player} C Up", $"P{player} C Down", $"P{player} C Right", $"P{player} C Left", $"P{player} L", $"P{player} R" });
-				def.AddXYPair($"P{player} {{0}} Axis", AxisPairOrientation.RightAndUp, -128, 0, 127);
-				def.AxisConstraints.Add(new AxisConstraint
-				{
-					Class = "Natural Circle",
-					Type = AxisConstraintType.Circular,
-					Params = new object[] { $"P{player} X Axis", $"P{player} Y Axis", 127.0f }
-				});
+				def.AddXYPair(
+					$"P{player} {{0}} Axis",
+					AxisPairOrientation.RightAndUp,
+					-128,
+					0,
+					127,
+					new AxisConstraint
+					{
+						Class = "Natural Circle",
+						Type = AxisConstraintType.Circular,
+						Params = new object[] { $"P{player} X Axis", $"P{player} Y Axis", 127.0f }
+					}
+				);
 			}
 
 			ControllerDefinition.BoolButtons.Clear();
-			ControllerDefinition.AxisControls.Clear();
-			ControllerDefinition.AxisRanges.Clear();
-			ControllerDefinition.AxisConstraints.Clear();
+			ControllerDefinition.Axes.Clear();
 
 			ControllerDefinition.BoolButtons.AddRange(new[] { "Reset", "Power" });
 			for (var i = 1; i <= 4; i++)

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.ISettable.cs
@@ -1,4 +1,5 @@
-﻿using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
+using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
 
@@ -37,9 +38,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 				def.AddXYPair(
 					$"P{player} {{0}} Axis",
 					AxisPairOrientation.RightAndUp,
-					-128,
+					(-128).RangeTo(127),
 					0,
-					127,
 					new AxisConstraint
 					{
 						Class = "Natural Circle",

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NDS/MelonDS.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.IO;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -100,7 +102,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Nintendo.NDS
 			ControllerDefinition.BoolButtons.Add("Power");
 
 			ControllerDefinition.BoolButtons.Add("Touch");
-			ControllerDefinition.AddXYPair("Touch{0}", AxisPairOrientation.RightAndUp, (0, 128, 255), (0, 96, 191)); //TODO verify direction against hardware
+			ControllerDefinition.AddXYPair("Touch{0}", AxisPairOrientation.RightAndUp, 0.RangeTo(255), 128, 0.RangeTo(191), 96); //TODO verify direction against hardware
 
 			CoreComm = comm;
 			_resampler = new SpeexResampler(SpeexResampler.Quality.QUALITY_DEFAULT, 32768, 44100, 32768, 44100);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -160,10 +160,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			}
 
 			// Add in the reset timing axis for subneshawk
-			if (using_reset_timing && ControllerDefinition.AxisControls.Count == 0)
+			if (using_reset_timing && ControllerDefinition.Axes.Count == 0)
 			{
-				ControllerDefinition.AxisControls.Add("Reset Cycle");
-				ControllerDefinition.AxisRanges.Add(new ControllerDefinition.AxisRange(0, 0, 500000));
+				ControllerDefinition.AddAxis("Reset Cycle", 0, 0, 500000);
 			}
 
 			// don't replace the magicSoundProvider on reset, as it's not needed

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NES.Core.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Emulation.Cores.Components.M6502;
 
@@ -162,7 +163,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			// Add in the reset timing axis for subneshawk
 			if (using_reset_timing && ControllerDefinition.Axes.Count == 0)
 			{
-				ControllerDefinition.AddAxis("Reset Cycle", 0, 0, 500000);
+				ControllerDefinition.AddAxis("Reset Cycle", 0.RangeTo(500000), 0);
 			}
 
 			// don't replace the magicSoundProvider on reset, as it's not needed

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
@@ -183,8 +183,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 			Right.SyncState(ser);
 			ser.EndSection();
 		}
-
-		internal static readonly AxisRange ArkanoidPaddleRange = new AxisRange(0, 80, 160);
 	}
 
 	public class UnpluggedNES : INesPort
@@ -388,12 +386,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		bool resetting = false;
 		byte latchedvalue = 0x54 ^ 0xff;
 
-		static ControllerDefinition Definition = new ControllerDefinition
-		{
-			BoolButtons = { "0Fire" },
-			AxisControls = { "0Paddle" },
-			AxisRanges = { NesDeck.ArkanoidPaddleRange }
-		};
+		private static readonly ControllerDefinition Definition
+			= new ControllerDefinition { BoolButtons = { "0Fire" } }
+				.AddAxis("0Paddle", 0, 80, 160);
 
 		public void Strobe(StrobeInfo s, IController c)
 		{
@@ -746,12 +741,9 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 		bool resetting = false;
 		byte latchedvalue = 0x54 ^ 0xff;
 
-		static ControllerDefinition Definition = new ControllerDefinition
-		{
-			BoolButtons = { "0Fire" },
-			AxisControls = { "0Paddle" },
-			AxisRanges = { NesDeck.ArkanoidPaddleRange }
-		};
+		private static readonly ControllerDefinition Definition
+			= new ControllerDefinition { BoolButtons = { "0Fire" } }
+				.AddAxis("0Paddle", 0, 80, 160);
 
 		public void Strobe(StrobeInfo s, IController c)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/NES/NESControllers.cs
@@ -388,7 +388,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		private static readonly ControllerDefinition Definition
 			= new ControllerDefinition { BoolButtons = { "0Fire" } }
-				.AddAxis("0Paddle", 0, 80, 160);
+				.AddAxis("0Paddle", 0.RangeTo(160), 80);
 
 		public void Strobe(StrobeInfo s, IController c)
 		{
@@ -538,7 +538,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 	internal static class NESControllerDefExtensions
 	{
 		public static ControllerDefinition AddZapper(this ControllerDefinition def, string nameFormat)
-			=> def.AddXYPair(nameFormat, AxisPairOrientation.RightAndUp, (0, 128, 255), (0, 120, 239)); //TODO verify direction against hardware
+			=> def.AddXYPair(nameFormat, AxisPairOrientation.RightAndUp, 0.RangeTo(255), 128, 0.RangeTo(239), 120); //TODO verify direction against hardware
 	}
 
 	// Dummy interface to indicate zapper behavior, used as a means of type checking for zapper functionality
@@ -743,7 +743,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.NES
 
 		private static readonly ControllerDefinition Definition
 			= new ControllerDefinition { BoolButtons = { "0Fire" } }
-				.AddAxis("0Paddle", 0, 80, 160);
+				.AddAxis("0Paddle", 0.RangeTo(160), 80);
 
 		public void Strobe(StrobeInfo s, IController c)
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesControllerDeck.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using BizHawk.Common.NumberExtensions;
 
@@ -92,7 +93,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 		/// for reference Snes9x is always in 224 mode
 		/// </remarks>
 		public static ControllerDefinition AddLightGun(this ControllerDefinition def, string nameFormat)
-			=> def.AddXYPair(nameFormat, AxisPairOrientation.RightAndUp, (0, 128, 256), (0, 0, 240)); //TODO verify direction against hardware
+			=> def.AddXYPair(nameFormat, AxisPairOrientation.RightAndUp, 0.RangeTo(256), 128, 0.RangeTo(240), 0); //TODO verify direction against hardware
 	}
 
 	public interface ILibsnesController
@@ -287,7 +288,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 
 		private static readonly ControllerDefinition _definition
 			= new ControllerDefinition { BoolButtons = { "0Mouse Left", "0Mouse Right" } }
-				.AddXYPair("0Mouse {0}", AxisPairOrientation.RightAndDown, -127, 0, 127); //TODO verify direction against hardware, R+D inferred from behaviour in Mario Paint
+				.AddXYPair("0Mouse {0}", AxisPairOrientation.RightAndDown, (-127).RangeTo(127), 0); //TODO verify direction against hardware, R+D inferred from behaviour in Mario Paint
 
 		public ControllerDefinition Definition => _definition;
 

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
@@ -208,7 +208,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 		{
 			private static readonly ControllerDefinition _definition
 				= new ControllerDefinition { BoolButtons = { "0Mouse Left", "0Mouse Right" } }
-					.AddXYPair("0Mouse {0}", AxisPairOrientation.RightAndUp, -127, 0, 127); //TODO verify direction against hardware
+					.AddXYPair("0Mouse {0}", AxisPairOrientation.RightAndUp, (-127).RangeTo(127), 0); //TODO verify direction against hardware
 
 			public override ControllerDefinition Definition => _definition;
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES9X/Snes9x.cs
@@ -197,7 +197,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES9X
 
 			public void ApplyState(IController controller, short[] input, int offset)
 			{
-				foreach (var s in Definition.AxisControls)
+				foreach (var s in Definition.Axes.Keys)
 					input[offset++] = (short)(controller.AxisValue(s));
 				foreach (var s in Definition.BoolButtons)
 					input[offset++] = (short)(controller.IsPressed(s) ? 1 : 0);

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
@@ -41,8 +41,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubGBHawk
 			_tracer = new TraceBuffer { Header = _GBCore.cpu.TraceHeader };
 			ser.Register(_tracer);
 
-			_GBCore.ControllerDefinition.AxisControls.Add("Input Cycle");
-			_GBCore.ControllerDefinition.AxisRanges.Add(new ControllerDefinition.AxisRange(0, 70224, 70224));
+			_GBCore.ControllerDefinition.AddAxis("Input Cycle", 0, 70224, 70224);
 		}
 
 		public GBHawk.GBHawk _GBCore;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SubGBHawk/SubGBHawk.cs
@@ -1,4 +1,5 @@
-﻿using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
+using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Nintendo.SubGBHawk
 {
@@ -41,7 +42,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SubGBHawk
 			_tracer = new TraceBuffer { Header = _GBCore.cpu.TraceHeader };
 			ser.Register(_tracer);
 
-			_GBCore.ControllerDefinition.AddAxis("Input Cycle", 0, 70224, 70224);
+			_GBCore.ControllerDefinition.AddAxis("Input Cycle", 0.RangeTo(70224), 70224);
 		}
 
 		public GBHawk.GBHawk _GBCore;

--- a/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PceControllerDeck.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/PC Engine/PceControllerDeck.cs
@@ -43,18 +43,11 @@ namespace BizHawk.Emulation.Cores.PCEngine
 					.Concat(_port5.Definition.BoolButtons)
 					.ToList()
 			};
-
-			Definition.AxisControls.AddRange(_port1.Definition.AxisControls);
-			Definition.AxisControls.AddRange(_port2.Definition.AxisControls);
-			Definition.AxisControls.AddRange(_port3.Definition.AxisControls);
-			Definition.AxisControls.AddRange(_port4.Definition.AxisControls);
-			Definition.AxisControls.AddRange(_port5.Definition.AxisControls);
-
-			Definition.AxisRanges.AddRange(_port1.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(_port2.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(_port3.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(_port4.Definition.AxisRanges);
-			Definition.AxisRanges.AddRange(_port5.Definition.AxisRanges);
+			foreach (var kvp in _port1.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in _port2.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in _port3.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in _port4.Definition.Axes) Definition.Axes.Add(kvp);
+			foreach (var kvp in _port5.Definition.Axes) Definition.Axes.Add(kvp);
 		}
 
 		private readonly IPort _port1;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -1,4 +1,5 @@
-﻿using BizHawk.Emulation.Common;
+﻿using BizHawk.Common;
+using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
 
@@ -28,7 +29,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						// scale the vertical to the display mode
 						var axisName = SMSLightPhaserController.Axes[1];
 						SMSLightPhaserController.Axes[axisName] = SMSLightPhaserController.Axes[axisName]
-							.With(range: new AxisRange(0, Vdp.FrameHeight / 2, Vdp.FrameHeight - 1));
+							.With(0.RangeTo(Vdp.FrameHeight - 1), Vdp.FrameHeight / 2);
 						return SMSLightPhaserController;
 					case SmsSyncSettings.ControllerTypes.SportsPad:
 						return SMSSportsPadController;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.IEmulator.cs
@@ -1,5 +1,7 @@
 ﻿using BizHawk.Emulation.Common;
 
+using static BizHawk.Emulation.Common.ControllerDefinition;
+
 namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 {
 	public partial class SMS : IEmulator
@@ -24,8 +26,9 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 						return SMSPaddleController;
 					case SmsSyncSettings.ControllerTypes.LightPhaser:
 						// scale the vertical to the display mode
-						SMSLightPhaserController.AxisRanges[1] = new ControllerDefinition.AxisRange(0, Vdp.FrameHeight / 2, Vdp.FrameHeight - 1);
-
+						var axisName = SMSLightPhaserController.Axes[1];
+						SMSLightPhaserController.Axes[axisName] = SMSLightPhaserController.Axes[axisName]
+							.With(range: new AxisRange(0, Vdp.FrameHeight / 2, Vdp.FrameHeight - 1));
 						return SMSLightPhaserController;
 					case SmsSyncSettings.ControllerTypes.SportsPad:
 						return SMSSportsPadController;

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -39,8 +40,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				"P1 Left", "P1 Right", "P1 B1",
 				"P2 Left", "P2 Right", "P2 B1",
 			}
-		}.AddAxis("P1 Paddle", 0, 128, 255)
-			.AddAxis("P2 Paddle", 0, 128, 255);
+		}.AddAxis("P1 Paddle", 0.RangeTo(255), 128)
+			.AddAxis("P2 Paddle", 0.RangeTo(255), 128);
 
 		public static readonly ControllerDefinition SMSLightPhaserController = new ControllerDefinition
 		{
@@ -50,7 +51,7 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				"Reset", "Pause",
 				"P1 Trigger"
 			}
-		}.AddXYPair("P1 {0}", AxisPairOrientation.RightAndUp, (0, 64, 127), (0, 500, 1000)); //TODO verify direction against hardware
+		}.AddXYPair("P1 {0}", AxisPairOrientation.RightAndUp, 0.RangeTo(127), 64, 0.RangeTo(1000), 500); //TODO verify direction against hardware
 
 		public static readonly ControllerDefinition SMSSportsPadController = new ControllerDefinition
 		{
@@ -61,8 +62,8 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				"P1 Left", "P1 Right", "P1 Up", "P1 Down", "P1 B1", "P1 B2",
 				"P2 Left", "P2 Right", "P2 Up", "P2 Down", "P2 B1", "P2 B2"
 			}
-		}.AddXYPair("P1 {0}", AxisPairOrientation.RightAndUp, -64, 0, 63) //TODO verify direction against hardware
-			.AddXYPair("P2 {0}", AxisPairOrientation.RightAndUp, -64, 0, 63); //TODO ditto
+		}.AddXYPair("P1 {0}", AxisPairOrientation.RightAndUp, (-64).RangeTo(63), 0) //TODO verify direction against hardware
+			.AddXYPair("P2 {0}", AxisPairOrientation.RightAndUp, (-64).RangeTo(63), 0); //TODO ditto
 
 		public static readonly ControllerDefinition SMSKeyboardController = new ControllerDefinition
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/SMS/SMS.Input.cs
@@ -38,18 +38,9 @@ namespace BizHawk.Emulation.Cores.Sega.MasterSystem
 				"Reset", "Pause",
 				"P1 Left", "P1 Right", "P1 B1",
 				"P2 Left", "P2 Right", "P2 B1",
-			},
-			AxisControls =
-			{
-				"P1 Paddle",
-				"P2 Paddle"
-			},
-			AxisRanges =
-			{
-				new AxisRange(0, 128, 255),
-				new AxisRange(0, 128, 255)
 			}
-		};
+		}.AddAxis("P1 Paddle", 0, 128, 255)
+			.AddAxis("P2 Paddle", 0, 128, 255);
 
 		public static readonly ControllerDefinition SMSLightPhaserController = new ControllerDefinition
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGXControlConverter.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGXControlConverter.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -121,7 +123,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 
 		private void DoMouseAnalog(int idx, int player)
 		{
-			ControllerDef.AddXYPair($"P{player} Mouse {{0}}", AxisPairOrientation.RightAndUp, -256, 0, 255); //TODO verify direction against hardware
+			ControllerDef.AddXYPair($"P{player} Mouse {{0}}", AxisPairOrientation.RightAndUp, (-256).RangeTo(255), 0); //TODO verify direction against hardware
 			var nx = $"P{player} Mouse X";
 			var ny = $"P{player} Mouse Y";
 			_converts.Add(() =>
@@ -134,7 +136,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 		private void DoLightgunAnalog(int idx, int player)
 		{
 			// lightgun needs to be transformed to match the current screen resolution
-			ControllerDef.AddXYPair($"P{player} Lightgun {{0}}", AxisPairOrientation.RightAndUp, 0, 5000, 10000); //TODO verify direction against hardware
+			ControllerDef.AddXYPair($"P{player} Lightgun {{0}}", AxisPairOrientation.RightAndUp, 0.RangeTo(10000), 5000); //TODO verify direction against hardware
 			var nx = $"P{player} Lightgun X";
 			var ny = $"P{player} Lightgun Y";
 			_converts.Add(() =>
@@ -146,7 +148,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 
 		private void DoXea1PAnalog(int idx, int player)
 		{
-			ControllerDef.AddXYZTriple($"P{player} Stick {{0}}", -128, 0, 127);
+			ControllerDef.AddXYZTriple($"P{player} Stick {{0}}", (-128).RangeTo(127), 0);
 			var nx = $"P{player} Stick X";
 			var ny = $"P{player} Stick Y";
 			var nz = $"P{player} Stick Z";

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -272,19 +272,11 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 							"P" + pnum + " A",
 					});
 
-					definition.AxisControls.AddRange(new[]
-						{
-								"P" + pnum + " Twist",
-								"P" + pnum + " 1",
-								"P" + pnum + " 2",
-								"P" + pnum + " L"
-							});
-
 					var axisRange = new AxisRange(0, 128, 255);
-					definition.AxisRanges.Add(axisRange);
-					definition.AxisRanges.Add(axisRange);
-					definition.AxisRanges.Add(axisRange);
-					definition.AxisRanges.Add(axisRange);
+					definition.AddAxis($"P{pnum} Twist", axisRange);
+					definition.AddAxis($"P{pnum} 1", axisRange);
+					definition.AddAxis($"P{pnum} 2", axisRange);
+					definition.AddAxis($"P{pnum} L", axisRange);
 				}
 				else
 				{
@@ -325,13 +317,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 				"Reset"
 			});
 
-			definition.AxisControls.Add("Disc Select");
-
-			definition.AxisRanges.Add(
-				//new ControllerDefinition.AxisRange(-1, -1, -1) //this is carefully chosen so that we end up with a -1 disc by default (indicating that it's never been set)
-				//hmm.. I don't see why this wouldn't work
-				new AxisRange(0, 1, 1)
-			);
+			definition.AddAxis("Disc Select", new AxisRange(0, 1, 1));
 
 			return definition;
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sony/PSX/Octoshock.cs
@@ -272,11 +272,10 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 							"P" + pnum + " A",
 					});
 
-					var axisRange = new AxisRange(0, 128, 255);
-					definition.AddAxis($"P{pnum} Twist", axisRange);
-					definition.AddAxis($"P{pnum} 1", axisRange);
-					definition.AddAxis($"P{pnum} 2", axisRange);
-					definition.AddAxis($"P{pnum} L", axisRange);
+					foreach (var axisName in new[] { $"P{pnum} Twist", $"P{pnum} 1", $"P{pnum} 2", $"P{pnum} L" })
+					{
+						definition.AddAxis(axisName, 0.RangeTo(255), 128);
+					}
 				}
 				else
 				{
@@ -304,8 +303,8 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 						definition.BoolButtons.Add("P" + pnum + " L3");
 						definition.BoolButtons.Add("P" + pnum + " R3");
 						definition.BoolButtons.Add("P" + pnum + " MODE");
-						definition.AddXYPair($"P{pnum} LStick {{0}}", AxisPairOrientation.RightAndDown, 0, 128, 255);
-						definition.AddXYPair($"P{pnum} RStick {{0}}", AxisPairOrientation.RightAndDown, 0, 128, 255);
+						definition.AddXYPair($"P{pnum} LStick {{0}}", AxisPairOrientation.RightAndDown, 0.RangeTo(255), 128);
+						definition.AddXYPair($"P{pnum} RStick {{0}}", AxisPairOrientation.RightAndDown, 0.RangeTo(255), 128);
 					}
 				}
 			}
@@ -317,7 +316,7 @@ namespace BizHawk.Emulation.Cores.Sony.PSX
 				"Reset"
 			});
 
-			definition.AddAxis("Disc Select", new AxisRange(0, 1, 1));
+			definition.AddAxis("Disc Select", 0.RangeTo(1), 1);
 
 			return definition;
 		}

--- a/src/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
+++ b/src/BizHawk.Emulation.Cores/Libretro/LibretroCore.cs
@@ -7,6 +7,8 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -255,7 +257,7 @@ namespace BizHawk.Emulation.Cores.Libretro
 				definition.BoolButtons.Add(string.Format(item,"RetroPad"));
 
 			definition.BoolButtons.Add("Pointer Pressed"); //TODO: this isnt showing up in the binding panel. I don't want to find out why.
-			definition.AddXYPair("Pointer {0}", AxisPairOrientation.RightAndUp, -32767, 0, 32767);
+			definition.AddXYPair("Pointer {0}", AxisPairOrientation.RightAndUp, (-32767).RangeTo(32767), 0);
 
 			foreach (var key in new[]{
 				"Key Backspace", "Key Tab", "Key Clear", "Key Return", "Key Pause", "Key Escape",

--- a/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Controller.cs
+++ b/src/BizHawk.Emulation.Cores/Waterbox/NymaCore.Controller.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 using NymaTypes;
 
@@ -178,7 +180,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 								var data = input.Extra.AsAxis();
 								var fullName = $"{name} {overrideName(data.NameNeg)} / {overrideName(data.NamePos)}";
 
-								ret.AddAxis(fullName, new AxisRange(0, 0x8000, 0xFFFF, (input.Flags & AxisFlags.InvertCo) != 0));
+								ret.AddAxis(fullName, 0.RangeTo(0xFFFF), 0x8000, (input.Flags & AxisFlags.InvertCo) != 0);
 								ret.CategoryLabels[fullName] = category;
 								_thunks.Add((c, b) =>
 								{
@@ -197,7 +199,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 								// reveals that a 16 bit value is read, but using anywhere near this full range makes
 								// PCFX mouse completely unusable.  Maybe this is some TAS situation where average users
 								// will want a 1/400 multiplier on sensitivity but TASers might want one frame screenwide movement?
-								ret.AddAxis(fullName, new AxisRange(-127, 0, 127, (input.Flags & AxisFlags.InvertCo) != 0));
+								ret.AddAxis(fullName, (-127).RangeTo(127), 0, (input.Flags & AxisFlags.InvertCo) != 0);
 								ret.CategoryLabels[fullName] = category;
 								_thunks.Add((c, b) =>
 								{
@@ -210,7 +212,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 							case InputType.PointerX:
 							{
 								// I think the core expects to be sent some sort of 16 bit integer, but haven't investigated much
-								ret.AddAxis(name, new AxisRange(systemInfo.PointerOffsetX, systemInfo.PointerOffsetX, systemInfo.PointerScaleX));
+								ret.AddAxis(name, systemInfo.PointerOffsetX.RangeTo(systemInfo.PointerScaleX), systemInfo.PointerOffsetX);
 								_thunks.Add((c, b) =>
 								{
 									var val = c.AxisValue(name);
@@ -222,7 +224,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 							case InputType.PointerY:
 							{
 								// I think the core expects to be sent some sort of 16 bit integer, but haven't investigated much
-								ret.AddAxis(name, new AxisRange(systemInfo.PointerOffsetY, systemInfo.PointerOffsetY, systemInfo.PointerScaleY));
+								ret.AddAxis(name, systemInfo.PointerOffsetY.RangeTo(systemInfo.PointerScaleY), systemInfo.PointerOffsetY);
 								_thunks.Add((c, b) =>
 								{
 									var val = c.AxisValue(name);
@@ -233,7 +235,7 @@ namespace BizHawk.Emulation.Cores.Waterbox
 							}
 							case InputType.ButtonAnalog:
 							{
-								ret.AddAxis(name, new AxisRange(0, 0, 0xFFFF));
+								ret.AddAxis(name, 0.RangeTo(0xFFFF), 0);
 								ret.CategoryLabels[name] = category;
 								_thunks.Add((c, b) =>
 								{

--- a/src/BizHawk.Tests/Client.Common/Display/InputDisplayTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Display/InputDisplayTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using BizHawk.Client.Common;
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 using static BizHawk.Emulation.Common.ControllerDefinition;
@@ -24,7 +25,7 @@ namespace BizHawk.Tests.Client.Common.Display
 
 			_axisController = new SimpleController
 			{
-				Definition = new ControllerDefinition().AddXYPair("Stick{0}", AxisPairOrientation.RightAndUp, 0, MidValue, 200)
+				Definition = new ControllerDefinition().AddXYPair("Stick{0}", AxisPairOrientation.RightAndUp, 0.RangeTo(200), MidValue)
 			};
 		}
 

--- a/src/BizHawk.Tests/Client.Common/Movie/LogGeneratorTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/LogGeneratorTests.cs
@@ -23,7 +23,7 @@ namespace BizHawk.Common.Tests.Client.Common.Movie
 
 			_axisController = new SimpleController
 			{
-				Definition = new ControllerDefinition().AddXYPair("Stick{0}", AxisPairOrientation.RightAndUp, 0, 100, 200)
+				Definition = new ControllerDefinition().AddXYPair("Stick{0}", AxisPairOrientation.RightAndUp, 0.RangeTo(200), 100)
 			};
 		}
 


### PR DESCRIPTION
All this is basically just setup for adding the concept of linked/grouped axes. The new prop `AxisDict Axes` is indexable as `Axes[0]` (returns the name as a `string` like `BoolButtons`) and as `Axes["P1 X"]` (returns the `AxisSpec`).

TODO not in scope but PSX disc switcher is suspicious