### PR TITLE
Create a generic core menu

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -283,8 +283,6 @@
 			this.vDPViewerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
 			this.GenesisSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.wonderSwanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.AppleSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.AppleDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator31 = new System.Windows.Forms.ToolStripSeparator();
@@ -424,7 +422,6 @@
             this.N64SubMenu,
             this.DGBSubMenu,
 			this.GenesisSubMenu,
-			this.wonderSwanToolStripMenuItem,
 			this.AppleSubMenu,
 			this.C64SubMenu,
 			this.IntvSubMenu,
@@ -2498,21 +2495,6 @@
 			this.GenesisSettingsToolStripMenuItem.Text = "&Settings...";
 			this.GenesisSettingsToolStripMenuItem.Click += new System.EventHandler(this.GenesisSettingsMenuItem_Click);
 			// 
-			// wonderSwanToolStripMenuItem
-			// 
-			this.wonderSwanToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.settingsToolStripMenuItem});
-			this.wonderSwanToolStripMenuItem.Name = "wonderSwanToolStripMenuItem";
-			this.wonderSwanToolStripMenuItem.Size = new System.Drawing.Size(83, 17);
-			this.wonderSwanToolStripMenuItem.Text = "&WonderSwan";
-			// 
-			// settingsToolStripMenuItem
-			// 
-			this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-			this.settingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.settingsToolStripMenuItem.Text = "&Settings...";
-			this.settingsToolStripMenuItem.Click += new System.EventHandler(this.WonderSwanSettingsMenuItem_Click);
-			// 
 			// AppleSubMenu
 			// 
 			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3723,8 +3705,6 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator23;
 		private System.Windows.Forms.ToolStripMenuItem N64CircularAnalogRangeMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem paletteToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem wonderSwanToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ProfilesMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem PceSoundDebuggerToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SynclessRecordingMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -279,8 +279,6 @@
 			this.N64ExpansionSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.GGLSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.GGLsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.GenesisSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.vDPViewerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
@@ -425,7 +423,6 @@
             this.ColecoSubMenu,
             this.N64SubMenu,
             this.DGBSubMenu,
-			this.GGLSubMenu,
 			this.GenesisSubMenu,
 			this.wonderSwanToolStripMenuItem,
 			this.AppleSubMenu,
@@ -2472,21 +2469,6 @@
 			this.DGBsettingsToolStripMenuItem.Text = "Settings...";
 			this.DGBsettingsToolStripMenuItem.Click += new System.EventHandler(this.DgbSettingsMenuItem_Click);
 			// 
-			// GGLSubMenu
-			// 
-			this.GGLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.GGLsettingsToolStripMenuItem});
-			this.GGLSubMenu.Name = "GGLSubMenu";
-			this.GGLSubMenu.Size = new System.Drawing.Size(54, 17);
-			this.GGLSubMenu.Text = "&GG Link";
-			// 
-			// GGLsettingsToolStripMenuItem
-			// 
-			this.GGLsettingsToolStripMenuItem.Name = "GGLsettingsToolStripMenuItem";
-			this.GGLsettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.GGLsettingsToolStripMenuItem.Text = "Settings...";
-			this.GGLsettingsToolStripMenuItem.Click += new System.EventHandler(this.GgSettingsMenuItem_Click);
-			// 
 			// GenesisSubMenu
 			// 
 			this.GenesisSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3702,8 +3684,6 @@
 		private System.Windows.Forms.ToolStripMenuItem FdsEjectDiskMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem DGBSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem DGBsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GGLSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem GGLsettingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GenericCoreSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem GenericCoreSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GenesisSubMenu;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -2801,7 +2801,7 @@
 			this.GenericCoreSettingsMenuItem});
 			this.GenericCoreSubMenu.Name = "GenericCoreSubMenu";
 			this.GenericCoreSubMenu.Size = new System.Drawing.Size(56, 17);
-			this.GenericCoreSubMenu.Text = "&MSX";
+			this.GenericCoreSubMenu.Text = "&Core";
 			// 
 			// GenericCoreSettingsMenuItem
 			// 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -293,8 +293,6 @@
 			this.C64SettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.IntvSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.IntVControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.virtualBoyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.preferencesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
 			this.zXSpectrumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ZXSpectrumCoreEmulationSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ZXSpectrumControllerConfigurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -425,7 +423,6 @@
 			this.AppleSubMenu,
 			this.C64SubMenu,
 			this.IntvSubMenu,
-			this.virtualBoyToolStripMenuItem,
 			this.zXSpectrumToolStripMenuItem,
 			this.GenericCoreSubMenu,
 			this.amstradCPCToolStripMenuItem,
@@ -2573,21 +2570,6 @@
 			this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
 			this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
 			// 
-			// virtualBoyToolStripMenuItem
-			// 
-			this.virtualBoyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.preferencesToolStripMenuItem1});
-			this.virtualBoyToolStripMenuItem.Name = "virtualBoyToolStripMenuItem";
-			this.virtualBoyToolStripMenuItem.Size = new System.Drawing.Size(67, 17);
-			this.virtualBoyToolStripMenuItem.Text = "&VirtualBoy";
-			// 
-			// preferencesToolStripMenuItem1
-			// 
-			this.preferencesToolStripMenuItem1.Name = "preferencesToolStripMenuItem1";
-			this.preferencesToolStripMenuItem1.Size = new System.Drawing.Size(144, 22);
-			this.preferencesToolStripMenuItem1.Text = "Preferences...";
-			this.preferencesToolStripMenuItem1.Click += new System.EventHandler(this.VirtualBoySettingsMenuItem_Click);
-			// 
 			// zXSpectrumToolStripMenuItem
 			// 
 			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3778,8 +3760,6 @@
 		private System.Windows.Forms.ToolStripMenuItem SNESControllerConfigurationMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem C64DisksSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;
-		private System.Windows.Forms.ToolStripMenuItem virtualBoyToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem1;
 		private System.Windows.Forms.ToolStripMenuItem Atari7800HawkCoreMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem zXSpectrumToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumControllerConfigurationMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -299,8 +299,6 @@
 			this.IntVControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.virtualBoyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.preferencesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.neoGeoPocketToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.preferencesToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
 			this.zXSpectrumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ZXSpectrumCoreEmulationSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ZXSpectrumControllerConfigurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -434,7 +432,6 @@
 			this.C64SubMenu,
 			this.IntvSubMenu,
 			this.virtualBoyToolStripMenuItem,
-			this.neoGeoPocketToolStripMenuItem,
 			this.zXSpectrumToolStripMenuItem,
 			this.GenericCoreSubMenu,
 			this.amstradCPCToolStripMenuItem,
@@ -2627,21 +2624,6 @@
 			this.preferencesToolStripMenuItem1.Text = "Preferences...";
 			this.preferencesToolStripMenuItem1.Click += new System.EventHandler(this.VirtualBoySettingsMenuItem_Click);
 			// 
-			// neoGeoPocketToolStripMenuItem
-			// 
-			this.neoGeoPocketToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.preferencesToolStripMenuItem2});
-			this.neoGeoPocketToolStripMenuItem.Name = "neoGeoPocketToolStripMenuItem";
-			this.neoGeoPocketToolStripMenuItem.Size = new System.Drawing.Size(92, 17);
-			this.neoGeoPocketToolStripMenuItem.Text = "&NeoGeo Pocket";
-			// 
-			// preferencesToolStripMenuItem2
-			// 
-			this.preferencesToolStripMenuItem2.Name = "preferencesToolStripMenuItem2";
-			this.preferencesToolStripMenuItem2.Size = new System.Drawing.Size(144, 22);
-			this.preferencesToolStripMenuItem2.Text = "Preferences...";
-			this.preferencesToolStripMenuItem2.Click += new System.EventHandler(this.NeoGeoSettingsMenuItem_Click);
-			// 
 			// zXSpectrumToolStripMenuItem
 			// 
 			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3838,8 +3820,6 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;
 		private System.Windows.Forms.ToolStripMenuItem virtualBoyToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem1;
-		private System.Windows.Forms.ToolStripMenuItem neoGeoPocketToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem2;
 		private System.Windows.Forms.ToolStripMenuItem Atari7800HawkCoreMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem zXSpectrumToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumControllerConfigurationMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -277,8 +277,6 @@
 			this.N64CircularAnalogRangeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.MupenStyleLagMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.N64ExpansionSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaturnSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaturnPreferencesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBHawkSubMenu = new System.Windows.Forms.ToolStripMenuItem();
@@ -436,7 +434,6 @@
             this.SNESSubMenu,
             this.ColecoSubMenu,
             this.N64SubMenu,
-            this.SaturnSubMenu,
             this.DGBSubMenu,
             this.DGBHawkSubMenu,
 			this.GGLSubMenu,
@@ -2475,21 +2472,6 @@
 			this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
 			this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
 			// 
-			// SaturnSubMenu
-			// 
-			this.SaturnSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SaturnPreferencesMenuItem});
-			this.SaturnSubMenu.Name = "SaturnSubMenu";
-			this.SaturnSubMenu.Size = new System.Drawing.Size(51, 17);
-			this.SaturnSubMenu.Text = "&Saturn";
-			// 
-			// SaturnPreferencesMenuItem
-			// 
-			this.SaturnPreferencesMenuItem.Name = "SaturnPreferencesMenuItem";
-			this.SaturnPreferencesMenuItem.Size = new System.Drawing.Size(144, 22);
-			this.SaturnPreferencesMenuItem.Text = "Preferences...";
-			this.SaturnPreferencesMenuItem.Click += new System.EventHandler(this.SaturnPreferencesMenuItem_Click);
-			// 
 			// DGBSubMenu
 			// 
 			this.DGBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3800,8 +3782,6 @@
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator29;
 		private System.Windows.Forms.ToolStripMenuItem N64SubMenu;
 		private System.Windows.Forms.ToolStripMenuItem N64PluginSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaturnSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SaturnPreferencesMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ConfigContextMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem RewindOptionsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem FirmwaresMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -243,8 +243,6 @@
 			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
 			this.AutoloadKeypadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.paletteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AtariSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.AtariSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.A7800SubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.A7800ControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.A7800FilterSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -323,12 +321,8 @@
 			this.ZXSpectrumDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.zxt2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VectrexSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.VectrexsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MSXSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.MSXsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.O2HawkSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.O2HawksettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.GenericCoreSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.GenericCoreSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.HelpSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.OnlineHelpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.ForumsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -434,8 +428,7 @@
             this.PCESubMenu,
             this.SMSSubMenu,
             this.TI83SubMenu,
-            this.AtariSubMenu,
-            this.A7800SubMenu,
+			this.A7800SubMenu,
             this.GBSubMenu,
             this.GBASubMenu,
             this.NDSSubMenu,
@@ -457,9 +450,7 @@
 			this.virtualBoyToolStripMenuItem,
 			this.neoGeoPocketToolStripMenuItem,
 			this.zXSpectrumToolStripMenuItem,
-			this.VectrexSubMenu,
-			this.MSXSubMenu,
-			this.O2HawkSubMenu,
+			this.GenericCoreSubMenu,
 			this.amstradCPCToolStripMenuItem,
 			this.arcadeToolStripMenuItem,
 			this.HelpSubMenu});
@@ -2222,21 +2213,6 @@
 			this.paletteToolStripMenuItem.Text = "Palette...";
 			this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
 			// 
-			// AtariSubMenu
-			// 
-			this.AtariSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AtariSettingsToolStripMenuItem});
-			this.AtariSubMenu.Name = "AtariSubMenu";
-			this.AtariSubMenu.Size = new System.Drawing.Size(42, 17);
-			this.AtariSubMenu.Text = "&Atari";
-			// 
-			// AtariSettingsToolStripMenuItem
-			// 
-			this.AtariSettingsToolStripMenuItem.Name = "AtariSettingsToolStripMenuItem";
-			this.AtariSettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.AtariSettingsToolStripMenuItem.Text = "Settings...";
-			this.AtariSettingsToolStripMenuItem.Click += new System.EventHandler(this.AtariSettingsMenuItem_Click);
-			// 
 			// A7800SubMenu
 			// 
 			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -2837,50 +2813,20 @@
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
 			// 
-			// VectrexSubMenu
+			// GenericCoreSubMenu
 			// 
-			this.VectrexSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.VectrexsettingsToolStripMenuItem});
-			this.VectrexSubMenu.Name = "VectrexSubMenu";
-			this.VectrexSubMenu.Size = new System.Drawing.Size(56, 17);
-			this.VectrexSubMenu.Text = "&Vectrex";
+			this.GenericCoreSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.GenericCoreSettingsMenuItem});
+			this.GenericCoreSubMenu.Name = "GenericCoreSubMenu";
+			this.GenericCoreSubMenu.Size = new System.Drawing.Size(56, 17);
+			this.GenericCoreSubMenu.Text = "&MSX";
 			// 
-			// VectrexsettingsToolStripMenuItem
+			// GenericCoreSettingsMenuItem
 			// 
-			this.VectrexsettingsToolStripMenuItem.Name = "VectrexsettingsToolStripMenuItem";
-			this.VectrexsettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.VectrexsettingsToolStripMenuItem.Text = "Settings...";
-			this.VectrexsettingsToolStripMenuItem.Click += new System.EventHandler(this.VectrexSettingsMenuItem_Click);
-			// 
-			// MSXSubMenu
-			// 
-			this.MSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.MSXsettingsToolStripMenuItem});
-			this.MSXSubMenu.Name = "MSXSubMenu";
-			this.MSXSubMenu.Size = new System.Drawing.Size(56, 17);
-			this.MSXSubMenu.Text = "&MSX";
-			// 
-			// MSXsettingsToolStripMenuItem
-			// 
-			this.MSXsettingsToolStripMenuItem.Name = "MSXsettingsToolStripMenuItem";
-			this.MSXsettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.MSXsettingsToolStripMenuItem.Text = "Settings...";
-			this.MSXsettingsToolStripMenuItem.Click += new System.EventHandler(this.MsxSettingsMenuItem_Click);
-			// 
-			// O2HawkSubMenu
-			// 
-			this.O2HawkSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.O2HawksettingsToolStripMenuItem});
-			this.O2HawkSubMenu.Name = "O2HawkSubMenu";
-			this.O2HawkSubMenu.Size = new System.Drawing.Size(59, 17);
-			this.O2HawkSubMenu.Text = "&Odyssey 2";
-			// 
-			// O2HawksettingsToolStripMenuItem
-			// 
-			this.O2HawksettingsToolStripMenuItem.Name = "O2HawksettingsToolStripMenuItem";
-			this.O2HawksettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.O2HawksettingsToolStripMenuItem.Text = "Settings...";
-			this.O2HawksettingsToolStripMenuItem.Click += new System.EventHandler(this.O2HawkSettingsMenuItem_Click);
+			this.GenericCoreSettingsMenuItem.Name = "GenericCoreSettingsMenuItem";
+			this.GenericCoreSettingsMenuItem.Size = new System.Drawing.Size(125, 22);
+			this.GenericCoreSettingsMenuItem.Text = "Settings...";
+			this.GenericCoreSettingsMenuItem.Click += new System.EventHandler(this.GenericCoreSettingsMenuItem_Click);
 			// 
 			// HelpSubMenu
 			// 
@@ -3812,7 +3758,6 @@
 		private System.Windows.Forms.ToolStripMenuItem SMSSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem PCEBGViewerMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ScreenshotContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AtariSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem A7800SubMenu;
 		private System.Windows.Forms.ToolStripMenuItem NESSoundChannelsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem SNESSubMenu;
@@ -3871,15 +3816,10 @@
 		private System.Windows.Forms.ToolStripMenuItem DGBHawksettingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GGLSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem GGLsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VectrexSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem VectrexsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MSXSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem MSXsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem O2HawkSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem O2HawksettingsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem GenericCoreSubMenu;
+		private System.Windows.Forms.ToolStripMenuItem GenericCoreSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GenesisSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem GenesisSettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AtariSettingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem A7800ControllerSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem A7800FilterSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem MovieSettingsMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -330,8 +330,6 @@
 			this.cpct1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.AmstradCPCDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.cpcd1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.arcadeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.settingsToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
 			this.Atari7800HawkCoreMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.MainStatusBar = new StatusStripEx();
 			this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
@@ -440,7 +438,6 @@
 			this.zXSpectrumToolStripMenuItem,
 			this.GenericCoreSubMenu,
 			this.amstradCPCToolStripMenuItem,
-			this.arcadeToolStripMenuItem,
 			this.HelpSubMenu});
 			this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
 			this.MainformMenu.Location = new System.Drawing.Point(0, 0);
@@ -2876,21 +2873,6 @@
 			this.cpcd1ToolStripMenuItem.Size = new System.Drawing.Size(102, 22);
 			this.cpcd1ToolStripMenuItem.Text = "cpcd1";
 			// 
-			// arcadeToolStripMenuItem
-			// 
-			this.arcadeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.settingsToolStripMenuItem2});
-			this.arcadeToolStripMenuItem.Name = "arcadeToolStripMenuItem";
-			this.arcadeToolStripMenuItem.Size = new System.Drawing.Size(53, 17);
-			this.arcadeToolStripMenuItem.Text = "Arcade";
-			// 
-			// settingsToolStripMenuItem2
-			// 
-			this.settingsToolStripMenuItem2.Name = "settingsToolStripMenuItem2";
-			this.settingsToolStripMenuItem2.Size = new System.Drawing.Size(125, 22);
-			this.settingsToolStripMenuItem2.Text = "Settings...";
-			this.settingsToolStripMenuItem2.Click += new System.EventHandler(this.ArcadeSettingsMenuItem_Click);
-			// 
 			// Atari7800HawkCoreMenuItem
 			// 
 			this.Atari7800HawkCoreMenuItem.Name = "Atari7800HawkCoreMenuItem";
@@ -3884,7 +3866,5 @@
 		private System.Windows.Forms.ToolStripMenuItem NDSSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem NdsSyncSettingsMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem NdsSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem arcadeToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem2;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -299,8 +299,6 @@
 			this.C64SettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.IntvSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.IntVControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.sNESToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.virtualBoyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.preferencesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
 			this.neoGeoPocketToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -440,7 +438,6 @@
 			this.AppleSubMenu,
 			this.C64SubMenu,
 			this.IntvSubMenu,
-			this.sNESToolStripMenuItem,
 			this.virtualBoyToolStripMenuItem,
 			this.neoGeoPocketToolStripMenuItem,
 			this.zXSpectrumToolStripMenuItem,
@@ -2636,21 +2633,6 @@
 			this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
 			this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
 			// 
-			// sNESToolStripMenuItem
-			// 
-			this.sNESToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.preferencesToolStripMenuItem});
-			this.sNESToolStripMenuItem.Name = "sNESToolStripMenuItem";
-			this.sNESToolStripMenuItem.Size = new System.Drawing.Size(44, 17);
-			this.sNESToolStripMenuItem.Text = "&SNES";
-			// 
-			// preferencesToolStripMenuItem
-			// 
-			this.preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
-			this.preferencesToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
-			this.preferencesToolStripMenuItem.Text = "Preferences...";
-			this.preferencesToolStripMenuItem.Click += new System.EventHandler(this.Snes9xSettingsMenuItem_Click);
-			// 
 			// virtualBoyToolStripMenuItem
 			// 
 			this.virtualBoyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3892,8 +3874,6 @@
 		private System.Windows.Forms.ToolStripMenuItem SNESControllerConfigurationMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem C64DisksSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;
-		private System.Windows.Forms.ToolStripMenuItem sNESToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem virtualBoyToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem1;
 		private System.Windows.Forms.ToolStripMenuItem neoGeoPocketToolStripMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -301,8 +301,6 @@
 			this.IntVControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.sNESToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pCFXToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.preferencesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
 			this.virtualBoyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.preferencesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
 			this.neoGeoPocketToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -443,7 +441,6 @@
 			this.C64SubMenu,
 			this.IntvSubMenu,
 			this.sNESToolStripMenuItem,
-			this.pCFXToolStripMenuItem,
 			this.virtualBoyToolStripMenuItem,
 			this.neoGeoPocketToolStripMenuItem,
 			this.zXSpectrumToolStripMenuItem,
@@ -2654,21 +2651,6 @@
 			this.preferencesToolStripMenuItem.Text = "Preferences...";
 			this.preferencesToolStripMenuItem.Click += new System.EventHandler(this.Snes9xSettingsMenuItem_Click);
 			// 
-			// pCFXToolStripMenuItem
-			// 
-			this.pCFXToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.preferencesToolStripMenuItem3});
-			this.pCFXToolStripMenuItem.Name = "pCFXToolStripMenuItem";
-			this.pCFXToolStripMenuItem.Size = new System.Drawing.Size(48, 17);
-			this.pCFXToolStripMenuItem.Text = "&PC-FX";
-			// 
-			// preferencesToolStripMenuItem3
-			// 
-			this.preferencesToolStripMenuItem3.Name = "preferencesToolStripMenuItem3";
-			this.preferencesToolStripMenuItem3.Size = new System.Drawing.Size(144, 22);
-			this.preferencesToolStripMenuItem3.Text = "Preferences...";
-			this.preferencesToolStripMenuItem3.Click += new System.EventHandler(this.PCFXSettingsMenuItem_Click);
-			// 
 			// virtualBoyToolStripMenuItem
 			// 
 			this.virtualBoyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3917,8 +3899,6 @@
 		private System.Windows.Forms.ToolStripMenuItem neoGeoPocketToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem2;
 		private System.Windows.Forms.ToolStripMenuItem Atari7800HawkCoreMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem pCFXToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem3;
 		private System.Windows.Forms.ToolStripMenuItem zXSpectrumToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumControllerConfigurationMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumCoreEmulationSettingsMenuItem;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -279,8 +279,6 @@
 			this.N64ExpansionSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.DGBsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DGBHawkSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.DGBHawksettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.GGLSubMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.GGLsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.GenesisSubMenu = new System.Windows.Forms.ToolStripMenuItem();
@@ -431,7 +429,6 @@
             this.ColecoSubMenu,
             this.N64SubMenu,
             this.DGBSubMenu,
-            this.DGBHawkSubMenu,
 			this.GGLSubMenu,
 			this.GenesisSubMenu,
 			this.wonderSwanToolStripMenuItem,
@@ -2481,21 +2478,6 @@
 			this.DGBsettingsToolStripMenuItem.Text = "Settings...";
 			this.DGBsettingsToolStripMenuItem.Click += new System.EventHandler(this.DgbSettingsMenuItem_Click);
 			// 
-			// DGBHawkSubMenu
-			// 
-			this.DGBHawkSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.DGBHawksettingsToolStripMenuItem});
-			this.DGBHawkSubMenu.Name = "DGBHawkSubMenu";
-			this.DGBHawkSubMenu.Size = new System.Drawing.Size(53, 17);
-			this.DGBHawkSubMenu.Text = "&GB Link";
-			// 
-			// DGBHawksettingsToolStripMenuItem
-			// 
-			this.DGBHawksettingsToolStripMenuItem.Name = "DGBHawksettingsToolStripMenuItem";
-			this.DGBHawksettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
-			this.DGBHawksettingsToolStripMenuItem.Text = "Settings...";
-			this.DGBHawksettingsToolStripMenuItem.Click += new System.EventHandler(this.DgbHawkSettingsMenuItem_Click);
-			// 
 			// GGLSubMenu
 			// 
 			this.GGLSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -3756,8 +3738,6 @@
 		private System.Windows.Forms.ToolStripMenuItem FdsEjectDiskMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem DGBSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem DGBsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DGBHawkSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem DGBHawksettingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GGLSubMenu;
 		private System.Windows.Forms.ToolStripMenuItem GGLsettingsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem GenericCoreSubMenu;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -2050,11 +2050,6 @@ namespace BizHawk.Client.EmuHawk
 			GenericCoreConfig.DoDialog(this, "NeoPop Settings");
 		}
 
-		private void PCFXSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "PC-FX Settings");
-		}
-
 		private void ZXSpectrumControllerConfigurationMenuItem_Click(object sender, EventArgs e)
 		{
 			if (Emulator is ZXSpectrum zxs)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1928,11 +1928,6 @@ namespace BizHawk.Client.EmuHawk
 			GenericCoreConfig.DoDialog(this, "Genesis Settings");
 		}
 
-		private void WonderSwanSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "WonderSwan Settings");
-		}
-
 		private void AppleIISettingsMenuItem_Click(object sender, EventArgs e)
 		{
 			GenericCoreConfig.DoDialog(this, "Apple II Settings");

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1913,11 +1913,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void GgSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Game Gear Settings");
-		}
-
 		private void GenericCoreSettingsMenuItem_Click(object sender, EventArgs e)
 		{
 			GenericCoreConfig.DoDialog(this, $"{Emulator.DisplayName()} Settings");

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1910,11 +1910,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void SaturnPreferencesMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Saturn Settings");
-		}
-
 		private void DgbSettingsMenuItem_Click(object sender, EventArgs e)
 		{
 			if (Emulator is GambatteLink gambatte)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1642,11 +1642,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void AtariSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Atari 2600 Settings");
-		}
-
 		private void A7800SubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			A7800ControllerSettingsMenuItem.Enabled
@@ -1938,19 +1933,9 @@ namespace BizHawk.Client.EmuHawk
 			GenericCoreConfig.DoDialog(this, "Game Gear Settings");
 		}
 
-		private void VectrexSettingsMenuItem_Click(object sender, EventArgs e)
+		private void GenericCoreSettingsMenuItem_Click(object sender, EventArgs e)
 		{
-			GenericCoreConfig.DoDialog(this, "Vectrex Settings", true, false);
-		}
-
-		private void MsxSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "MSX Settings");
-		}
-
-		private void O2HawkSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Odyssey Settings");
+			GenericCoreConfig.DoDialog(this, $"{Emulator.DisplayName()} Settings");
 		}
 
 		private void GenVdpViewerMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -2020,11 +2020,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void VirtualBoySettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "VirtualBoy Settings");
-		}
-
 		private void ZXSpectrumControllerConfigurationMenuItem_Click(object sender, EventArgs e)
 		{
 			if (Emulator is ZXSpectrum zxs)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -2302,11 +2302,6 @@ namespace BizHawk.Client.EmuHawk
 			
 		}
 
-		private void ArcadeSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Arcade Settings");
-		}
-
 		private void HelpSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			FeaturesMenuItem.Visible = VersionInfo.DeveloperBuild;

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -2035,11 +2035,6 @@ namespace BizHawk.Client.EmuHawk
 			GenericCoreConfig.DoDialog(this, "VirtualBoy Settings");
 		}
 
-		private void NeoGeoSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "NeoPop Settings");
-		}
-
 		private void ZXSpectrumControllerConfigurationMenuItem_Click(object sender, EventArgs e)
 		{
 			if (Emulator is ZXSpectrum zxs)

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1913,11 +1913,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void DgbHawkSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Gameboy Settings");
-		}
-
 		private void GgSettingsMenuItem_Click(object sender, EventArgs e)
 		{
 			GenericCoreConfig.DoDialog(this, "Game Gear Settings");

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -1796,11 +1796,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private void Snes9xSettingsMenuItem_Click(object sender, EventArgs e)
-		{
-			GenericCoreConfig.DoDialog(this, "Snes9x Settings");
-		}
-
 		private void ColecoSubMenu_DropDownOpened(object sender, EventArgs e)
 		{
 			if (Emulator is ColecoVision coleco)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1827,7 +1827,6 @@ namespace BizHawk.Client.EmuHawk
 			neoGeoPocketToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
-			arcadeToolStripMenuItem.Visible = false;
 
 			switch (Emulator.SystemId)
 			{
@@ -1941,9 +1940,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "GGL":
 					GGLSubMenu.Visible = true;
-					break;
-				case "MAME":
-					arcadeToolStripMenuItem.Visible = true;
 					break;
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1803,12 +1803,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void HandlePlatformMenus()
 		{
-			var system = "";
-			if (!Game.IsNullInstance())
-			{
-				system = Emulator.SystemId;
-			}
-
+			GenericCoreSubMenu.Visible = false;
 			TI83SubMenu.Visible = false;
 			NESSubMenu.Visible = false;
 			PCESubMenu.Visible = false;
@@ -1816,7 +1811,6 @@ namespace BizHawk.Client.EmuHawk
 			GBSubMenu.Visible = false;
 			GBASubMenu.Visible = false;
 			NDSSubMenu.Visible = false;
-			AtariSubMenu.Visible = false;
 			A7800SubMenu.Visible = false;
 			SNESSubMenu.Visible = false;
 			PSXSubMenu.Visible = false;
@@ -1837,13 +1831,16 @@ namespace BizHawk.Client.EmuHawk
 			pCFXToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
-			VectrexSubMenu.Visible = false;
-			MSXSubMenu.Visible = false;
-			O2HawkSubMenu.Visible = false;
 			arcadeToolStripMenuItem.Visible = false;
 
-			switch (system)
+			switch (Emulator.SystemId)
 			{
+				default:
+					GenericCoreSubMenu.Visible = true;
+					GenericCoreSubMenu.Text = EmulatorExtensions.DisplayName(Emulator);
+					break;
+				case "NULL":
+					break;
 				case "GEN":
 					GenesisSubMenu.Visible = true;
 					break;
@@ -1879,9 +1876,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "NDS":
 					NDSSubMenu.Visible = true;
-					break;
-				case "A26":
-					AtariSubMenu.Visible = true;
 					break;
 				case "A78":
 					A7800SubMenu.Visible = true;
@@ -1958,15 +1952,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "GGL":
 					GGLSubMenu.Visible = true;
-					break;
-				case "VEC":
-					VectrexSubMenu.Visible = true;
-					break;
-				case "MSX":
-					MSXSubMenu.Visible = true;
-					break;
-				case "O2":
-					O2HawkSubMenu.Visible = true;
 					break;
 				case "GB3x":
 				case "GB4x":
@@ -2723,7 +2708,7 @@ namespace BizHawk.Client.EmuHawk
 			CoreNameStatusBarButton.Visible = true;
 			var attributes = Emulator.Attributes();
 
-			CoreNameStatusBarButton.Text = Emulator.DisplayName();
+			CoreNameStatusBarButton.Text = CoreExtensions.CoreExtensions.DisplayName(Emulator);
 			CoreNameStatusBarButton.Image = Emulator.Icon();
 			CoreNameStatusBarButton.ToolTipText = attributes.Ported ? "(ported) " : "";
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1827,7 +1827,6 @@ namespace BizHawk.Client.EmuHawk
 			virtualBoyToolStripMenuItem.Visible = false;
 			sNESToolStripMenuItem.Visible = false;
 			neoGeoPocketToolStripMenuItem.Visible = false;
-			pCFXToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
 			arcadeToolStripMenuItem.Visible = false;
@@ -1931,9 +1930,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "NGP":
 					neoGeoPocketToolStripMenuItem.Visible = true;
-					break;
-				case "PCFX":
-					pCFXToolStripMenuItem.Visible = true;
 					break;
 				case "ZXSpectrum":
 					zXSpectrumToolStripMenuItem.Visible = true;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1817,7 +1817,6 @@ namespace BizHawk.Client.EmuHawk
 			ColecoSubMenu.Visible = false;
 			N64SubMenu.Visible = false;
 			DGBSubMenu.Visible = false;
-			DGBHawkSubMenu.Visible = false;
 			GGLSubMenu.Visible = false;
 			GenesisSubMenu.Visible = false;
 			wonderSwanToolStripMenuItem.Visible = false;
@@ -1904,7 +1903,7 @@ namespace BizHawk.Client.EmuHawk
 				case "DGB":
 					if (Emulator is GBHawkLink)
 					{
-						DGBHawkSubMenu.Visible = true;
+						DisplayDefaultCoreMenu();
 					}
 					else
 					{
@@ -1942,10 +1941,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "GGL":
 					GGLSubMenu.Visible = true;
-					break;
-				case "GB3x":
-				case "GB4x":
-					DGBHawkSubMenu.Visible = true;
 					break;
 				case "MAME":
 					arcadeToolStripMenuItem.Visible = true;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1824,7 +1824,6 @@ namespace BizHawk.Client.EmuHawk
 			C64SubMenu.Visible = false;
 			IntvSubMenu.Visible = false;
 			virtualBoyToolStripMenuItem.Visible = false;
-			neoGeoPocketToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
 
@@ -1923,9 +1922,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "VB":
 					virtualBoyToolStripMenuItem.Visible = true;
-					break;
-				case "NGP":
-					neoGeoPocketToolStripMenuItem.Visible = true;
 					break;
 				case "ZXSpectrum":
 					zXSpectrumToolStripMenuItem.Visible = true;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1818,7 +1818,6 @@ namespace BizHawk.Client.EmuHawk
 			N64SubMenu.Visible = false;
 			DGBSubMenu.Visible = false;
 			GenesisSubMenu.Visible = false;
-			wonderSwanToolStripMenuItem.Visible = false;
 			AppleSubMenu.Visible = false;
 			C64SubMenu.Visible = false;
 			IntvSubMenu.Visible = false;
@@ -1906,9 +1905,6 @@ namespace BizHawk.Client.EmuHawk
 					{
 						DGBSubMenu.Visible = true;
 					}
-					break;
-				case "WSWAN":
-					wonderSwanToolStripMenuItem.Visible = true;
 					break;
 				case "AppleII":
 					AppleSubMenu.Visible = true;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1821,7 +1821,6 @@ namespace BizHawk.Client.EmuHawk
 			AppleSubMenu.Visible = false;
 			C64SubMenu.Visible = false;
 			IntvSubMenu.Visible = false;
-			virtualBoyToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
 
@@ -1914,9 +1913,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "INTV":
 					IntvSubMenu.Visible = true;
-					break;
-				case "VB":
-					virtualBoyToolStripMenuItem.Visible = true;
 					break;
 				case "ZXSpectrum":
 					zXSpectrumToolStripMenuItem.Visible = true;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1816,7 +1816,6 @@ namespace BizHawk.Client.EmuHawk
 			PSXSubMenu.Visible = false;
 			ColecoSubMenu.Visible = false;
 			N64SubMenu.Visible = false;
-			SaturnSubMenu.Visible = false;
 			DGBSubMenu.Visible = false;
 			DGBHawkSubMenu.Visible = false;
 			GGLSubMenu.Visible = false;
@@ -1904,9 +1903,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "N64":
 					N64SubMenu.Visible = true;
-					break;
-				case "SAT":
-					SaturnSubMenu.Visible = true;
 					break;
 				case "DGB":
 					if (Emulator is GBHawkLink)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1825,7 +1825,6 @@ namespace BizHawk.Client.EmuHawk
 			C64SubMenu.Visible = false;
 			IntvSubMenu.Visible = false;
 			virtualBoyToolStripMenuItem.Visible = false;
-			sNESToolStripMenuItem.Visible = false;
 			neoGeoPocketToolStripMenuItem.Visible = false;
 			zXSpectrumToolStripMenuItem.Visible = false;
 			amstradCPCToolStripMenuItem.Visible = false;
@@ -1834,8 +1833,7 @@ namespace BizHawk.Client.EmuHawk
 			switch (Emulator.SystemId)
 			{
 				default:
-					GenericCoreSubMenu.Visible = true;
-					GenericCoreSubMenu.Text = "&" + EmulatorExtensions.DisplayName(Emulator);
+					DisplayDefaultCoreMenu();
 					break;
 				case "NULL":
 					break;
@@ -1890,7 +1888,7 @@ namespace BizHawk.Client.EmuHawk
 					}
 					else if (Emulator is Snes9x || Emulator is Faust)
 					{
-						sNESToolStripMenuItem.Visible = true;
+						DisplayDefaultCoreMenu();
 					}
 					else if (Emulator is Sameboy)
 					{
@@ -1953,6 +1951,12 @@ namespace BizHawk.Client.EmuHawk
 					arcadeToolStripMenuItem.Visible = true;
 					break;
 			}
+		}
+
+		private void DisplayDefaultCoreMenu()
+		{
+			GenericCoreSubMenu.Visible = true;
+			GenericCoreSubMenu.Text = "&" + EmulatorExtensions.DisplayName(Emulator);
 		}
 
 		private void InitControls()

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1817,7 +1817,6 @@ namespace BizHawk.Client.EmuHawk
 			ColecoSubMenu.Visible = false;
 			N64SubMenu.Visible = false;
 			DGBSubMenu.Visible = false;
-			GGLSubMenu.Visible = false;
 			GenesisSubMenu.Visible = false;
 			wonderSwanToolStripMenuItem.Visible = false;
 			AppleSubMenu.Visible = false;
@@ -1933,9 +1932,6 @@ namespace BizHawk.Client.EmuHawk
 					break;
 				case "AmstradCPC":
 					amstradCPCToolStripMenuItem.Visible = true;
-					break;
-				case "GGL":
-					GGLSubMenu.Visible = true;
 					break;
 			}
 		}

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -1836,7 +1836,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				default:
 					GenericCoreSubMenu.Visible = true;
-					GenericCoreSubMenu.Text = EmulatorExtensions.DisplayName(Emulator);
+					GenericCoreSubMenu.Text = "&" + EmulatorExtensions.DisplayName(Emulator);
 					break;
 				case "NULL":
 					break;

--- a/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolManager.cs
@@ -714,7 +714,7 @@ namespace BizHawk.Client.EmuHawk
 				return true; // no ToolAttribute on given type -> assumed all supported
 			}
 
-			var displayName = _emulator.DisplayName();
+			var displayName = CoreExtensions.CoreExtensions.DisplayName(_emulator);
 			var systemId = _emulator.SystemId;
 			return !attr.UnsupportedCores.Contains(displayName) // not unsupported
 				&& (!attr.SupportedSystems.Any() || attr.SupportedSystems.Contains(systemId)); // supported (no supported list -> assumed all supported)

--- a/src/BizHawk.Emulation.Common/CoreAttribute.cs
+++ b/src/BizHawk.Emulation.Common/CoreAttribute.cs
@@ -5,7 +5,7 @@ namespace BizHawk.Emulation.Common
 	[AttributeUsage(AttributeTargets.Class)]
 	public sealed class CoreAttribute : Attribute
 	{
-		public CoreAttribute(string name, string author, bool isPorted, bool isReleased, string portedVersion, string portedUrl, bool singleInstance)
+		public CoreAttribute(string name, string author, bool isPorted, bool isReleased, string portedVersion = null, string portedUrl = null, bool singleInstance = false, string displayName = null)
 		{
 			CoreName = name;
 			Author = author;
@@ -14,12 +14,11 @@ namespace BizHawk.Emulation.Common
 			PortedVersion = portedVersion ?? string.Empty;
 			PortedUrl = portedUrl ?? string.Empty;
 			SingleInstance = singleInstance;
+			DisplayName = displayName;
 		}
 
-		public CoreAttribute(string name, string author, bool isPorted, bool isReleased)
-			: this(name, author, isPorted, isReleased, null, null, false) {}
-
 		public string CoreName { get; }
+		public string DisplayName { get; }
 		public string Author { get; }
 		public bool Ported { get; }
 		public bool Released { get; }

--- a/src/BizHawk.Emulation.Common/Extensions.cs
+++ b/src/BizHawk.Emulation.Common/Extensions.cs
@@ -19,6 +19,17 @@ namespace BizHawk.Emulation.Common
 			return (CoreAttribute)Attribute.GetCustomAttribute(core.GetType(), typeof(CoreAttribute));
 		}
 
+		public static string DisplayName(this IEmulator core)
+		{
+			var attr = (CoreAttribute)Attribute.GetCustomAttribute(core.GetType(), typeof(CoreAttribute));
+			if (attr == null)
+			{
+				return core.GetType().Name;
+			}
+
+			return attr.DisplayName ?? attr.CoreName;
+		}
+
 		// todo: most of the special cases involving the NullEmulator should probably go away
 		public static bool IsNull(this IEmulator core)
 		{

--- a/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
+++ b/src/BizHawk.Emulation.Cores/Arcades/MAME/MAME.cs
@@ -92,7 +92,8 @@ namespace BizHawk.Emulation.Cores.Arcades.MAME
 		isReleased: false,
 		portedVersion: "0.221",
 		portedUrl: "https://github.com/mamedev/mame.git",
-		singleInstance: false)]
+		singleInstance: false,
+		displayName: "Arcade")]
 	public partial class MAME : IEmulator, IVideoProvider, ISoundProvider, ISettable<object, MAME.SyncSettings>, IStatable, IInputPollable
 	{
 		public MAME(string dir, string file, object syncSettings, out string gamename)

--- a/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
+++ b/src/BizHawk.Emulation.Cores/Computers/MSX/MSX.cs
@@ -8,7 +8,8 @@ namespace BizHawk.Emulation.Cores.Computers.MSX
 		"MSXHawk",
 		"",
 		isPorted: false,
-		isReleased: false)]
+		isReleased: false,
+		displayName: "MSX")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class MSX : IEmulator, IVideoProvider, ISoundProvider, ISaveRam, IInputPollable, IRegionable, ISettable<MSX.MSXSettings, MSX.MSXSyncSettings>
 	{

--- a/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Atari/2600/Atari2600.cs
@@ -10,7 +10,8 @@ namespace BizHawk.Emulation.Cores.Atari.Atari2600
 		"Atari2600Hawk",
 		"Micro500, Alyosha, adelikat, natt",
 		isPorted: false,
-		isReleased: true)]
+		isReleased: true,
+		displayName: "Atari 2600")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight), typeof(ISaveRam) })]
 	public partial class Atari2600 : IEmulator, IDebuggable, IInputPollable, IBoardInfo, IRomInfo,
 		IRegionable, ICreateGameDBEntries, ISettable<Atari2600.A2600Settings, Atari2600.A2600SyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.ISettable.cs
@@ -7,19 +7,16 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 {
-	public partial class VectrexHawk : IEmulator, ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>
+	public partial class VectrexHawk : IEmulator, ISettable<object, VectrexHawk.VectrexSyncSettings>
 	{
-		public VectrexSettings GetSettings()
-		{
-			return _settings.Clone();
-		}
+		public object GetSettings() => _settings;
 
 		public VectrexSyncSettings GetSyncSettings()
 		{
 			return _syncSettings.Clone();
 		}
 
-		public PutSettingsDirtyBits PutSettings(VectrexSettings o)
+		public PutSettingsDirtyBits PutSettings(object o)
 		{
 			_settings = o;
 			return PutSettingsDirtyBits.None;
@@ -32,22 +29,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 			return ret ? PutSettingsDirtyBits.RebootCore : PutSettingsDirtyBits.None;
 		}
 
-		private VectrexSettings _settings = new VectrexSettings();
+		private object _settings = new object();
 		public VectrexSyncSettings _syncSettings = new VectrexSyncSettings();
-
-		public class VectrexSettings
-		{
-
-			public VectrexSettings Clone()
-			{
-				return (VectrexSettings)MemberwiseClone();
-			}
-
-			public VectrexSettings()
-			{
-				SettingsUtil.SetDefaultValues(this);
-			}
-		}
 
 		public class VectrexSyncSettings
 		{

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
@@ -10,7 +10,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 		"VectrexHawk",
 		"",
 		isPorted: false,
-		isReleased: true)]
+		isReleased: true,
+		displayName: "Vectrex")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class VectrexHawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, 
 	ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/GCE/Vectrex/VectrexHawk.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 		displayName: "Vectrex")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class VectrexHawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, 
-	ISettable<VectrexHawk.VectrexSettings, VectrexHawk.VectrexSyncSettings>
+	ISettable<object, VectrexHawk.VectrexSyncSettings>
 	{
 		public byte[] RAM = new byte[0x400];
 
@@ -50,7 +50,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 			ppu = new PPU();
 			serialport = new SerialPort();
 
-			_settings = (VectrexSettings)settings ?? new VectrexSettings();
+			_settings = settings ?? new object();
 			_syncSettings = (VectrexSyncSettings)syncSettings ?? new VectrexSyncSettings();
 			_controllerDeck = new VectrexHawkControllerDeck(_syncSettings.Port1, _syncSettings.Port2);
 
@@ -110,7 +110,7 @@ namespace BizHawk.Emulation.Cores.Consoles.Vectrex
 			ser.Register<ISoundProvider>(audio);
 			ServiceProvider = ser;
 
-			_settings = (VectrexSettings)settings ?? new VectrexSettings();
+			_settings = settings ?? new object();
 			_syncSettings = (VectrexSyncSettings)syncSettings ?? new VectrexSyncSettings();
 
 			_tracer = new TraceBuffer { Header = cpu.TraceHeader };

--- a/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Magnavox/Odyssey2/O2Hawk.cs
@@ -10,7 +10,8 @@ namespace BizHawk.Emulation.Cores.Consoles.O2Hawk
 		"O2Hawk",
 		"",
 		isPorted: false,
-		isReleased: false)]
+		isReleased: false,
+		displayName: "Odyssey 2")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class O2Hawk : IEmulator, ISaveRam, IDebuggable, IInputPollable, IRegionable, ISettable<O2Hawk.O2Settings, O2Hawk.O2SyncSettings>, IBoardInfo
 	{

--- a/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/NEC/PCFX/Tst.cs
@@ -14,7 +14,7 @@ using BizHawk.Common;
 namespace BizHawk.Emulation.Cores.Consoles.NEC.PCFX
 {
 	[Core("T. S. T.", "Mednafen Team", true, true, "1.24.3",
-		"https://mednafen.github.io/releases/", false)]
+		"https://mednafen.github.io/releases/", false, "PC-FX")]
 	public class Tst : NymaCore
 	{
 		[CoreConstructor("PCFX")]

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink/GBHawkLink.cs
@@ -6,7 +6,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink
 		"GBHawkLink",
 		"",
 		isPorted: false,
-		isReleased: true)]
+		isReleased: true,
+		displayName: "Gameboy")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class GBHawkLink : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable, ILinkable,
 	ISettable<GBHawkLink.GBLinkSettings, GBHawkLink.GBLinkSyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink3x/GBHawkLink3x.cs
@@ -6,7 +6,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink3x
 		"GBHawkLink3x",
 		"",
 		isPorted: false,
-		isReleased: true)]
+		isReleased: true,
+		displayName: "Gameboy")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class GBHawkLink3x : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable,
 	ISettable<GBHawkLink3x.GBLink3xSettings, GBHawkLink3x.GBLink3xSyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBHawkLink4x/GBHawkLink4x.cs
@@ -6,7 +6,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBHawkLink4x
 		"GBHawkLink4x",
 		"",
 		isPorted: false,
-		isReleased: true)]
+		isReleased: true,
+		displayName: "Gameboy")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class GBHawkLink4x : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable,
 	ISettable<GBHawkLink4x.GBLink4xSettings, GBHawkLink4x.GBLink4xSyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/VB/VirtualBoyee.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace BizHawk.Emulation.Cores.Consoles.Nintendo.VB
 {
 	[Core("Virtual Boyee", "Mednafen Team", true, true, "0.9.44.1",
-		"https://mednafen.github.io/releases/", false)]
+		"https://mednafen.github.io/releases/", false, "VirtualBoy")]
 	public class VirtualBoyee : WaterboxCore, ISettable<VirtualBoyee.Settings, VirtualBoyee.SyncSettings>
 	{
 		private LibVirtualBoyee _boyee;

--- a/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/SNK/NeoGeoPort.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 namespace BizHawk.Emulation.Cores.Consoles.SNK
 {
 	[Core("NeoPop", "Thomas Klausner, Mednafen Team", true, true, "1.24.3",
-		"https://mednafen.github.io/releases/", false)]
+		"https://mednafen.github.io/releases/", false, "NeoPop")]
 	public class NeoGeoPort : NymaCore,
 		ISaveRam // NGP provides its own saveram interface
 	{

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/GGHawkLink/GGHawkLink.cs
@@ -7,7 +7,8 @@ namespace BizHawk.Emulation.Cores.Sega.GGHawkLink
 		"GGHawkLink",
 		"",
 		isPorted: false,
-		isReleased: false)]
+		isReleased: false,
+		displayName: "Game Gear")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight) })]
 	public partial class GGHawkLink : IEmulator, ISaveRam, IDebuggable, IStatable, IInputPollable, IRegionable, ILinkable,
 	ISettable<GGHawkLink.GGLinkSettings, GGHawkLink.GGLinkSyncSettings>

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/Saturn/Saturnus.cs
@@ -16,7 +16,7 @@ using System.Text;
 namespace BizHawk.Emulation.Cores.Consoles.Sega.Saturn
 {
 	[Core("Saturnus", "Mednafen Team", true, true, "1.24.3",
-		"https://mednafen.github.io/releases/", false)]
+		"https://mednafen.github.io/releases/", false, "Saturn")]
 	public class Saturnus : NymaCore, IRegionable
 	{
 		[CoreConstructor("SAT")]

--- a/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/WonderSwan/WonderSwan.cs
@@ -6,7 +6,7 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Emulation.Cores.WonderSwan
 {
-	[Core("Cygne/Mednafen", "Dox, Mednafen Team", true, true, "1.24.3", "https://mednafen.github.io/releases/", false)]
+	[Core("Cygne/Mednafen", "Dox, Mednafen Team", true, true, "1.24.3", "https://mednafen.github.io/releases/", false, "WonderSwan")]
 	[ServiceNotApplicable(new[] { typeof(IDriveLight), typeof(IRegionable) })]
 	public partial class WonderSwan : IEmulator, IVideoProvider, ISoundProvider,
 		IInputPollable, IDebuggable


### PR DESCRIPTION
Make a generic core menu that includes a Settings menu item that opens a GenericCoreConfig dialog.  Remove a lot of hardcoded menus that only did this.  Default to this, if system id is not recognized.

This reduces a lot of boilerplate code that is necessary to spin up a new core.  And we can make this more clever later on and remove other hardcoded menu items (such as dynamically adding core specific tool dialogs)