### PR TITLE
RAM Watch Domain Fixes

### DIFF
--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatch.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatch.cs
@@ -11,6 +11,7 @@ namespace BizHawk.Client.Common.RamSearchEngine
 		long Address { get; }
 		long Previous { get; } // do not store sign extended variables in here.
 		void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian);
+		bool IsValid(MemoryDomain domain);
 	}
 
 	internal sealed class MiniByteWatch : IMiniWatch
@@ -21,14 +22,29 @@ namespace BizHawk.Client.Common.RamSearchEngine
 		public MiniByteWatch(MemoryDomain domain, long addr)
 		{
 			Address = addr;
-			_previous = domain.PeekByte(Address % domain.Size);
+			_previous = GetByte(Address, domain);
 		}
 
 		public long Previous => _previous;
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = domain.PeekByte(Address % domain.Size);
+			_previous = GetByte(Address, domain);
+		}
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < domain.Size;
+		}
+
+		public static byte GetByte(long address, MemoryDomain domain)
+		{
+			if (address >= domain.Size)
+			{
+				return 0;
+			}
+
+			return domain.PeekByte(address);
 		}
 	}
 
@@ -40,14 +56,29 @@ namespace BizHawk.Client.Common.RamSearchEngine
 		public MiniWordWatch(MemoryDomain domain, long addr, bool bigEndian)
 		{
 			Address = addr;
-			_previous = domain.PeekUshort(Address % domain.Size, bigEndian);
+			_previous = GetUshort(Address, domain, bigEndian);
 		}
 
 		public long Previous => _previous;
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = domain.PeekUshort(Address, bigEndian);
+			_previous = GetUshort(Address, domain, bigEndian);
+		}
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < (domain.Size - 1);
+		}
+
+		public static ushort GetUshort(long address, MemoryDomain domain, bool bigEndian)
+		{
+			if (address >= (domain.Size - 1))
+			{
+				return 0;
+			}
+
+			return domain.PeekUshort(address, bigEndian);
 		}
 	}
 
@@ -59,14 +90,29 @@ namespace BizHawk.Client.Common.RamSearchEngine
 		public MiniDWordWatch(MemoryDomain domain, long addr, bool bigEndian)
 		{
 			Address = addr;
-			_previous = domain.PeekUint(Address % domain.Size, bigEndian);
+			_previous = GetUint(Address, domain, bigEndian);
 		}
 
 		public long Previous => _previous;
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = domain.PeekUint(Address, bigEndian);
+			_previous = GetUint(Address, domain, bigEndian);
+		}
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < (domain.Size - 3);
+		}
+
+		public static uint GetUint(long address, MemoryDomain domain, bool bigEndian)
+		{
+			if (address >= (domain.Size - 3))
+			{
+				return 0;
+			}
+
+			return domain.PeekUint(address, bigEndian);
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatch.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatch.cs
@@ -27,19 +27,24 @@ namespace BizHawk.Client.Common.RamSearchEngine
 
 		public long Previous => _previous;
 
+		public bool IsValid(MemoryDomain domain)
+		{
+			return IsValid(Address, domain);
+		}
+
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
 			_previous = GetByte(Address, domain);
 		}
 
-		public bool IsValid(MemoryDomain domain)
+		public static bool IsValid(long address, MemoryDomain domain)
 		{
-			return Address < domain.Size;
+			return address < domain.Size;
 		}
 
 		public static byte GetByte(long address, MemoryDomain domain)
 		{
-			if (address >= domain.Size)
+			if (!IsValid(address, domain))
 			{
 				return 0;
 			}
@@ -68,12 +73,17 @@ namespace BizHawk.Client.Common.RamSearchEngine
 
 		public bool IsValid(MemoryDomain domain)
 		{
-			return Address < (domain.Size - 1);
+			return IsValid(Address, domain);
+		}
+
+		public static bool IsValid(long address, MemoryDomain domain)
+		{
+			return address < (domain.Size - 1);
 		}
 
 		public static ushort GetUshort(long address, MemoryDomain domain, bool bigEndian)
 		{
-			if (address >= (domain.Size - 1))
+			if (!IsValid(address, domain))
 			{
 				return 0;
 			}
@@ -102,12 +112,17 @@ namespace BizHawk.Client.Common.RamSearchEngine
 
 		public bool IsValid(MemoryDomain domain)
 		{
-			return Address < (domain.Size - 3);
+			return IsValid(Address, domain);
+		}
+
+		public static bool IsValid(long address, MemoryDomain domain)
+		{
+			return address < (domain.Size - 3);
 		}
 
 		public static uint GetUint(long address, MemoryDomain domain, bool bigEndian)
 		{
-			if (address >= (domain.Size - 3))
+			if (!IsValid(address, domain))
 			{
 				return 0;
 			}

--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatchDetails.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatchDetails.cs
@@ -30,7 +30,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = _prevFrame = domain.PeekByte(Address % domain.Size);
+			_previous = _prevFrame = MiniByteWatch.GetByte(Address, domain);
 		}
 
 		public long Previous => _previous;
@@ -39,7 +39,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void Update(PreviousType type, MemoryDomain domain, bool bigEndian)
 		{
-			var value = domain.PeekByte(Address % domain.Size);
+			var value = MiniByteWatch.GetByte(Address, domain);
 
 			if (value != _prevFrame)
 			{
@@ -67,6 +67,11 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 		}
 
 		public void ClearChangeCount() => ChangeCount = 0;
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < domain.Size;
+		}
 	}
 
 	internal sealed class MiniWordWatchDetailed : IMiniWatchDetails
@@ -84,7 +89,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = _prevFrame = domain.PeekUshort(Address % domain.Size, bigEndian);
+			_previous = _prevFrame = MiniWordWatch.GetUshort(Address, domain, bigEndian);
 		}
 
 		public long Previous => _previous;
@@ -93,7 +98,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void Update(PreviousType type, MemoryDomain domain, bool bigEndian)
 		{
-			var value = domain.PeekUshort(Address % domain.Size, bigEndian);
+			var value = MiniWordWatch.GetUshort(Address, domain, bigEndian);
 			if (value != Previous)
 			{
 				ChangeCount++;
@@ -120,6 +125,11 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 		}
 
 		public void ClearChangeCount() => ChangeCount = 0;
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < (domain.Size - 1);
+		}
 	}
 
 	internal sealed class MiniDWordWatchDetailed : IMiniWatchDetails
@@ -137,7 +147,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void SetPreviousToCurrent(MemoryDomain domain, bool bigEndian)
 		{
-			_previous = _prevFrame = domain.PeekUint(Address % domain.Size, bigEndian);
+			_previous = _prevFrame = MiniDWordWatch.GetUint(Address, domain, bigEndian);
 		}
 
 		public long Previous => (int)_previous;
@@ -146,7 +156,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void Update(PreviousType type, MemoryDomain domain, bool bigEndian)
 		{
-			var value = domain.PeekUint(Address % domain.Size, bigEndian);
+			var value = MiniDWordWatch.GetUint(Address, domain, bigEndian);
 			if (value != Previous)
 			{
 				ChangeCount++;
@@ -173,5 +183,10 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 		}
 
 		public void ClearChangeCount() => ChangeCount = 0;
+
+		public bool IsValid(MemoryDomain domain)
+		{
+			return Address < (domain.Size - 3);
+		}
 	}
 }

--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatchDetails.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/IMiniWatchDetails.cs
@@ -68,10 +68,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void ClearChangeCount() => ChangeCount = 0;
 
-		public bool IsValid(MemoryDomain domain)
-		{
-			return Address < domain.Size;
-		}
+		public bool IsValid(MemoryDomain domain) => MiniByteWatch.IsValid(Address, domain);
 	}
 
 	internal sealed class MiniWordWatchDetailed : IMiniWatchDetails
@@ -126,10 +123,7 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void ClearChangeCount() => ChangeCount = 0;
 
-		public bool IsValid(MemoryDomain domain)
-		{
-			return Address < (domain.Size - 1);
-		}
+		public bool IsValid(MemoryDomain domain) => MiniWordWatch.IsValid(Address, domain);
 	}
 
 	internal sealed class MiniDWordWatchDetailed : IMiniWatchDetails
@@ -184,9 +178,6 @@ namespace  BizHawk.Client.Common.RamSearchEngine
 
 		public void ClearChangeCount() => ChangeCount = 0;
 
-		public bool IsValid(MemoryDomain domain)
-		{
-			return Address < (domain.Size - 3);
-		}
+		public bool IsValid(MemoryDomain domain) => MiniDWordWatch.IsValid(Address, domain);
 	}
 }

--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/RamSearchEngine.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/RamSearchEngine.cs
@@ -248,7 +248,7 @@ namespace BizHawk.Client.Common.RamSearchEngine
 			}
 
 			var addresses = watches.Select(w => w.Address);
-			_watchList.RemoveAll(w => addresses.Contains(w.Address));
+			RemoveAddressRange(addresses);
 		}
 
 		public void RemoveRange(IEnumerable<int> indices)
@@ -260,6 +260,11 @@ namespace BizHawk.Client.Common.RamSearchEngine
 
 			var removeList = indices.Select(i => _watchList[i]); // This will fail after int.MaxValue but RAM Search fails on domains that large anyway
 			_watchList = _watchList.Except(removeList).ToList();
+		}
+
+		public void RemoveAddressRange(IEnumerable<long> addresses)
+		{
+			_watchList.RemoveAll(w => addresses.Contains(w.Address));
 		}
 
 		public void AddRange(IEnumerable<long> addresses, bool append)
@@ -313,7 +318,6 @@ namespace BizHawk.Client.Common.RamSearchEngine
 
 		public bool UndoEnabled { get; set; }
 		
-
 		public bool CanUndo => UndoEnabled && _history.CanUndo;
 
 		public bool CanRedo => UndoEnabled && _history.CanRedo;

--- a/src/BizHawk.Client.Common/tools/RamSearchEngine/RamSearchEngine.cs
+++ b/src/BizHawk.Client.Common/tools/RamSearchEngine/RamSearchEngine.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.Common.RamSearchEngine
 		}
 
 		public IEnumerable<long> OutOfRangeAddress => _watchList
-			.Where(watch => watch.Address >= Domain.Size)
+			.Where(watch => !watch.IsValid(Domain))
 			.Select(watch => watch.Address);
 
 		public void Start()
@@ -610,10 +610,10 @@ namespace BizHawk.Client.Common.RamSearchEngine
 			// do not return sign extended variables from here.
 			return _settings.Size switch
 			{
-				WatchSize.Byte => _settings.Domain.PeekByte(addr % Domain.Size),
-				WatchSize.Word => _settings.Domain.PeekUshort(addr % Domain.Size, _settings.BigEndian),
-				WatchSize.DWord => _settings.Domain.PeekUint(addr % Domain.Size, _settings.BigEndian),
-				_ => _settings.Domain.PeekByte(addr % Domain.Size)
+				WatchSize.Byte => MiniByteWatch.GetByte(addr, Domain),
+				WatchSize.Word => MiniWordWatch.GetUshort(addr, Domain, _settings.BigEndian),
+				WatchSize.DWord => MiniDWordWatch.GetUint(addr, Domain, _settings.BigEndian),
+				_ => MiniByteWatch.GetByte(addr, Domain)
 			};
 		}
 

--- a/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/ByteWatch.cs
@@ -170,6 +170,7 @@ namespace BizHawk.Client.Common
 		{
 			return Type switch
 			{
+				_ when !IsValid => "-",
 				DisplayType.Unsigned => val.ToString(),
 				DisplayType.Signed => ((sbyte) val).ToString(),
 				DisplayType.Hex => $"{val:X2}",
@@ -183,6 +184,11 @@ namespace BizHawk.Client.Common
 		/// between current value and the previous one
 		/// </summary>
 		public override string Diff => $"{_value - (short)_previous:+#;-#;0}";
+
+		/// <summary>
+		/// Returns true if the Watch is valid, false otherwise
+		/// </summary>
+		public override bool IsValid => Domain.Size == 0 || Address < Domain.Size;
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -201,6 +201,16 @@ namespace BizHawk.Client.Common
 				return _float.ToString();
 			};
 
+			string FormatBinary()
+			{
+				var str = Convert.ToString(val, 2).PadLeft(32, '0');
+				for (var i = 28; i > 0; i -= 4)
+				{
+					str = str.Insert(i, " ");
+				}
+				return str;
+			};
+
 			return Type switch
 			{
 				_ when !IsValid => "-",
@@ -210,6 +220,7 @@ namespace BizHawk.Client.Common
 				DisplayType.FixedPoint_20_12 => $"{(int)val / 4096.0:0.######}",
 				DisplayType.FixedPoint_16_16 => $"{(int)val / 65536.0:0.######}",
 				DisplayType.Float => FormatFloat(),
+				DisplayType.Binary => FormatBinary(),
 				_ => val.ToString()
 			};
 		}

--- a/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/DWordWatch.cs
@@ -194,24 +194,24 @@ namespace BizHawk.Client.Common
 		// TODO: Implements IFormattable
 		public string FormatValue(uint val)
 		{
-			switch (Type)
+			string FormatFloat()
 			{
-				default:
-				case DisplayType.Unsigned:
-					return val.ToString();
-				case DisplayType.Signed:
-					return ((int)val).ToString();
-				case DisplayType.Hex:
-					return $"{val:X8}";
-				case DisplayType.FixedPoint_20_12:
-					return $"{(int)val / 4096.0:0.######}";
-				case DisplayType.FixedPoint_16_16:
-					return $"{(int)val / 65536.0:0.######}";
-				case DisplayType.Float:
-					var bytes = BitConverter.GetBytes(val);
-					var _float = BitConverter.ToSingle(bytes, 0);
-					return _float.ToString(); // adelikat: decided that we like sci notation instead of spooky rounding
-			}
+				var bytes = BitConverter.GetBytes(val);
+				var _float = BitConverter.ToSingle(bytes, 0);
+				return _float.ToString();
+			};
+
+			return Type switch
+			{
+				_ when !IsValid => "-",
+				DisplayType.Unsigned => val.ToString(),
+				DisplayType.Signed => ((int)val).ToString(),
+				DisplayType.Hex => $"{val:X8}",
+				DisplayType.FixedPoint_20_12 => $"{(int)val / 4096.0:0.######}",
+				DisplayType.FixedPoint_16_16 => $"{(int)val / 65536.0:0.######}",
+				DisplayType.Float => FormatFloat(),
+				_ => val.ToString()
+			};
 		}
 
 		/// <summary>
@@ -219,6 +219,11 @@ namespace BizHawk.Client.Common
 		/// between current value and the previous one
 		/// </summary>
 		public override string Diff => $"{_value - (long)_previous:+#;-#;0}";
+
+		/// <summary>
+		/// Returns true if the Watch is valid, false otherwise
+		/// </summary>
+		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 3);
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/SeparatorWatch.cs
@@ -94,6 +94,11 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Ignore that stuff
 		/// </summary>
+		public override bool IsValid => true;
+
+		/// <summary>
+		/// Ignore that stuff
+		/// </summary>
 		public override string Diff => "";
 
 		/// <summary>

--- a/src/BizHawk.Client.Common/tools/Watch/Watch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/Watch.cs
@@ -267,67 +267,55 @@ namespace BizHawk.Client.Common
 
 		protected byte GetByte()
 		{
-			if (_domain.Size == 0)
+			if (!IsValid)
 			{
-				return _domain.PeekByte(Address);
+				return 0;
 			}
 
-			return _domain.PeekByte(Address % _domain.Size);
+			return _domain.PeekByte(Address);
 		}
 
 		protected ushort GetWord()
 		{
-			if (_domain.Size == 0)
+			if (!IsValid)
 			{
-				return _domain.PeekUshort(Address, BigEndian);
+				return 0;
 			}
 
-			return _domain.PeekUshort(Address % _domain.Size, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
+			return _domain.PeekUshort(Address, BigEndian);
 		}
 
 		protected uint GetDWord()
 		{
-			if (_domain.Size == 0)
+			if (!IsValid)
 			{
-				return _domain.PeekUint(Address, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
+				return 0;
 			}
 
-			return _domain.PeekUint(Address % _domain.Size, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
+			return _domain.PeekUint(Address, BigEndian);
 		}
 
 		protected void PokeByte(byte val)
 		{
-			if (_domain.Size == 0)
+			if (IsValid)
 			{
 				_domain.PokeByte(Address, val);
-			}
-			else
-			{
-				_domain.PokeByte(Address % _domain.Size, val);
 			}
 		}
 
 		protected void PokeWord(ushort val)
 		{
-			if (_domain.Size == 0)
+			if (IsValid)
 			{
-				_domain.PokeUshort(Address, val, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
-			}
-			else
-			{
-				_domain.PokeUshort(Address % _domain.Size, val, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
+				_domain.PokeUshort(Address, val, BigEndian);
 			}
 		}
 
 		protected void PokeDWord(uint val)
 		{
-			if (_domain.Size == 0)
+			if (IsValid)
 			{
-				_domain.PokeUint(Address, val, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
-			}
-			else
-			{
-				_domain.PokeUint(Address % _domain.Size, val, BigEndian); // TODO: % size still isn't correct since it could be the last byte of the domain
+				_domain.PokeUint(Address, val, BigEndian);
 			}
 		}
 
@@ -471,6 +459,11 @@ namespace BizHawk.Client.Common
 		/// Gets a string representation of the current value
 		/// </summary>
 		public abstract string ValueString { get; }
+
+		/// <summary>
+		/// Returns true if the Watch is valid, false otherwise
+		/// </summary>
+		public abstract bool IsValid { get; }
 
 		/// <summary>
 		/// Try to sets the value into the <see cref="MemoryDomain"/>

--- a/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
+++ b/src/BizHawk.Client.Common/tools/Watch/WordWatch.cs
@@ -180,6 +180,7 @@ namespace BizHawk.Client.Common
 		{
 			return Type switch
 			{
+				_ when !IsValid => "-",
 				DisplayType.Unsigned => val.ToString(),
 				DisplayType.Signed => ((short) val).ToString(), DisplayType.Hex => $"{val:X4}",
 				DisplayType.FixedPoint_12_4 => $"{val / 16.0:F4}",
@@ -198,6 +199,11 @@ namespace BizHawk.Client.Common
 		/// between current value and the previous one
 		/// </summary>
 		public override string Diff => $"{_value - (int)_previous:+#;-#;0}";
+
+		/// <summary>
+		/// Returns true if the Watch is valid, false otherwise
+		/// </summary>
+		public override bool IsValid => Domain.Size == 0 || Address < (Domain.Size - 1);
 
 		/// <summary>
 		/// Get the maximum possible value

--- a/src/BizHawk.Client.DiscoHawk/BizHawk.Client.DiscoHawk.csproj
+++ b/src/BizHawk.Client.DiscoHawk/BizHawk.Client.DiscoHawk.csproj
@@ -70,13 +70,13 @@
 		<Content Include="discohawk.ico" />
 	</ItemGroup>
 	<ItemGroup>
-		<Compile Update="About.cs" SubType="Form" />
+		<Compile Update="About.cs" />
 		<Compile Update="About.Designer.cs" DependentUpon="About.cs" />
 		<EmbeddedResource Update="About.resx" DependentUpon="About.cs" />
-		<Compile Update="ComparisonResults.cs" SubType="Form" />
+		<Compile Update="ComparisonResults.cs" />
 		<Compile Update="ComparisonResults.Designer.cs" DependentUpon="ComparisonResults.cs" />
 		<EmbeddedResource Update="ComparisonResults.resx" DependentUpon="ComparisonResults.cs" />
-		<Compile Update="MainDiscoForm.cs" SubType="Form" />
+		<Compile Update="MainDiscoForm.cs" />
 		<Compile Update="MainDiscoForm.Designer.cs" DependentUpon="MainDiscoForm.cs" />
 
 		<EmbeddedResource Remove="MainDiscoForm.resx" />

--- a/src/BizHawk.Client.DiscoHawk/BizHawk.Client.DiscoHawk.csproj
+++ b/src/BizHawk.Client.DiscoHawk/BizHawk.Client.DiscoHawk.csproj
@@ -70,13 +70,13 @@
 		<Content Include="discohawk.ico" />
 	</ItemGroup>
 	<ItemGroup>
-		<Compile Update="About.cs" />
+		<Compile Update="About.cs" SubType="Form" />
 		<Compile Update="About.Designer.cs" DependentUpon="About.cs" />
 		<EmbeddedResource Update="About.resx" DependentUpon="About.cs" />
-		<Compile Update="ComparisonResults.cs" />
+		<Compile Update="ComparisonResults.cs" SubType="Form" />
 		<Compile Update="ComparisonResults.Designer.cs" DependentUpon="ComparisonResults.cs" />
 		<EmbeddedResource Update="ComparisonResults.resx" DependentUpon="ComparisonResults.cs" />
-		<Compile Update="MainDiscoForm.cs" />
+		<Compile Update="MainDiscoForm.cs" SubType="Form" />
 		<Compile Update="MainDiscoForm.Designer.cs" DependentUpon="MainDiscoForm.cs" />
 
 		<EmbeddedResource Remove="MainDiscoForm.resx" />

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -1490,7 +1490,7 @@ namespace BizHawk.Client.EmuHawk
 		private void ErrorIconButton_Click(object sender, EventArgs e)
 		{
 			var outOfRangeAddresses = _searches.OutOfRangeAddress.ToList();
-
+			_searches.RemoveAddressRange(outOfRangeAddresses);
 			SetRemovedMessage(outOfRangeAddresses.Count);
 
 			UpdateList();

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -196,7 +196,7 @@ namespace BizHawk.Client.EmuHawk
 				var isCheat = MainForm.CheatList.IsActive(_settings.Domain, _searches[index].Address);
 				var isWeeded = Settings.PreviewMode && !_forcePreviewClear && _searches.Preview(_searches[index].Address);
 
-				if (_searches[index].Address >= _searches[index].Domain.Size)
+				if (!_searches[index].IsValid)
 				{
 					nextColor = Color.PeachPuff;
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -404,7 +404,6 @@ namespace BizHawk.Client.EmuHawk
 				var result = we.ShowHawkDialog(this);
 				if (result == DialogResult.OK)
 				{
-					Changes();
 					if (duplicate)
 					{
 						_watches.AddRange(we.Watches);
@@ -418,6 +417,7 @@ namespace BizHawk.Client.EmuHawk
 							_watches[indexes[i]] = we.Watches[i];
 						}
 					}
+					Changes();
 				}
 
 				GeneralUpdate();
@@ -587,7 +587,7 @@ namespace BizHawk.Client.EmuHawk
 				}
 			}
 
-			ErrorIconButton.Visible = _watches.Where(watch => !watch.IsSeparator).Any(watch => watch.Address >= watch.Domain.Size);
+			ErrorIconButton.Visible = _watches.Where(watch => !watch.IsSeparator).Any(watch => !watch.IsValid);
 
 			MessageLabel.Text = message;
 		}
@@ -608,7 +608,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				color = BackColor;
 			}
-			else if (_watches[index].Address >= _watches[index].Domain.Size)
+			else if (!_watches[index].IsValid)
 			{
 				color = Color.PeachPuff;
 			}
@@ -1230,7 +1230,7 @@ namespace BizHawk.Client.EmuHawk
 		private void ErrorIconButton_Click(object sender, EventArgs e)
 		{
 			var items = _watches
-				.Where(watch => watch.Address >= watch.Domain.Size)
+				.Where(watch => !watch.IsValid)
 				.ToList(); // enumerate because _watches is about to be changed
 
 			foreach (var item in items)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/WatchEditor.cs
@@ -276,19 +276,16 @@ namespace BizHawk.Client.EmuHawk
 						_ => WatchSize.Byte
 					};
 
+					var displayType = Watch.StringToDisplayType(DisplayTypeDropDown.SelectedItem.ToString());
+
 					Watches[i] = Watch.GenerateWatch(
 						Watches[i].Domain,
 						Watches.Count == 1 ? AddressBox.ToRawInt() ?? 0 : Watches[i].Address,
 						size,
-						Watches[i].Type,
+						_changedDisplayType ? displayType : Watches[i].Type,
 						Watches[i].BigEndian,
 						Watches[i].Notes);
 				}
-			}
-
-			if (_changedDisplayType)
-			{
-				Watches.ForEach(x => x.Type = Watch.StringToDisplayType(DisplayTypeDropDown.SelectedItem.ToString()));
 			}
 
 			if (BigEndianCheckBox.CheckState != CheckState.Indeterminate)


### PR DESCRIPTION
Various fixes relating to RAM Watch Domains and Display

* Added an `IsValid` property to `Watch`, which is used to determine if a RAM watch is within range
* If a RAM watch is out of range, "-" is displayed
* Pokes on out of range watches no longer do anything
* `IMiniWatch` and `IMiniWatchDetails` have been adjusted in a similar way, however, out of range behaviour cannot be tested because loading from .wchs is broken.
* Display Type Binary on 32-bit watches was the same as Unsigned, this was fixed
* Changing a watch's size to one where the display type is incompatible (e.g. 32 bit float -> 16 bit unsigned) resulted in a exception, this was also fixed

Possible extensions:

* Disable Poke dialog entirely on out of range watches
* Always filter Out of Range addresses with any Ram Search criteria.

Considering that out of range watches aren't supposed to be the normal case anyway, I wouldn't invest too much time into that, however.