### PR TITLE
Fix handling of duplicate Ram Watches

### DIFF
--- a/src/BizHawk.Client.Common/tools/Watch/WatchList/WatchList.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/WatchList/WatchList.cs
@@ -174,17 +174,13 @@ namespace BizHawk.Client.Common
 
 		/// <summary>
 		/// Add an existing collection of <see cref="Watch"/> into the current one
-		/// <see cref="Watch"/> equality will be checked to avoid doubles
 		/// </summary>
 		/// <param name="watches"><see cref="IEnumerable{Watch}"/> of watch to merge</param>
 		public void AddRange(IEnumerable<Watch> watches)
 		{
 			Parallel.ForEach(watches, watch =>
 			{
-				if (!_watchList.Contains(watch))
-				{
-					_watchList.Add(watch);
-				}
+				_watchList.Add(watch);
 			});
 			Changes = true;
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -350,14 +350,6 @@ namespace BizHawk.Client.EmuHawk
 
 			if (SelectedWatches.Any())
 			{
-				foreach (var sw in SelectedWatches)
-				{
-					if (sw.Domain != SelectedWatches.First().Domain)
-					{
-						throw new InvalidOperationException("Can't edit multiple watches on varying memory domains");
-					}
-				}
-
 				var we = new WatchEditor
 				{
 					InitialLocation = this.ChildPointToScreen(WatchListView),

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -741,14 +741,15 @@ namespace BizHawk.Client.EmuHawk
 
 		private void RemoveWatchMenuItem_Click(object sender, EventArgs e)
 		{
-			var items = SelectedItems.ToList();
-			if (items.Any())
+			var indices = SelectedIndices
+				.OrderByDescending(i => i)
+				.ToList();
+			if (indices.Any())
 			{
-				foreach (var item in items)
+				foreach (var index in indices)
 				{
-					_watches.Remove(item);
+					_watches.RemoveAt(index);
 				}
-
 				WatchListView.RowCount = _watches.Count;
 				GeneralUpdate();
 				UpdateWatchCount();


### PR DESCRIPTION
Fixes two issues relating to duplicate Ram Watches

- Because equality is checked only by address, domain and size, if there is multiple Ram Watches present, deleting one would always delete the first one
- The "Duplicate Watch" dialog would silently discard a ram watch if its address was identical to the previous one. This changes the behaviour of AddRange of WatchList, but as the method is used only here, this should be safe.