### PR TITLE
Add some menu "Ex" controls

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -21,360 +21,360 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.MainformMenu = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenRomMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentRomSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.OpenAdvancedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CloseRomMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.SaveStateSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState8MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState9MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveState0MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.SaveNamedStateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadStateSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState8MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState9MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadState0MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.LoadNamedStateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator21 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoloadLastSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveSlotSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot0MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot8MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectSlot9MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PreviousSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NextSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.SaveToCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadCurrentSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveRAMSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.FlushSaveRAMMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
-			this.MovieSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ReadonlyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-			this.RecentMovieSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-			this.RecordMovieMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PlayMovieMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopMovieMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PlayFromBeginningMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ImportMoviesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMovieMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMovieAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopMovieWithoutSavingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutomaticallyBackupMoviesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FullMovieLoadstatesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieEndSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieEndFinishMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieEndRecordMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieEndStopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieEndPauseMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AVSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecordAVMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ConfigAndRecordAVMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopAVIMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
-			this.CaptureOSDMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SynclessRecordingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotClientClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
-			this.ScreenshotCaptureOSDMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EmulationSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.PauseMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RebootCoreMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.SoftResetMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HardResetMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ViewSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.WindowSizeSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.x1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.x2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.x3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.x4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.x5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.mzMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SwitchToFullscreenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.DisplayFPSMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayFrameCounterMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayLagCounterMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayInputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayRerecordCountMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplaySubtitlesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
-			this.DisplayStatusBarMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayMessagesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayLogWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ConfigSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ControllersMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HotkeysMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayConfigMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SoundMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PathsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FirmwaresMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MessagesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutofireMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RewindOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.extensionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClientOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ProfilesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-			this.SpeedSkipSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClockThrottleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AudioThrottleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VsyncThrottleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator27 = new System.Windows.Forms.ToolStripSeparator();
-			this.VsyncEnabledMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
-			this.miUnthrottled = new System.Windows.Forms.ToolStripMenuItem();
-			this.MinimizeSkippingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NeverSkipMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem17 = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip8MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Frameskip9MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
-			this.Speed50MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Speed75MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Speed100MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Speed150MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Speed200MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Speed400MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.KeyPrioritySubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.BothHkAndControllerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InputOverHkMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HkOverInputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CoresSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-			this.SaveConfigMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveConfigAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadConfigMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadConfigFromMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ToolsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ToolBoxMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-			this.RamWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RamSearchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LuaConsoleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.TAStudioMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HexEditorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.TraceLoggerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DebuggerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CodeDataLoggerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MacroToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VirtualPadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BasicBotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-			this.CheatsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.GameSharkConverterMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator29 = new System.Windows.Forms.ToolStripSeparator();
-			this.MultiDiskBundlerFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ExternalToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.dummyExternalTool = new System.Windows.Forms.ToolStripMenuItem();
-			this.BatchRunnerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NESSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NESPPUViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NESNametableViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MusicRipperMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
-			this.NesControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NESGraphicSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NESSoundChannelsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VSSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MovieSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
-			this.FDSControlsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FdsEjectDiskMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VSControlsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VSInsertCoinP1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VSInsertCoinP2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VSServiceSwitchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BarcodeReaderMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.TI83SubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.KeypadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadTIFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoloadKeypadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.paletteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.A7800SubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.A7800ControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.A7800FilterSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.GBSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.GBcoreSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator28 = new System.Windows.Forms.ToolStripSeparator();
-			this.GBGPUViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.GBPrinterViewerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PSXSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.PSXControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PSXOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PSXDiscControlsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PSXHashDiscsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SNESSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SNESControllerConfigurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
-			this.SnesGfxDebuggerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SnesOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ColecoSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ColecoControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
-			this.ColecoSkipBiosMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ColecoUseSGMMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.N64SubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.N64PluginSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.N64ControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
-			this.N64CircularAnalogRangeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MupenStyleLagMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.N64ExpansionSlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DGBSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.DGBsettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AppleSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.AppleDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator31 = new System.Windows.Forms.ToolStripSeparator();
-			this.settingsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.C64SubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.C64DisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator36 = new System.Windows.Forms.ToolStripSeparator();
-			this.C64SettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.IntvSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.IntVControllerSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.zXSpectrumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumCoreEmulationSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumControllerConfigurationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumAudioSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumNonSyncSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumPokeMemoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumMediaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumTapesSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.zxt1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.zxt2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.GenericCoreSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.HelpSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.OnlineHelpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ForumsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FeaturesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.amstradCPCToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCAudioSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCPokeMemoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCMediaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCTapesSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.cpct1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AmstradCPCDisksSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.cpcd1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Atari7800HawkCoreMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentRomSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.OpenAdvancedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloseRomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadStateSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadState0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.LoadNamedStateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutoloadLastSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSlotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectSlot9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PreviousSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NextSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveToCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadCurrentSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveRAMSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FlushSaveRAMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.MovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ReadonlyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecentMovieSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecordMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayFromBeginningMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ImportMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieWithoutSavingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutomaticallyBackupMoviesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FullMovieLoadstatesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndFinishMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndRecordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndStopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieEndPauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AVSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ConfigAndRecordAVMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotClientClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ScreenshotCaptureOSDMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EmulationSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PauseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RebootCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SoftResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HardResetMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.WindowSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.x5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.mzMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SwitchToFullscreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisplayFPSMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayFrameCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayLagCounterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayRerecordCountMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplaySubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SoundMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PathsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FirmwaresMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutofireMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RewindOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.extensionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClientOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ProfilesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SpeedSkipSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClockThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AudioThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VsyncThrottleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator27 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.VsyncEnabledMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.miUnthrottled = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MinimizeSkippingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NeverSkipMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem17 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip8MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Frameskip9MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.Speed50MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed75MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed100MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed150MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed200MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Speed400MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.KeyPrioritySubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BothHkAndControllerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InputOverHkMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HkOverInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CoresSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SaveConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveConfigAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadConfigMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadConfigFromMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ToolsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ToolBoxMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RamSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LuaConsoleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TAStudioMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HexEditorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TraceLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CodeDataLoggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MacroToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VirtualPadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BasicBotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.CheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GameSharkConverterMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator29 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.MultiDiskBundlerFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExternalToolMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.dummyExternalTool = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BatchRunnerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESPPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESNametableViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MusicRipperMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.NesControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESGraphicSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NESSoundChannelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MovieSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.FDSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FdsEjectDiskMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSInsertCoinP1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSInsertCoinP2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VSServiceSwitchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BarcodeReaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TI83SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.KeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadTIFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.AutoloadKeypadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.paletteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.A7800FilterSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBcoreSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator28 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.GBGPUViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GBPrinterViewerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXDiscControlsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PSXHashDiscsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SNESSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SNESControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.SnesGfxDebuggerMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SnesOptionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator35 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ColecoSkipBiosMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColecoUseSGMMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64PluginSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64ControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.N64CircularAnalogRangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MupenStyleLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.N64ExpansionSlotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DGBSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DGBsettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppleSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppleDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator31 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.settingsToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.C64SubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.C64DisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator36 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.C64SettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.IntvSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.IntVControllerSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zXSpectrumToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumCoreEmulationSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumControllerConfigurationMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumAudioSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumNonSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumPokeMemoryMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumMediaMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zxt1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.zxt2ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.GenericCoreSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OnlineHelpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ForumsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FeaturesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AboutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.amstradCPCToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCAudioSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCPokeMemoryToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCMediaToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCTapesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cpct1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AmstradCPCDisksSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cpcd1ToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Atari7800HawkCoreMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MainStatusBar = new StatusStripEx();
 			this.DumpStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.EmuStatus = new System.Windows.Forms.ToolStripStatusLabel();
+			this.EmuStatus = new BizHawk.WinForms.Controls.StatusLabelEx();
 			this.PlayRecordStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
 			this.PauseStatusButton = new System.Windows.Forms.ToolStripDropDownButton();
-			this.RebootStatusBarIcon = new System.Windows.Forms.ToolStripStatusLabel();
-			this.AVIStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.LedLightStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.SaveSlotsStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot1StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot2StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot3StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot4StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot5StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot6StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot7StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot8StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot9StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.Slot0StatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.CheatStatusButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.KeyPriorityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.CoreNameStatusBarButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.ProfileFirstBootLabel = new System.Windows.Forms.ToolStripStatusLabel();
-			this.LinkConnectStatusBarButton = new System.Windows.Forms.ToolStripStatusLabel();
-			this.UpdateNotification = new System.Windows.Forms.ToolStripStatusLabel();
+			this.RebootStatusBarIcon = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.AVIStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.LedLightStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.SaveSlotsStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot1StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot2StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot3StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot4StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot5StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot6StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot7StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot8StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot9StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.Slot0StatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.CheatStatusButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.KeyPriorityStatusLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.CoreNameStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.ProfileFirstBootLabel = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.LinkConnectStatusBarButton = new BizHawk.WinForms.Controls.StatusLabelEx();
+			this.UpdateNotification = new BizHawk.WinForms.Controls.StatusLabelEx();
 			this.MainFormContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.OpenRomContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadLastRomContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopAVContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ContextSeparator_AfterROM = new System.Windows.Forms.ToolStripSeparator();
-			this.RecordMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PlayMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RestartMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadLastMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BackupMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StopNoSaveContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ViewSubtitlesContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddSubtitleContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ViewCommentsContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMovieContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMovieAsContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ContextSeparator_AfterMovie = new System.Windows.Forms.ToolStripSeparator();
-			this.UndoSavestateContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ContextSeparator_AfterUndo = new System.Windows.Forms.ToolStripSeparator();
-			this.ConfigContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem10 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem11 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem12 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem13 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem14 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem15 = new System.Windows.Forms.ToolStripMenuItem();
-			this.customizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator30 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripMenuItem66 = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripMenuItem67 = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CloseRomContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearSRAMContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ShowMenuContextMenuSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.ShowMenuContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.OpenRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadLastRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopAVContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterROM = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.RecordMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PlayMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RestartMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadLastMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BackupMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StopNoSaveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewSubtitlesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddSubtitleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewCommentsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMovieAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterMovie = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.UndoSavestateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ContextSeparator_AfterUndo = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ConfigContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem6 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem7 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem8 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem9 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem10 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem11 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem12 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem13 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem14 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem15 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.customizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator30 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripMenuItem66 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripMenuItem67 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloseRomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearSRAMContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
-			this.NDSSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NdsSyncSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NdsSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.NDSSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NdsSyncSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NdsSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MainformMenu.SuspendLayout();
 			this.MainStatusBar.SuspendLayout();
 			this.MainFormContextMenu.SuspendLayout();
@@ -430,15 +430,11 @@ namespace BizHawk.Client.EmuHawk
 			this.ScreenshotSubMenu,
 			this.toolStripSeparator4,
 			this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 17);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// OpenRomMenuItem
 			// 
-			this.OpenRomMenuItem.Name = "OpenRomMenuItem";
-			this.OpenRomMenuItem.Size = new System.Drawing.Size(151, 22);
 			this.OpenRomMenuItem.Text = "&Open ROM";
 			this.OpenRomMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
 			// 
@@ -446,34 +442,18 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator3});
-			this.RecentRomSubMenu.Name = "RecentRomSubMenu";
-			this.RecentRomSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.RecentRomSubMenu.Text = "&Recent ROM";
 			this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
 			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(57, 6);
-			// 
 			// OpenAdvancedMenuItem
 			// 
-			this.OpenAdvancedMenuItem.Name = "OpenAdvancedMenuItem";
-			this.OpenAdvancedMenuItem.Size = new System.Drawing.Size(151, 22);
 			this.OpenAdvancedMenuItem.Text = "Open Ad&vanced";
 			this.OpenAdvancedMenuItem.Click += new System.EventHandler(this.OpenAdvancedMenuItem_Click);
 			// 
 			// CloseRomMenuItem
 			// 
-			this.CloseRomMenuItem.Name = "CloseRomMenuItem";
-			this.CloseRomMenuItem.Size = new System.Drawing.Size(151, 22);
 			this.CloseRomMenuItem.Text = "&Close ROM";
 			this.CloseRomMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(148, 6);
 			// 
 			// SaveStateSubMenu
 			// 
@@ -490,90 +470,61 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveState0MenuItem,
 			this.toolStripSeparator6,
 			this.SaveNamedStateMenuItem});
-			this.SaveStateSubMenu.Name = "SaveStateSubMenu";
-			this.SaveStateSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.SaveStateSubMenu.Text = "&Save State";
 			this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
 			// 
 			// SaveState1MenuItem
 			// 
-			this.SaveState1MenuItem.Name = "SaveState1MenuItem";
-			this.SaveState1MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState1MenuItem.Text = "1";
 			this.SaveState1MenuItem.Click += new System.EventHandler(this.Savestate1MenuItem_Click);
 			// 
 			// SaveState2MenuItem
 			// 
-			this.SaveState2MenuItem.Name = "SaveState2MenuItem";
-			this.SaveState2MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState2MenuItem.Text = "2";
 			this.SaveState2MenuItem.Click += new System.EventHandler(this.Savestate2MenuItem_Click);
 			// 
 			// SaveState3MenuItem
 			// 
-			this.SaveState3MenuItem.Name = "SaveState3MenuItem";
-			this.SaveState3MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState3MenuItem.Text = "3";
 			this.SaveState3MenuItem.Click += new System.EventHandler(this.Savestate3MenuItem_Click);
 			// 
 			// SaveState4MenuItem
 			// 
-			this.SaveState4MenuItem.Name = "SaveState4MenuItem";
-			this.SaveState4MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState4MenuItem.Text = "4";
 			this.SaveState4MenuItem.Click += new System.EventHandler(this.Savestate4MenuItem_Click);
 			// 
 			// SaveState5MenuItem
 			// 
-			this.SaveState5MenuItem.Name = "SaveState5MenuItem";
-			this.SaveState5MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState5MenuItem.Text = "5";
 			this.SaveState5MenuItem.Click += new System.EventHandler(this.Savestate5MenuItem_Click);
 			// 
 			// SaveState6MenuItem
 			// 
-			this.SaveState6MenuItem.Name = "SaveState6MenuItem";
-			this.SaveState6MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState6MenuItem.Text = "6";
 			this.SaveState6MenuItem.Click += new System.EventHandler(this.Savestate6MenuItem_Click);
 			// 
 			// SaveState7MenuItem
 			// 
-			this.SaveState7MenuItem.Name = "SaveState7MenuItem";
-			this.SaveState7MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState7MenuItem.Text = "7";
 			this.SaveState7MenuItem.Click += new System.EventHandler(this.Savestate7MenuItem_Click);
 			// 
 			// SaveState8MenuItem
 			// 
-			this.SaveState8MenuItem.Name = "SaveState8MenuItem";
-			this.SaveState8MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState8MenuItem.Text = "8";
 			this.SaveState8MenuItem.Click += new System.EventHandler(this.Savestate8MenuItem_Click);
 			// 
 			// SaveState9MenuItem
 			// 
-			this.SaveState9MenuItem.Name = "SaveState9MenuItem";
-			this.SaveState9MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState9MenuItem.Text = "9";
 			this.SaveState9MenuItem.Click += new System.EventHandler(this.Savestate9MenuItem_Click);
 			// 
 			// SaveState0MenuItem
 			// 
-			this.SaveState0MenuItem.Name = "SaveState0MenuItem";
-			this.SaveState0MenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveState0MenuItem.Text = "0";
 			this.SaveState0MenuItem.Click += new System.EventHandler(this.Savestate0MenuItem_Click);
 			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(172, 6);
-			// 
 			// SaveNamedStateMenuItem
 			// 
-			this.SaveNamedStateMenuItem.Name = "SaveNamedStateMenuItem";
-			this.SaveNamedStateMenuItem.Size = new System.Drawing.Size(175, 22);
 			this.SaveNamedStateMenuItem.Text = "Save Named State...";
 			this.SaveNamedStateMenuItem.Click += new System.EventHandler(this.SaveNamedStateMenuItem_Click);
 			// 
@@ -594,102 +545,66 @@ namespace BizHawk.Client.EmuHawk
 			this.LoadNamedStateMenuItem,
 			this.toolStripSeparator21,
 			this.AutoloadLastSlotMenuItem});
-			this.LoadStateSubMenu.Name = "LoadStateSubMenu";
-			this.LoadStateSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.LoadStateSubMenu.Text = "&Load State";
 			this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
 			// 
 			// LoadState1MenuItem
 			// 
-			this.LoadState1MenuItem.Name = "LoadState1MenuItem";
-			this.LoadState1MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState1MenuItem.Text = "1";
 			this.LoadState1MenuItem.Click += new System.EventHandler(this.Loadstate1MenuItem_Click);
 			// 
 			// LoadState2MenuItem
 			// 
-			this.LoadState2MenuItem.Name = "LoadState2MenuItem";
-			this.LoadState2MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState2MenuItem.Text = "2";
 			this.LoadState2MenuItem.Click += new System.EventHandler(this.Loadstate2MenuItem_Click);
 			// 
 			// LoadState3MenuItem
 			// 
-			this.LoadState3MenuItem.Name = "LoadState3MenuItem";
-			this.LoadState3MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState3MenuItem.Text = "3";
 			this.LoadState3MenuItem.Click += new System.EventHandler(this.Loadstate3MenuItem_Click);
 			// 
 			// LoadState4MenuItem
 			// 
-			this.LoadState4MenuItem.Name = "LoadState4MenuItem";
-			this.LoadState4MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState4MenuItem.Text = "4";
 			this.LoadState4MenuItem.Click += new System.EventHandler(this.Loadstate4MenuItem_Click);
 			// 
 			// LoadState5MenuItem
 			// 
-			this.LoadState5MenuItem.Name = "LoadState5MenuItem";
-			this.LoadState5MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState5MenuItem.Text = "5";
 			this.LoadState5MenuItem.Click += new System.EventHandler(this.Loadstate5MenuItem_Click);
 			// 
 			// LoadState6MenuItem
 			// 
-			this.LoadState6MenuItem.Name = "LoadState6MenuItem";
-			this.LoadState6MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState6MenuItem.Text = "6";
 			this.LoadState6MenuItem.Click += new System.EventHandler(this.Loadstate6MenuItem_Click);
 			// 
 			// LoadState7MenuItem
 			// 
-			this.LoadState7MenuItem.Name = "LoadState7MenuItem";
-			this.LoadState7MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState7MenuItem.Text = "7";
 			this.LoadState7MenuItem.Click += new System.EventHandler(this.Loadstate7MenuItem_Click);
 			// 
 			// LoadState8MenuItem
 			// 
-			this.LoadState8MenuItem.Name = "LoadState8MenuItem";
-			this.LoadState8MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState8MenuItem.Text = "8";
 			this.LoadState8MenuItem.Click += new System.EventHandler(this.Loadstate8MenuItem_Click);
 			// 
 			// LoadState9MenuItem
 			// 
-			this.LoadState9MenuItem.Name = "LoadState9MenuItem";
-			this.LoadState9MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState9MenuItem.Text = "9";
 			this.LoadState9MenuItem.Click += new System.EventHandler(this.Loadstate9MenuItem_Click);
 			// 
 			// LoadState0MenuItem
 			// 
-			this.LoadState0MenuItem.Name = "LoadState0MenuItem";
-			this.LoadState0MenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadState0MenuItem.Text = "0";
 			this.LoadState0MenuItem.Click += new System.EventHandler(this.Loadstate0MenuItem_Click);
 			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(171, 6);
-			// 
 			// LoadNamedStateMenuItem
 			// 
-			this.LoadNamedStateMenuItem.Name = "LoadNamedStateMenuItem";
-			this.LoadNamedStateMenuItem.Size = new System.Drawing.Size(174, 22);
 			this.LoadNamedStateMenuItem.Text = "Load Named State...";
 			this.LoadNamedStateMenuItem.Click += new System.EventHandler(this.LoadNamedStateMenuItem_Click);
 			// 
-			// toolStripSeparator21
-			// 
-			this.toolStripSeparator21.Name = "toolStripSeparator21";
-			this.toolStripSeparator21.Size = new System.Drawing.Size(171, 6);
-			// 
 			// AutoloadLastSlotMenuItem
 			// 
-			this.AutoloadLastSlotMenuItem.Name = "AutoloadLastSlotMenuItem";
-			this.AutoloadLastSlotMenuItem.Size = new System.Drawing.Size(174, 22);
 			this.AutoloadLastSlotMenuItem.Text = "Autoload last Slot";
 			this.AutoloadLastSlotMenuItem.Click += new System.EventHandler(this.AutoloadLastSlotMenuItem_Click);
 			// 
@@ -711,111 +626,76 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator5,
 			this.SaveToCurrentSlotMenuItem,
 			this.LoadCurrentSlotMenuItem});
-			this.SaveSlotSubMenu.Name = "SaveSlotSubMenu";
-			this.SaveSlotSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.SaveSlotSubMenu.Text = "Save S&lot";
 			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
 			// 
 			// SelectSlot0MenuItem
 			// 
-			this.SelectSlot0MenuItem.Name = "SelectSlot0MenuItem";
-			this.SelectSlot0MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot0MenuItem.Text = "Select Slot 0";
 			this.SelectSlot0MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot1MenuItem
 			// 
-			this.SelectSlot1MenuItem.Name = "SelectSlot1MenuItem";
-			this.SelectSlot1MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot1MenuItem.Text = "Select Slot 1";
 			this.SelectSlot1MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot2MenuItem
 			// 
-			this.SelectSlot2MenuItem.Name = "SelectSlot2MenuItem";
-			this.SelectSlot2MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot2MenuItem.Text = "Select Slot 2";
 			this.SelectSlot2MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot3MenuItem
 			// 
-			this.SelectSlot3MenuItem.Name = "SelectSlot3MenuItem";
-			this.SelectSlot3MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot3MenuItem.Text = "Select Slot 3";
 			this.SelectSlot3MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot4MenuItem
 			// 
-			this.SelectSlot4MenuItem.Name = "SelectSlot4MenuItem";
-			this.SelectSlot4MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot4MenuItem.Text = "Select Slot 4";
 			this.SelectSlot4MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot5MenuItem
 			// 
-			this.SelectSlot5MenuItem.Name = "SelectSlot5MenuItem";
-			this.SelectSlot5MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot5MenuItem.Text = "Select Slot 5";
 			this.SelectSlot5MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot6MenuItem
 			// 
-			this.SelectSlot6MenuItem.Name = "SelectSlot6MenuItem";
-			this.SelectSlot6MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot6MenuItem.Text = "Select Slot 6";
 			this.SelectSlot6MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot7MenuItem
 			// 
-			this.SelectSlot7MenuItem.Name = "SelectSlot7MenuItem";
-			this.SelectSlot7MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot7MenuItem.Text = "Select Slot 7";
 			this.SelectSlot7MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot8MenuItem
 			// 
-			this.SelectSlot8MenuItem.Name = "SelectSlot8MenuItem";
-			this.SelectSlot8MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot8MenuItem.Text = "Select Slot 8";
 			this.SelectSlot8MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// SelectSlot9MenuItem
 			// 
-			this.SelectSlot9MenuItem.Name = "SelectSlot9MenuItem";
-			this.SelectSlot9MenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SelectSlot9MenuItem.Text = "Select Slot 9";
 			this.SelectSlot9MenuItem.Click += new System.EventHandler(this.SelectSlotMenuItems_Click);
 			// 
 			// PreviousSlotMenuItem
 			// 
-			this.PreviousSlotMenuItem.Name = "PreviousSlotMenuItem";
-			this.PreviousSlotMenuItem.Size = new System.Drawing.Size(172, 22);
 			this.PreviousSlotMenuItem.Text = "Previous Slot";
 			this.PreviousSlotMenuItem.Click += new System.EventHandler(this.PreviousSlotMenuItem_Click);
 			// 
 			// NextSlotMenuItem
 			// 
-			this.NextSlotMenuItem.Name = "NextSlotMenuItem";
-			this.NextSlotMenuItem.Size = new System.Drawing.Size(172, 22);
 			this.NextSlotMenuItem.Text = "Next Slot";
 			this.NextSlotMenuItem.Click += new System.EventHandler(this.NextSlotMenuItem_Click);
 			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(169, 6);
-			// 
 			// SaveToCurrentSlotMenuItem
 			// 
-			this.SaveToCurrentSlotMenuItem.Name = "SaveToCurrentSlotMenuItem";
-			this.SaveToCurrentSlotMenuItem.Size = new System.Drawing.Size(172, 22);
 			this.SaveToCurrentSlotMenuItem.Text = "Save to Current Slot";
 			this.SaveToCurrentSlotMenuItem.Click += new System.EventHandler(this.SaveToCurrentSlotMenuItem_Click);
 			// 
 			// LoadCurrentSlotMenuItem
 			// 
-			this.LoadCurrentSlotMenuItem.Name = "LoadCurrentSlotMenuItem";
-			this.LoadCurrentSlotMenuItem.Size = new System.Drawing.Size(172, 22);
 			this.LoadCurrentSlotMenuItem.Text = "Load Current Slot";
 			this.LoadCurrentSlotMenuItem.Click += new System.EventHandler(this.LoadCurrentSlotMenuItem_Click);
 			// 
@@ -823,22 +703,13 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.FlushSaveRAMMenuItem});
-			this.SaveRAMSubMenu.Name = "SaveRAMSubMenu";
-			this.SaveRAMSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.SaveRAMSubMenu.Text = "Save &RAM";
 			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
 			// 
 			// FlushSaveRAMMenuItem
 			// 
-			this.FlushSaveRAMMenuItem.Name = "FlushSaveRAMMenuItem";
-			this.FlushSaveRAMMenuItem.Size = new System.Drawing.Size(150, 22);
 			this.FlushSaveRAMMenuItem.Text = "&Flush Save Ram";
 			this.FlushSaveRAMMenuItem.Click += new System.EventHandler(this.FlushSaveRAMMenuItem_Click);
-			// 
-			// toolStripMenuItem2
-			// 
-			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-			this.toolStripMenuItem2.Size = new System.Drawing.Size(148, 6);
 			// 
 			// MovieSubMenu
 			// 
@@ -858,109 +729,68 @@ namespace BizHawk.Client.EmuHawk
 			this.AutomaticallyBackupMoviesMenuItem,
 			this.FullMovieLoadstatesMenuItem,
 			this.MovieEndSubMenu});
-			this.MovieSubMenu.Name = "MovieSubMenu";
-			this.MovieSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.MovieSubMenu.Text = "&Movie";
 			this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
 			// 
 			// ReadonlyMenuItem
 			// 
-			this.ReadonlyMenuItem.Name = "ReadonlyMenuItem";
-			this.ReadonlyMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.ReadonlyMenuItem.Text = "Read-only";
 			this.ReadonlyMenuItem.Click += new System.EventHandler(this.ReadonlyMenuItem_Click);
-			// 
-			// toolStripSeparator15
-			// 
-			this.toolStripSeparator15.Name = "toolStripSeparator15";
-			this.toolStripSeparator15.Size = new System.Drawing.Size(208, 6);
 			// 
 			// RecentMovieSubMenu
 			// 
 			this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator16});
-			this.RecentMovieSubMenu.Name = "RecentMovieSubMenu";
-			this.RecentMovieSubMenu.Size = new System.Drawing.Size(211, 22);
 			this.RecentMovieSubMenu.Text = "Recent";
 			this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator16
-			// 
-			this.toolStripSeparator16.Name = "toolStripSeparator16";
-			this.toolStripSeparator16.Size = new System.Drawing.Size(57, 6);
-			// 
 			// RecordMovieMenuItem
 			// 
-			this.RecordMovieMenuItem.Name = "RecordMovieMenuItem";
-			this.RecordMovieMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.RecordMovieMenuItem.Text = "&Record Movie...";
 			this.RecordMovieMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
 			// 
 			// PlayMovieMenuItem
 			// 
-			this.PlayMovieMenuItem.Name = "PlayMovieMenuItem";
-			this.PlayMovieMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.PlayMovieMenuItem.Text = "&Play Movie...";
 			this.PlayMovieMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
 			// 
 			// StopMovieMenuItem
 			// 
-			this.StopMovieMenuItem.Name = "StopMovieMenuItem";
-			this.StopMovieMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.StopMovieMenuItem.Text = "Stop Movie";
 			this.StopMovieMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
 			// 
 			// PlayFromBeginningMenuItem
 			// 
-			this.PlayFromBeginningMenuItem.Name = "PlayFromBeginningMenuItem";
-			this.PlayFromBeginningMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.PlayFromBeginningMenuItem.Text = "Play from Beginning";
 			this.PlayFromBeginningMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
 			// 
 			// ImportMoviesMenuItem
 			// 
-			this.ImportMoviesMenuItem.Name = "ImportMoviesMenuItem";
-			this.ImportMoviesMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.ImportMoviesMenuItem.Text = "Import Movies...";
 			this.ImportMoviesMenuItem.Click += new System.EventHandler(this.ImportMovieMenuItem_Click);
 			// 
 			// SaveMovieMenuItem
 			// 
-			this.SaveMovieMenuItem.Name = "SaveMovieMenuItem";
-			this.SaveMovieMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.SaveMovieMenuItem.Text = "&Save Movie";
 			this.SaveMovieMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
 			// 
 			// SaveMovieAsMenuItem
 			// 
-			this.SaveMovieAsMenuItem.Name = "SaveMovieAsMenuItem";
-			this.SaveMovieAsMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.SaveMovieAsMenuItem.Text = "Save Movie As...";
 			this.SaveMovieAsMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
 			// 
 			// StopMovieWithoutSavingMenuItem
 			// 
-			this.StopMovieWithoutSavingMenuItem.Name = "StopMovieWithoutSavingMenuItem";
-			this.StopMovieWithoutSavingMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.StopMovieWithoutSavingMenuItem.Text = "Stop Movie without Saving";
 			this.StopMovieWithoutSavingMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
 			// 
-			// toolStripSeparator14
-			// 
-			this.toolStripSeparator14.Name = "toolStripSeparator14";
-			this.toolStripSeparator14.Size = new System.Drawing.Size(208, 6);
-			// 
 			// AutomaticallyBackupMoviesMenuItem
 			// 
-			this.AutomaticallyBackupMoviesMenuItem.Name = "AutomaticallyBackupMoviesMenuItem";
-			this.AutomaticallyBackupMoviesMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.AutomaticallyBackupMoviesMenuItem.Text = "Automatically Backup Movies";
 			this.AutomaticallyBackupMoviesMenuItem.Click += new System.EventHandler(this.AutomaticMovieBackupMenuItem_Click);
 			// 
 			// FullMovieLoadstatesMenuItem
 			// 
-			this.FullMovieLoadstatesMenuItem.Name = "FullMovieLoadstatesMenuItem";
-			this.FullMovieLoadstatesMenuItem.Size = new System.Drawing.Size(211, 22);
 			this.FullMovieLoadstatesMenuItem.Text = "Full Movie Loadstates";
 			this.FullMovieLoadstatesMenuItem.Click += new System.EventHandler(this.FullMovieLoadstatesMenuItem_Click);
 			// 
@@ -971,36 +801,26 @@ namespace BizHawk.Client.EmuHawk
 			this.MovieEndRecordMenuItem,
 			this.MovieEndStopMenuItem,
 			this.MovieEndPauseMenuItem});
-			this.MovieEndSubMenu.Name = "MovieEndSubMenu";
-			this.MovieEndSubMenu.Size = new System.Drawing.Size(211, 22);
 			this.MovieEndSubMenu.Text = "On Movie End";
 			this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
 			// 
 			// MovieEndFinishMenuItem
 			// 
-			this.MovieEndFinishMenuItem.Name = "MovieEndFinishMenuItem";
-			this.MovieEndFinishMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.MovieEndFinishMenuItem.Text = "Switch to Finished";
 			this.MovieEndFinishMenuItem.Click += new System.EventHandler(this.MovieEndFinishMenuItem_Click);
 			// 
 			// MovieEndRecordMenuItem
 			// 
-			this.MovieEndRecordMenuItem.Name = "MovieEndRecordMenuItem";
-			this.MovieEndRecordMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.MovieEndRecordMenuItem.Text = "Switch To Record";
 			this.MovieEndRecordMenuItem.Click += new System.EventHandler(this.MovieEndRecordMenuItem_Click);
 			// 
 			// MovieEndStopMenuItem
 			// 
-			this.MovieEndStopMenuItem.Name = "MovieEndStopMenuItem";
-			this.MovieEndStopMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.MovieEndStopMenuItem.Text = "Stop";
 			this.MovieEndStopMenuItem.Click += new System.EventHandler(this.MovieEndStopMenuItem_Click);
 			// 
 			// MovieEndPauseMenuItem
 			// 
-			this.MovieEndPauseMenuItem.Name = "MovieEndPauseMenuItem";
-			this.MovieEndPauseMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.MovieEndPauseMenuItem.Text = "Pause";
 			this.MovieEndPauseMenuItem.Click += new System.EventHandler(this.MovieEndPauseMenuItem_Click);
 			// 
@@ -1013,48 +833,31 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator19,
 			this.CaptureOSDMenuItem,
 			this.SynclessRecordingMenuItem});
-			this.AVSubMenu.Name = "AVSubMenu";
-			this.AVSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.AVSubMenu.Text = "&AVI/WAV";
 			this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
 			// 
 			// RecordAVMenuItem
 			// 
-			this.RecordAVMenuItem.Name = "RecordAVMenuItem";
-			this.RecordAVMenuItem.Size = new System.Drawing.Size(210, 22);
 			this.RecordAVMenuItem.Text = "&Record AVI/WAV";
 			this.RecordAVMenuItem.Click += new System.EventHandler(this.RecordAVMenuItem_Click);
 			// 
 			// ConfigAndRecordAVMenuItem
 			// 
-			this.ConfigAndRecordAVMenuItem.Name = "ConfigAndRecordAVMenuItem";
-			this.ConfigAndRecordAVMenuItem.Size = new System.Drawing.Size(210, 22);
 			this.ConfigAndRecordAVMenuItem.Text = "Config and Record AVI/WAV";
 			this.ConfigAndRecordAVMenuItem.Click += new System.EventHandler(this.ConfigAndRecordAVMenuItem_Click);
 			// 
 			// StopAVIMenuItem
 			// 
-			this.StopAVIMenuItem.Name = "StopAVIMenuItem";
-			this.StopAVIMenuItem.Size = new System.Drawing.Size(210, 22);
 			this.StopAVIMenuItem.Text = "&Stop AVI/WAV";
 			this.StopAVIMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
 			// 
-			// toolStripSeparator19
-			// 
-			this.toolStripSeparator19.Name = "toolStripSeparator19";
-			this.toolStripSeparator19.Size = new System.Drawing.Size(207, 6);
-			// 
 			// CaptureOSDMenuItem
 			// 
-			this.CaptureOSDMenuItem.Name = "CaptureOSDMenuItem";
-			this.CaptureOSDMenuItem.Size = new System.Drawing.Size(210, 22);
 			this.CaptureOSDMenuItem.Text = "Capture OSD";
 			this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
 			// 
 			// SynclessRecordingMenuItem
 			// 
-			this.SynclessRecordingMenuItem.Name = "SynclessRecordingMenuItem";
-			this.SynclessRecordingMenuItem.Size = new System.Drawing.Size(210, 22);
 			this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
 			this.SynclessRecordingMenuItem.Click += new System.EventHandler(this.SynclessRecordingMenuItem_Click);
 			// 
@@ -1067,61 +870,37 @@ namespace BizHawk.Client.EmuHawk
 			this.ScreenshotClientClipboardMenuItem,
 			this.toolStripSeparator20,
 			this.ScreenshotCaptureOSDMenuItem1});
-			this.ScreenshotSubMenu.Name = "ScreenshotSubMenu";
-			this.ScreenshotSubMenu.Size = new System.Drawing.Size(151, 22);
 			this.ScreenshotSubMenu.Text = "Scree&nshot";
 			this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
 			// 
 			// ScreenshotMenuItem
 			// 
-			this.ScreenshotMenuItem.Name = "ScreenshotMenuItem";
-			this.ScreenshotMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.ScreenshotMenuItem.Text = "Screenshot";
 			this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
 			// 
 			// ScreenshotAsMenuItem
 			// 
-			this.ScreenshotAsMenuItem.Name = "ScreenshotAsMenuItem";
-			this.ScreenshotAsMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.ScreenshotAsMenuItem.Text = "Screenshot As...";
 			this.ScreenshotAsMenuItem.Click += new System.EventHandler(this.ScreenshotAsMenuItem_Click);
 			// 
 			// ScreenshotClipboardMenuItem
 			// 
-			this.ScreenshotClipboardMenuItem.Name = "ScreenshotClipboardMenuItem";
-			this.ScreenshotClipboardMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.ScreenshotClipboardMenuItem.Text = "Screenshot (raw) -> Clipboard";
 			this.ScreenshotClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClipboardMenuItem_Click);
 			// 
 			// ScreenshotClientClipboardMenuItem
 			// 
-			this.ScreenshotClientClipboardMenuItem.Name = "ScreenshotClientClipboardMenuItem";
-			this.ScreenshotClientClipboardMenuItem.Size = new System.Drawing.Size(227, 22);
 			this.ScreenshotClientClipboardMenuItem.Text = "Screenshot (client) -> Clipboard";
 			this.ScreenshotClientClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotClientClipboardMenuItem_Click);
 			// 
-			// toolStripSeparator20
-			// 
-			this.toolStripSeparator20.Name = "toolStripSeparator20";
-			this.toolStripSeparator20.Size = new System.Drawing.Size(224, 6);
-			// 
 			// ScreenshotCaptureOSDMenuItem1
 			// 
-			this.ScreenshotCaptureOSDMenuItem1.Name = "ScreenshotCaptureOSDMenuItem1";
-			this.ScreenshotCaptureOSDMenuItem1.Size = new System.Drawing.Size(227, 22);
 			this.ScreenshotCaptureOSDMenuItem1.Text = "Capture OSD";
 			this.ScreenshotCaptureOSDMenuItem1.Click += new System.EventHandler(this.ScreenshotCaptureOSDMenuItem_Click);
 			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(148, 6);
-			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(151, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -1133,41 +912,26 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator1,
 			this.SoftResetMenuItem,
 			this.HardResetMenuItem});
-			this.EmulationSubMenu.Name = "EmulationSubMenu";
-			this.EmulationSubMenu.Size = new System.Drawing.Size(65, 17);
 			this.EmulationSubMenu.Text = "&Emulation";
 			this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
 			// 
 			// PauseMenuItem
 			// 
-			this.PauseMenuItem.Name = "PauseMenuItem";
-			this.PauseMenuItem.Size = new System.Drawing.Size(135, 22);
 			this.PauseMenuItem.Text = "&Pause";
 			this.PauseMenuItem.Click += new System.EventHandler(this.PauseMenuItem_Click);
 			// 
 			// RebootCoreMenuItem
 			// 
-			this.RebootCoreMenuItem.Name = "RebootCoreMenuItem";
-			this.RebootCoreMenuItem.Size = new System.Drawing.Size(135, 22);
 			this.RebootCoreMenuItem.Text = "&Reboot Core";
 			this.RebootCoreMenuItem.Click += new System.EventHandler(this.PowerMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(132, 6);
-			// 
 			// SoftResetMenuItem
 			// 
-			this.SoftResetMenuItem.Name = "SoftResetMenuItem";
-			this.SoftResetMenuItem.Size = new System.Drawing.Size(135, 22);
 			this.SoftResetMenuItem.Text = "&Soft Reset";
 			this.SoftResetMenuItem.Click += new System.EventHandler(this.SoftResetMenuItem_Click);
 			// 
 			// HardResetMenuItem
 			// 
-			this.HardResetMenuItem.Name = "HardResetMenuItem";
-			this.HardResetMenuItem.Size = new System.Drawing.Size(135, 22);
 			this.HardResetMenuItem.Text = "&Hard Reset";
 			this.HardResetMenuItem.Click += new System.EventHandler(this.HardResetMenuItem_Click);
 			// 
@@ -1187,8 +951,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DisplayStatusBarMenuItem,
 			this.DisplayMessagesMenuItem,
 			this.DisplayLogWindowMenuItem});
-			this.ViewSubMenu.Name = "ViewSubMenu";
-			this.ViewSubMenu.Size = new System.Drawing.Size(41, 17);
 			this.ViewSubMenu.Text = "&View";
 			this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
 			// 
@@ -1201,130 +963,86 @@ namespace BizHawk.Client.EmuHawk
 			this.x4MenuItem,
 			this.x5MenuItem,
 			this.mzMenuItem});
-			this.WindowSizeSubMenu.Name = "WindowSizeSubMenu";
-			this.WindowSizeSubMenu.Size = new System.Drawing.Size(187, 22);
 			this.WindowSizeSubMenu.Text = "&Window Size";
 			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
 			// 
 			// x1MenuItem
 			// 
-			this.x1MenuItem.Name = "x1MenuItem";
-			this.x1MenuItem.Size = new System.Drawing.Size(94, 22);
 			this.x1MenuItem.Text = "&1x";
 			this.x1MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// x2MenuItem
 			// 
-			this.x2MenuItem.Name = "x2MenuItem";
-			this.x2MenuItem.Size = new System.Drawing.Size(94, 22);
 			this.x2MenuItem.Text = "&2x";
 			this.x2MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// x3MenuItem
 			// 
-			this.x3MenuItem.Name = "x3MenuItem";
-			this.x3MenuItem.Size = new System.Drawing.Size(94, 22);
 			this.x3MenuItem.Text = "&3x";
 			this.x3MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// x4MenuItem
 			// 
-			this.x4MenuItem.Name = "x4MenuItem";
-			this.x4MenuItem.Size = new System.Drawing.Size(94, 22);
 			this.x4MenuItem.Text = "&4x";
 			this.x4MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// x5MenuItem
 			// 
-			this.x5MenuItem.Name = "x5MenuItem";
-			this.x5MenuItem.Size = new System.Drawing.Size(94, 22);
 			this.x5MenuItem.Text = "&5x";
 			this.x5MenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// mzMenuItem
 			// 
-			this.mzMenuItem.Name = "mzMenuItem";
-			this.mzMenuItem.Size = new System.Drawing.Size(94, 22);
 			this.mzMenuItem.Text = "&Max";
 			this.mzMenuItem.Click += new System.EventHandler(this.WindowSize_Click);
 			// 
 			// SwitchToFullscreenMenuItem
 			// 
-			this.SwitchToFullscreenMenuItem.Name = "SwitchToFullscreenMenuItem";
-			this.SwitchToFullscreenMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.SwitchToFullscreenMenuItem.Text = "Switch to Fullscreen";
 			this.SwitchToFullscreenMenuItem.Click += new System.EventHandler(this.SwitchToFullscreenMenuItem_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(184, 6);
-			// 
 			// DisplayFPSMenuItem
 			// 
-			this.DisplayFPSMenuItem.Name = "DisplayFPSMenuItem";
-			this.DisplayFPSMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayFPSMenuItem.Text = "Display FPS";
 			this.DisplayFPSMenuItem.Click += new System.EventHandler(this.DisplayFpsMenuItem_Click);
 			// 
 			// DisplayFrameCounterMenuItem
 			// 
-			this.DisplayFrameCounterMenuItem.Name = "DisplayFrameCounterMenuItem";
-			this.DisplayFrameCounterMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayFrameCounterMenuItem.Text = "Display FrameCounter";
 			this.DisplayFrameCounterMenuItem.Click += new System.EventHandler(this.DisplayFrameCounterMenuItem_Click);
 			// 
 			// DisplayLagCounterMenuItem
 			// 
-			this.DisplayLagCounterMenuItem.Name = "DisplayLagCounterMenuItem";
-			this.DisplayLagCounterMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayLagCounterMenuItem.Text = "Display Lag Counter";
 			this.DisplayLagCounterMenuItem.Click += new System.EventHandler(this.DisplayLagCounterMenuItem_Click);
 			// 
 			// DisplayInputMenuItem
 			// 
-			this.DisplayInputMenuItem.Name = "DisplayInputMenuItem";
-			this.DisplayInputMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayInputMenuItem.Text = "Display Input";
 			this.DisplayInputMenuItem.Click += new System.EventHandler(this.DisplayInputMenuItem_Click);
 			// 
 			// DisplayRerecordCountMenuItem
 			// 
-			this.DisplayRerecordCountMenuItem.Name = "DisplayRerecordCountMenuItem";
-			this.DisplayRerecordCountMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayRerecordCountMenuItem.Text = "Display Rerecord Count";
 			this.DisplayRerecordCountMenuItem.Click += new System.EventHandler(this.DisplayRerecordsMenuItem_Click);
 			// 
 			// DisplaySubtitlesMenuItem
 			// 
-			this.DisplaySubtitlesMenuItem.Name = "DisplaySubtitlesMenuItem";
-			this.DisplaySubtitlesMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplaySubtitlesMenuItem.Text = "Display Subtitles";
 			this.DisplaySubtitlesMenuItem.Click += new System.EventHandler(this.DisplaySubtitlesMenuItem_Click);
 			// 
-			// toolStripMenuItem4
-			// 
-			this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-			this.toolStripMenuItem4.Size = new System.Drawing.Size(184, 6);
-			// 
 			// DisplayStatusBarMenuItem
 			// 
-			this.DisplayStatusBarMenuItem.Name = "DisplayStatusBarMenuItem";
-			this.DisplayStatusBarMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayStatusBarMenuItem.Text = "Display Status Bar";
 			this.DisplayStatusBarMenuItem.Click += new System.EventHandler(this.DisplayStatusBarMenuItem_Click);
 			// 
 			// DisplayMessagesMenuItem
 			// 
-			this.DisplayMessagesMenuItem.Name = "DisplayMessagesMenuItem";
-			this.DisplayMessagesMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayMessagesMenuItem.Text = "Display Messages";
 			this.DisplayMessagesMenuItem.Click += new System.EventHandler(this.DisplayMessagesMenuItem_Click);
 			// 
 			// DisplayLogWindowMenuItem
 			// 
-			this.DisplayLogWindowMenuItem.Name = "DisplayLogWindowMenuItem";
-			this.DisplayLogWindowMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.DisplayLogWindowMenuItem.Text = "Display Log Window";
 			this.DisplayLogWindowMenuItem.Click += new System.EventHandler(this.DisplayLogWindowMenuItem_Click);
 			// 
@@ -1352,99 +1070,68 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveConfigAsMenuItem,
 			this.LoadConfigMenuItem,
 			this.LoadConfigFromMenuItem});
-			this.ConfigSubMenu.Name = "ConfigSubMenu";
-			this.ConfigSubMenu.Size = new System.Drawing.Size(50, 17);
 			this.ConfigSubMenu.Text = "&Config";
 			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
 			// 
 			// ControllersMenuItem
 			// 
-			this.ControllersMenuItem.Name = "ControllersMenuItem";
-			this.ControllersMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.ControllersMenuItem.Text = "&Controllers...";
 			this.ControllersMenuItem.Click += new System.EventHandler(this.ControllersMenuItem_Click);
 			// 
 			// HotkeysMenuItem
 			// 
-			this.HotkeysMenuItem.Name = "HotkeysMenuItem";
-			this.HotkeysMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.HotkeysMenuItem.Text = "&Hotkeys...";
 			this.HotkeysMenuItem.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
 			// 
 			// DisplayConfigMenuItem
 			// 
-			this.DisplayConfigMenuItem.Name = "DisplayConfigMenuItem";
-			this.DisplayConfigMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.DisplayConfigMenuItem.Text = "Display...";
 			this.DisplayConfigMenuItem.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
 			// 
 			// SoundMenuItem
 			// 
-			this.SoundMenuItem.Name = "SoundMenuItem";
-			this.SoundMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.SoundMenuItem.Text = "&Sound...";
 			this.SoundMenuItem.Click += new System.EventHandler(this.SoundMenuItem_Click);
 			// 
 			// PathsMenuItem
 			// 
-			this.PathsMenuItem.Name = "PathsMenuItem";
-			this.PathsMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.PathsMenuItem.Text = "Paths...";
 			this.PathsMenuItem.Click += new System.EventHandler(this.PathsMenuItem_Click);
 			// 
 			// FirmwaresMenuItem
 			// 
-			this.FirmwaresMenuItem.Name = "FirmwaresMenuItem";
-			this.FirmwaresMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.FirmwaresMenuItem.Text = "&Firmwares...";
 			this.FirmwaresMenuItem.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
 			// 
 			// MessagesMenuItem
 			// 
-			this.MessagesMenuItem.Name = "MessagesMenuItem";
-			this.MessagesMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.MessagesMenuItem.Text = "&Messages...";
 			this.MessagesMenuItem.Click += new System.EventHandler(this.MessagesMenuItem_Click);
 			// 
 			// AutofireMenuItem
 			// 
-			this.AutofireMenuItem.Name = "AutofireMenuItem";
-			this.AutofireMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.AutofireMenuItem.Text = "&Autofire...";
 			this.AutofireMenuItem.Click += new System.EventHandler(this.AutofireMenuItem_Click);
 			// 
 			// RewindOptionsMenuItem
 			// 
-			this.RewindOptionsMenuItem.Name = "RewindOptionsMenuItem";
-			this.RewindOptionsMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.RewindOptionsMenuItem.Text = "&Rewind && States...";
 			this.RewindOptionsMenuItem.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
 			// 
 			// extensionsToolStripMenuItem
 			// 
-			this.extensionsToolStripMenuItem.Name = "extensionsToolStripMenuItem";
-			this.extensionsToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.extensionsToolStripMenuItem.Text = "File Extensions...";
 			this.extensionsToolStripMenuItem.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
 			// 
 			// ClientOptionsMenuItem
 			// 
-			this.ClientOptionsMenuItem.Name = "ClientOptionsMenuItem";
-			this.ClientOptionsMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.ClientOptionsMenuItem.Text = "&Customize...";
 			this.ClientOptionsMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
 			// 
 			// ProfilesMenuItem
 			// 
-			this.ProfilesMenuItem.Name = "ProfilesMenuItem";
-			this.ProfilesMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.ProfilesMenuItem.Text = "&Profiles...";
 			this.ProfilesMenuItem.Click += new System.EventHandler(this.ProfilesMenuItem_Click);
-			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			this.toolStripSeparator9.Size = new System.Drawing.Size(167, 6);
 			// 
 			// SpeedSkipSubMenu
 			// 
@@ -1466,67 +1153,41 @@ namespace BizHawk.Client.EmuHawk
 			this.Speed150MenuItem,
 			this.Speed200MenuItem,
 			this.Speed400MenuItem});
-			this.SpeedSkipSubMenu.Name = "SpeedSkipSubMenu";
-			this.SpeedSkipSubMenu.Size = new System.Drawing.Size(170, 22);
 			this.SpeedSkipSubMenu.Text = "Speed/Skip";
 			this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
 			// 
 			// ClockThrottleMenuItem
 			// 
-			this.ClockThrottleMenuItem.Name = "ClockThrottleMenuItem";
-			this.ClockThrottleMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.ClockThrottleMenuItem.Text = "Clock Throttle";
 			this.ClockThrottleMenuItem.Click += new System.EventHandler(this.ClockThrottleMenuItem_Click);
 			// 
 			// AudioThrottleMenuItem
 			// 
-			this.AudioThrottleMenuItem.Name = "AudioThrottleMenuItem";
-			this.AudioThrottleMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.AudioThrottleMenuItem.Text = "Audio Throttle";
 			this.AudioThrottleMenuItem.Click += new System.EventHandler(this.AudioThrottleMenuItem_Click);
 			// 
 			// VsyncThrottleMenuItem
 			// 
-			this.VsyncThrottleMenuItem.Name = "VsyncThrottleMenuItem";
-			this.VsyncThrottleMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.VsyncThrottleMenuItem.Text = "VSync Throttle";
 			this.VsyncThrottleMenuItem.Click += new System.EventHandler(this.VsyncThrottleMenuItem_Click);
 			// 
-			// toolStripSeparator27
-			// 
-			this.toolStripSeparator27.Name = "toolStripSeparator27";
-			this.toolStripSeparator27.Size = new System.Drawing.Size(178, 6);
-			// 
 			// VsyncEnabledMenuItem
 			// 
-			this.VsyncEnabledMenuItem.Name = "VsyncEnabledMenuItem";
-			this.VsyncEnabledMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.VsyncEnabledMenuItem.Text = "VSync Enabled";
 			this.VsyncEnabledMenuItem.Click += new System.EventHandler(this.VsyncEnabledMenuItem_Click);
 			// 
-			// toolStripMenuItem3
-			// 
-			this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-			this.toolStripMenuItem3.Size = new System.Drawing.Size(178, 6);
-			// 
 			// miUnthrottled
 			// 
-			this.miUnthrottled.Name = "miUnthrottled";
-			this.miUnthrottled.Size = new System.Drawing.Size(181, 22);
 			this.miUnthrottled.Text = "Unthrottled";
 			this.miUnthrottled.Click += new System.EventHandler(this.UnthrottledMenuItem_Click);
 			// 
 			// MinimizeSkippingMenuItem
 			// 
-			this.MinimizeSkippingMenuItem.Name = "MinimizeSkippingMenuItem";
-			this.MinimizeSkippingMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.MinimizeSkippingMenuItem.Text = "Auto-minimize skipping";
 			this.MinimizeSkippingMenuItem.Click += new System.EventHandler(this.MinimizeSkippingMenuItem_Click);
 			// 
 			// NeverSkipMenuItem
 			// 
-			this.NeverSkipMenuItem.Name = "NeverSkipMenuItem";
-			this.NeverSkipMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.NeverSkipMenuItem.Text = "Skip 0 (never)";
 			this.NeverSkipMenuItem.Click += new System.EventHandler(this.NeverSkipMenuItem_Click);
 			// 
@@ -1542,117 +1203,80 @@ namespace BizHawk.Client.EmuHawk
 			this.Frameskip7MenuItem,
 			this.Frameskip8MenuItem,
 			this.Frameskip9MenuItem});
-			this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-			this.toolStripMenuItem17.Size = new System.Drawing.Size(181, 22);
 			this.toolStripMenuItem17.Text = "Skip 1..9";
 			// 
 			// Frameskip1MenuItem
 			// 
-			this.Frameskip1MenuItem.Name = "Frameskip1MenuItem";
-			this.Frameskip1MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip1MenuItem.Text = "1";
 			this.Frameskip1MenuItem.Click += new System.EventHandler(this.Frameskip1MenuItem_Click);
 			// 
 			// Frameskip2MenuItem
 			// 
-			this.Frameskip2MenuItem.Name = "Frameskip2MenuItem";
-			this.Frameskip2MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip2MenuItem.Text = "2";
 			this.Frameskip2MenuItem.Click += new System.EventHandler(this.Frameskip2MenuItem_Click);
 			// 
 			// Frameskip3MenuItem
 			// 
-			this.Frameskip3MenuItem.Name = "Frameskip3MenuItem";
-			this.Frameskip3MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip3MenuItem.Text = "3";
 			this.Frameskip3MenuItem.Click += new System.EventHandler(this.Frameskip3MenuItem_Click);
 			// 
 			// Frameskip4MenuItem
 			// 
-			this.Frameskip4MenuItem.Name = "Frameskip4MenuItem";
-			this.Frameskip4MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip4MenuItem.Text = "4";
 			this.Frameskip4MenuItem.Click += new System.EventHandler(this.Frameskip4MenuItem_Click);
 			// 
 			// Frameskip5MenuItem
 			// 
-			this.Frameskip5MenuItem.Name = "Frameskip5MenuItem";
-			this.Frameskip5MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip5MenuItem.Text = "5";
 			this.Frameskip5MenuItem.Click += new System.EventHandler(this.Frameskip5MenuItem_Click);
 			// 
 			// Frameskip6MenuItem
 			// 
-			this.Frameskip6MenuItem.Name = "Frameskip6MenuItem";
-			this.Frameskip6MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip6MenuItem.Text = "6";
 			this.Frameskip6MenuItem.Click += new System.EventHandler(this.Frameskip6MenuItem_Click);
 			// 
 			// Frameskip7MenuItem
 			// 
-			this.Frameskip7MenuItem.Name = "Frameskip7MenuItem";
-			this.Frameskip7MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip7MenuItem.Text = "7";
 			this.Frameskip7MenuItem.Click += new System.EventHandler(this.Frameskip7MenuItem_Click);
 			// 
 			// Frameskip8MenuItem
 			// 
-			this.Frameskip8MenuItem.Name = "Frameskip8MenuItem";
-			this.Frameskip8MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip8MenuItem.Text = "8";
 			this.Frameskip8MenuItem.Click += new System.EventHandler(this.Frameskip8MenuItem_Click);
 			// 
 			// Frameskip9MenuItem
 			// 
-			this.Frameskip9MenuItem.Name = "Frameskip9MenuItem";
-			this.Frameskip9MenuItem.Size = new System.Drawing.Size(80, 22);
 			this.Frameskip9MenuItem.Text = "9";
 			this.Frameskip9MenuItem.Click += new System.EventHandler(this.Frameskip9MenuItem_Click);
 			// 
-			// toolStripMenuItem5
-			// 
-			this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-			this.toolStripMenuItem5.Size = new System.Drawing.Size(178, 6);
-			// 
 			// Speed50MenuItem
 			// 
-			this.Speed50MenuItem.Name = "Speed50MenuItem";
-			this.Speed50MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed50MenuItem.Text = "Speed 50%";
 			this.Speed50MenuItem.Click += new System.EventHandler(this.Speed50MenuItem_Click);
 			// 
 			// Speed75MenuItem
 			// 
-			this.Speed75MenuItem.Name = "Speed75MenuItem";
-			this.Speed75MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed75MenuItem.Text = "Speed 75%";
 			this.Speed75MenuItem.Click += new System.EventHandler(this.Speed75MenuItem_Click);
 			// 
 			// Speed100MenuItem
 			// 
-			this.Speed100MenuItem.Name = "Speed100MenuItem";
-			this.Speed100MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed100MenuItem.Text = "Speed 100%";
 			this.Speed100MenuItem.Click += new System.EventHandler(this.Speed100MenuItem_Click);
 			// 
 			// Speed150MenuItem
 			// 
-			this.Speed150MenuItem.Name = "Speed150MenuItem";
-			this.Speed150MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed150MenuItem.Text = "Speed 150%";
 			this.Speed150MenuItem.Click += new System.EventHandler(this.Speed150MenuItem_Click);
 			// 
 			// Speed200MenuItem
 			// 
-			this.Speed200MenuItem.Name = "Speed200MenuItem";
-			this.Speed200MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed200MenuItem.Text = "Speed 200%";
 			this.Speed200MenuItem.Click += new System.EventHandler(this.Speed200MenuItem_Click);
 			// 
 			// Speed400MenuItem
 			// 
-			this.Speed400MenuItem.Name = "Speed400MenuItem";
-			this.Speed400MenuItem.Size = new System.Drawing.Size(181, 22);
 			this.Speed400MenuItem.Text = "Speed 400%";
 			this.Speed400MenuItem.Click += new System.EventHandler(this.Speed400MenuItem_Click);
 			// 
@@ -1662,68 +1286,45 @@ namespace BizHawk.Client.EmuHawk
 			this.BothHkAndControllerMenuItem,
 			this.InputOverHkMenuItem,
 			this.HkOverInputMenuItem});
-			this.KeyPrioritySubMenu.Name = "KeyPrioritySubMenu";
-			this.KeyPrioritySubMenu.Size = new System.Drawing.Size(170, 22);
 			this.KeyPrioritySubMenu.Text = "Key Priority";
 			this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
 			// 
 			// BothHkAndControllerMenuItem
 			// 
-			this.BothHkAndControllerMenuItem.Name = "BothHkAndControllerMenuItem";
-			this.BothHkAndControllerMenuItem.Size = new System.Drawing.Size(214, 22);
 			this.BothHkAndControllerMenuItem.Text = "Both Hotkeys and Controllers";
 			this.BothHkAndControllerMenuItem.Click += new System.EventHandler(this.BothHkAndControllerMenuItem_Click);
 			// 
 			// InputOverHkMenuItem
 			// 
-			this.InputOverHkMenuItem.Name = "InputOverHkMenuItem";
-			this.InputOverHkMenuItem.Size = new System.Drawing.Size(214, 22);
 			this.InputOverHkMenuItem.Text = "Input overrides Hotkeys";
 			this.InputOverHkMenuItem.Click += new System.EventHandler(this.InputOverHkMenuItem_Click);
 			// 
 			// HkOverInputMenuItem
 			// 
-			this.HkOverInputMenuItem.Name = "HkOverInputMenuItem";
-			this.HkOverInputMenuItem.Size = new System.Drawing.Size(214, 22);
 			this.HkOverInputMenuItem.Text = "Hotkeys override Input";
 			this.HkOverInputMenuItem.Click += new System.EventHandler(this.HkOverInputMenuItem_Click);
 			// 
 			// CoresSubMenu
 			// 
-			this.CoresSubMenu.Name = "CoresSubMenu";
-			this.CoresSubMenu.Size = new System.Drawing.Size(170, 22);
 			this.CoresSubMenu.Text = "Cores";
-			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			this.toolStripSeparator10.Size = new System.Drawing.Size(167, 6);
 			// 
 			// SaveConfigMenuItem
 			// 
-			this.SaveConfigMenuItem.Name = "SaveConfigMenuItem";
-			this.SaveConfigMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.SaveConfigMenuItem.Text = "Save Config";
 			this.SaveConfigMenuItem.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
 			// 
 			// SaveConfigAsMenuItem
 			// 
-			this.SaveConfigAsMenuItem.Name = "SaveConfigAsMenuItem";
-			this.SaveConfigAsMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.SaveConfigAsMenuItem.Text = "Save Config As...";
 			this.SaveConfigAsMenuItem.Click += new System.EventHandler(this.SaveConfigAsMenuItem_Click);
 			// 
 			// LoadConfigMenuItem
 			// 
-			this.LoadConfigMenuItem.Name = "LoadConfigMenuItem";
-			this.LoadConfigMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.LoadConfigMenuItem.Text = "Load Config";
 			this.LoadConfigMenuItem.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
 			// 
 			// LoadConfigFromMenuItem
 			// 
-			this.LoadConfigFromMenuItem.Name = "LoadConfigFromMenuItem";
-			this.LoadConfigFromMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.LoadConfigFromMenuItem.Text = "Load Config From...";
 			this.LoadConfigFromMenuItem.Click += new System.EventHandler(this.LoadConfigFromMenuItem_Click);
 			// 
@@ -1750,128 +1351,81 @@ namespace BizHawk.Client.EmuHawk
 			this.MultiDiskBundlerFileMenuItem,
 			this.ExternalToolMenuItem,
 			this.BatchRunnerMenuItem});
-			this.ToolsSubMenu.Name = "ToolsSubMenu";
-			this.ToolsSubMenu.Size = new System.Drawing.Size(44, 17);
 			this.ToolsSubMenu.Text = "&Tools";
 			this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
 			// 
 			// ToolBoxMenuItem
 			// 
-			this.ToolBoxMenuItem.Name = "ToolBoxMenuItem";
-			this.ToolBoxMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.ToolBoxMenuItem.Text = "&Tool Box";
 			this.ToolBoxMenuItem.Click += new System.EventHandler(this.ToolBoxMenuItem_Click);
 			// 
-			// toolStripSeparator12
-			// 
-			this.toolStripSeparator12.Name = "toolStripSeparator12";
-			this.toolStripSeparator12.Size = new System.Drawing.Size(180, 6);
-			// 
 			// RamWatchMenuItem
 			// 
-			this.RamWatchMenuItem.Name = "RamWatchMenuItem";
-			this.RamWatchMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.RamWatchMenuItem.Text = "RAM &Watch";
 			this.RamWatchMenuItem.Click += new System.EventHandler(this.RamWatchMenuItem_Click);
 			// 
 			// RamSearchMenuItem
 			// 
-			this.RamSearchMenuItem.Name = "RamSearchMenuItem";
-			this.RamSearchMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.RamSearchMenuItem.Text = "RAM &Search";
 			this.RamSearchMenuItem.Click += new System.EventHandler(this.RamSearchMenuItem_Click);
 			// 
 			// LuaConsoleMenuItem
 			// 
-			this.LuaConsoleMenuItem.Name = "LuaConsoleMenuItem";
-			this.LuaConsoleMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.LuaConsoleMenuItem.Text = "Lua Console";
 			this.LuaConsoleMenuItem.Click += new System.EventHandler(this.LuaConsoleMenuItem_Click);
 			// 
 			// TAStudioMenuItem
 			// 
-			this.TAStudioMenuItem.Name = "TAStudioMenuItem";
-			this.TAStudioMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.TAStudioMenuItem.Text = "&TAStudio";
 			this.TAStudioMenuItem.Click += new System.EventHandler(this.TAStudioMenuItem_Click);
 			// 
 			// HexEditorMenuItem
 			// 
-			this.HexEditorMenuItem.Name = "HexEditorMenuItem";
-			this.HexEditorMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.HexEditorMenuItem.Text = "&Hex Editor";
 			this.HexEditorMenuItem.Click += new System.EventHandler(this.HexEditorMenuItem_Click);
 			// 
 			// TraceLoggerMenuItem
 			// 
-			this.TraceLoggerMenuItem.Name = "TraceLoggerMenuItem";
-			this.TraceLoggerMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.TraceLoggerMenuItem.Text = "Trace &Logger";
 			this.TraceLoggerMenuItem.Click += new System.EventHandler(this.TraceLoggerMenuItem_Click);
 			// 
 			// DebuggerMenuItem
 			// 
-			this.DebuggerMenuItem.Name = "DebuggerMenuItem";
-			this.DebuggerMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.DebuggerMenuItem.Text = "&Debugger";
 			this.DebuggerMenuItem.Click += new System.EventHandler(this.DebuggerMenuItem_Click);
 			// 
 			// CodeDataLoggerMenuItem
 			// 
-			this.CodeDataLoggerMenuItem.Name = "CodeDataLoggerMenuItem";
-			this.CodeDataLoggerMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.CodeDataLoggerMenuItem.Text = "Code-Data Logger";
 			this.CodeDataLoggerMenuItem.Click += new System.EventHandler(this.CodeDataLoggerMenuItem_Click);
 			// 
 			// MacroToolMenuItem
 			// 
-			this.MacroToolMenuItem.Name = "MacroToolMenuItem";
-			this.MacroToolMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.MacroToolMenuItem.Text = "&Macro Tool";
 			this.MacroToolMenuItem.Click += new System.EventHandler(this.MacroToolMenuItem_Click);
 			// 
 			// VirtualPadMenuItem
 			// 
-			this.VirtualPadMenuItem.Name = "VirtualPadMenuItem";
-			this.VirtualPadMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.VirtualPadMenuItem.Text = "Virtual Pad";
 			this.VirtualPadMenuItem.Click += new System.EventHandler(this.VirtualPadMenuItem_Click);
 			// 
 			// BasicBotMenuItem
 			// 
-			this.BasicBotMenuItem.Name = "BasicBotMenuItem";
-			this.BasicBotMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.BasicBotMenuItem.Text = "Basic Bot";
 			this.BasicBotMenuItem.Click += new System.EventHandler(this.BasicBotMenuItem_Click);
 			// 
-			// toolStripSeparator11
-			// 
-			this.toolStripSeparator11.Name = "toolStripSeparator11";
-			this.toolStripSeparator11.Size = new System.Drawing.Size(180, 6);
-			// 
 			// CheatsMenuItem
 			// 
-			this.CheatsMenuItem.Name = "CheatsMenuItem";
-			this.CheatsMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.CheatsMenuItem.Text = "Cheats";
 			this.CheatsMenuItem.Click += new System.EventHandler(this.CheatsMenuItem_Click);
 			// 
 			// gameSharkConverterToolStripMenuItem
 			// 
-			this.GameSharkConverterMenuItem.Name = "GameSharkConverterMenuItem";
-			this.GameSharkConverterMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.GameSharkConverterMenuItem.Text = "Cheat Code Converter";
 			this.GameSharkConverterMenuItem.Click += new System.EventHandler(this.CheatCodeConverterMenuItem_Click);
 			// 
-			// toolStripSeparator29
-			// 
-			this.toolStripSeparator29.Name = "toolStripSeparator29";
-			this.toolStripSeparator29.Size = new System.Drawing.Size(180, 6);
-			// 
 			// MultiDiskBundlerFileMenuItem
 			// 
-			this.MultiDiskBundlerFileMenuItem.Name = "MultiDiskBundlerFileMenuItem";
-			this.MultiDiskBundlerFileMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.MultiDiskBundlerFileMenuItem.Text = "Multi-disk Bundler";
 			this.MultiDiskBundlerFileMenuItem.Click += new System.EventHandler(this.MultidiskBundlerMenuItem_Click);
 			// 
@@ -1879,21 +1433,15 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.dummyExternalTool});
-			this.ExternalToolMenuItem.Name = "ExternalToolMenuItem";
-			this.ExternalToolMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.ExternalToolMenuItem.Text = "External Tool";
 			this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
 			// 
 			// dummyExternalTool
 			// 
-			this.dummyExternalTool.Name = "dummyExternalTool";
-			this.dummyExternalTool.Size = new System.Drawing.Size(99, 22);
 			this.dummyExternalTool.Text = "None";
 			// 
 			// batchRunnerToolStripMenuItem
 			// 
-			this.BatchRunnerMenuItem.Name = "BatchRunnerMenuItem";
-			this.BatchRunnerMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.BatchRunnerMenuItem.Text = "Batch Runner";
 			this.BatchRunnerMenuItem.Visible = false;
 			this.BatchRunnerMenuItem.Click += new System.EventHandler(this.BatchRunnerMenuItem_Click);
@@ -1914,90 +1462,58 @@ namespace BizHawk.Client.EmuHawk
 			this.FDSControlsMenuItem,
 			this.VSControlsMenuItem,
 			this.BarcodeReaderMenuItem});
-			this.NESSubMenu.Name = "NESSubMenu";
-			this.NESSubMenu.Size = new System.Drawing.Size(38, 17);
 			this.NESSubMenu.Text = "&NES";
 			this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
 			// 
 			// NESPPUViewerMenuItem
 			// 
-			this.NESPPUViewerMenuItem.Name = "NESPPUViewerMenuItem";
-			this.NESPPUViewerMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NESPPUViewerMenuItem.Text = "&PPU Viewer";
 			this.NESPPUViewerMenuItem.Click += new System.EventHandler(this.NesPpuViewerMenuItem_Click);
 			// 
 			// NESNametableViewerMenuItem
 			// 
-			this.NESNametableViewerMenuItem.Name = "NESNametableViewerMenuItem";
-			this.NESNametableViewerMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NESNametableViewerMenuItem.Text = "&Nametable Viewer";
 			this.NESNametableViewerMenuItem.Click += new System.EventHandler(this.NesNametableViewerMenuItem_Click);
 			// 
 			// musicRipperToolStripMenuItem
 			// 
-			this.MusicRipperMenuItem.Name = "MusicRipperMenuItem";
-			this.MusicRipperMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.MusicRipperMenuItem.Text = "Music Ripper";
 			this.MusicRipperMenuItem.Click += new System.EventHandler(this.MusicRipperMenuItem_Click);
 			// 
-			// toolStripSeparator17
-			// 
-			this.toolStripSeparator17.Name = "toolStripSeparator17";
-			this.toolStripSeparator17.Size = new System.Drawing.Size(214, 6);
-			// 
 			// NesControllerSettingsMenuItem
 			// 
-			this.NesControllerSettingsMenuItem.Name = "NesControllerSettingsMenuItem";
-			this.NesControllerSettingsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NesControllerSettingsMenuItem.Text = "Controller Settings...";
 			this.NesControllerSettingsMenuItem.Click += new System.EventHandler(this.NesControllerSettingsMenuItem_Click);
 			// 
 			// NESGraphicSettingsMenuItem
 			// 
-			this.NESGraphicSettingsMenuItem.Name = "NESGraphicSettingsMenuItem";
-			this.NESGraphicSettingsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NESGraphicSettingsMenuItem.Text = "Graphics Settings...";
 			this.NESGraphicSettingsMenuItem.Click += new System.EventHandler(this.NesGraphicSettingsMenuItem_Click);
 			// 
 			// NESSoundChannelsMenuItem
 			// 
-			this.NESSoundChannelsMenuItem.Name = "NESSoundChannelsMenuItem";
-			this.NESSoundChannelsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NESSoundChannelsMenuItem.Text = "Sound Channels...";
 			this.NESSoundChannelsMenuItem.Click += new System.EventHandler(this.NesSoundChannelsMenuItem_Click);
 			// 
 			// VSSettingsMenuItem
 			// 
-			this.VSSettingsMenuItem.Name = "VSSettingsMenuItem";
-			this.VSSettingsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.VSSettingsMenuItem.Text = "VS Settings...";
 			this.VSSettingsMenuItem.Click += new System.EventHandler(this.VsSettingsMenuItem_Click);
 			// 
 			// MovieSettingsMenuItem
 			// 
-			this.MovieSettingsMenuItem.Name = "MovieSettingsMenuItem";
-			this.MovieSettingsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.MovieSettingsMenuItem.Text = "Advanced Settings...";
 			this.MovieSettingsMenuItem.Click += new System.EventHandler(this.MovieSettingsMenuItem_Click);
-			// 
-			// toolStripSeparator22
-			// 
-			this.toolStripSeparator22.Name = "toolStripSeparator22";
-			this.toolStripSeparator22.Size = new System.Drawing.Size(214, 6);
 			// 
 			// FDSControlsMenuItem
 			// 
 			this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.FdsEjectDiskMenuItem});
-			this.FDSControlsMenuItem.Name = "FDSControlsMenuItem";
-			this.FDSControlsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.FDSControlsMenuItem.Text = "FDS Controls";
 			this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
 			// 
 			// FdsEjectDiskMenuItem
 			// 
-			this.FdsEjectDiskMenuItem.Name = "FdsEjectDiskMenuItem";
-			this.FdsEjectDiskMenuItem.Size = new System.Drawing.Size(120, 22);
 			this.FdsEjectDiskMenuItem.Text = "&Eject Disk";
 			this.FdsEjectDiskMenuItem.Click += new System.EventHandler(this.FdsEjectDiskMenuItem_Click);
 			// 
@@ -2007,35 +1523,25 @@ namespace BizHawk.Client.EmuHawk
 			this.VSInsertCoinP1MenuItem,
 			this.VSInsertCoinP2MenuItem,
 			this.VSServiceSwitchMenuItem});
-			this.VSControlsMenuItem.Name = "VSControlsMenuItem";
-			this.VSControlsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.VSControlsMenuItem.Text = "VS Controls";
 			// 
 			// VSInsertCoinP1MenuItem
 			// 
-			this.VSInsertCoinP1MenuItem.Name = "VSInsertCoinP1MenuItem";
-			this.VSInsertCoinP1MenuItem.Size = new System.Drawing.Size(143, 22);
 			this.VSInsertCoinP1MenuItem.Text = "Insert Coin P1";
 			this.VSInsertCoinP1MenuItem.Click += new System.EventHandler(this.VsInsertCoinP1MenuItem_Click);
 			// 
 			// VSInsertCoinP2MenuItem
 			// 
-			this.VSInsertCoinP2MenuItem.Name = "VSInsertCoinP2MenuItem";
-			this.VSInsertCoinP2MenuItem.Size = new System.Drawing.Size(143, 22);
 			this.VSInsertCoinP2MenuItem.Text = "Insert Coin P2";
 			this.VSInsertCoinP2MenuItem.Click += new System.EventHandler(this.VsInsertCoinP2MenuItem_Click);
 			// 
 			// VSServiceSwitchMenuItem
 			// 
-			this.VSServiceSwitchMenuItem.Name = "VSServiceSwitchMenuItem";
-			this.VSServiceSwitchMenuItem.Size = new System.Drawing.Size(143, 22);
 			this.VSServiceSwitchMenuItem.Text = "Service Switch";
 			this.VSServiceSwitchMenuItem.Click += new System.EventHandler(this.VsServiceSwitchMenuItem_Click);
 			// 
 			// barcodeReaderToolStripMenuItem
 			// 
-			this.BarcodeReaderMenuItem.Name = "BarcodeReaderMenuItem";
-			this.BarcodeReaderMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.BarcodeReaderMenuItem.Text = "Barcode Reader";
 			this.BarcodeReaderMenuItem.Click += new System.EventHandler(this.BarcodeReaderMenuItem_Click);
 			// 
@@ -2047,43 +1553,28 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator13,
 			this.AutoloadKeypadMenuItem,
 			this.paletteToolStripMenuItem});
-			this.TI83SubMenu.Name = "TI83SubMenu";
-			this.TI83SubMenu.Size = new System.Drawing.Size(41, 17);
 			this.TI83SubMenu.Text = "TI83";
 			this.TI83SubMenu.DropDownOpened += new System.EventHandler(this.Ti83SubMenu_DropDownOpened);
 			// 
 			// KeypadMenuItem
 			// 
-			this.KeypadMenuItem.Name = "KeypadMenuItem";
-			this.KeypadMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.KeypadMenuItem.Text = "Keypad";
 			this.KeypadMenuItem.Click += new System.EventHandler(this.Ti83KeypadMenuItem_Click);
 			// 
 			// LoadTIFileMenuItem
 			// 
-			this.LoadTIFileMenuItem.Name = "LoadTIFileMenuItem";
-			this.LoadTIFileMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.LoadTIFileMenuItem.Text = "Load TI-83 File...";
 			this.LoadTIFileMenuItem.Click += new System.EventHandler(this.Ti83LoadTIFileMenuItem_Click);
-			// 
-			// toolStripSeparator13
-			// 
-			this.toolStripSeparator13.Name = "toolStripSeparator13";
-			this.toolStripSeparator13.Size = new System.Drawing.Size(154, 6);
 			// 
 			// AutoloadKeypadMenuItem
 			// 
 			this.AutoloadKeypadMenuItem.Checked = true;
 			this.AutoloadKeypadMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.AutoloadKeypadMenuItem.Name = "AutoloadKeypadMenuItem";
-			this.AutoloadKeypadMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.AutoloadKeypadMenuItem.Text = "Autoload Keypad";
 			this.AutoloadKeypadMenuItem.Click += new System.EventHandler(this.AutoloadKeypadMenuItem_Click);
 			// 
 			// paletteToolStripMenuItem
 			// 
-			this.paletteToolStripMenuItem.Name = "paletteToolStripMenuItem";
-			this.paletteToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.paletteToolStripMenuItem.Text = "Palette...";
 			this.paletteToolStripMenuItem.Click += new System.EventHandler(this.Ti83PaletteMenuItem_Click);
 			// 
@@ -2092,22 +1583,16 @@ namespace BizHawk.Client.EmuHawk
 			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.A7800ControllerSettingsMenuItem,
 			this.A7800FilterSettingsMenuItem});
-			this.A7800SubMenu.Name = "A7800SubMenu";
-			this.A7800SubMenu.Size = new System.Drawing.Size(50, 17);
 			this.A7800SubMenu.Text = "&A7800";
 			this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
 			// 
 			// A7800ControllerSettingsMenuItem
 			// 
-			this.A7800ControllerSettingsMenuItem.Name = "A7800ControllerSettingsMenuItem";
-			this.A7800ControllerSettingsMenuItem.Size = new System.Drawing.Size(163, 22);
 			this.A7800ControllerSettingsMenuItem.Text = "Controller Settings";
 			this.A7800ControllerSettingsMenuItem.Click += new System.EventHandler(this.A7800ControllerSettingsMenuItem_Click);
 			// 
 			// A7800FilterSettingsMenuItem
 			// 
-			this.A7800FilterSettingsMenuItem.Name = "A7800FilterSettingsMenuItem";
-			this.A7800FilterSettingsMenuItem.Size = new System.Drawing.Size(163, 22);
 			this.A7800FilterSettingsMenuItem.Text = "Filter Settings";
 			this.A7800FilterSettingsMenuItem.Click += new System.EventHandler(this.A7800FilterSettingsMenuItem_Click);
 			// 
@@ -2118,33 +1603,20 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator28,
 			this.GBGPUViewerMenuItem,
 			this.GBPrinterViewerMenuItem});
-			this.GBSubMenu.Name = "GBSubMenu";
-			this.GBSubMenu.Size = new System.Drawing.Size(32, 17);
 			this.GBSubMenu.Text = "&GB";
 			// 
 			// GBcoreSettingsToolStripMenuItem
 			// 
-			this.GBcoreSettingsToolStripMenuItem.Name = "GBcoreSettingsToolStripMenuItem";
-			this.GBcoreSettingsToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.GBcoreSettingsToolStripMenuItem.Text = "Settings...";
 			this.GBcoreSettingsToolStripMenuItem.Click += new System.EventHandler(this.GbCoreSettingsMenuItem_Click);
 			// 
-			// toolStripSeparator28
-			// 
-			this.toolStripSeparator28.Name = "toolStripSeparator28";
-			this.toolStripSeparator28.Size = new System.Drawing.Size(214, 6);
-			// 
 			// GBGPUViewerMenuItem
 			// 
-			this.GBGPUViewerMenuItem.Name = "GBGPUViewerMenuItem";
-			this.GBGPUViewerMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.GBGPUViewerMenuItem.Text = "GPU Viewer";
 			this.GBGPUViewerMenuItem.Click += new System.EventHandler(this.GbGpuViewerMenuItem_Click);
 			// 
 			// GBPrinterViewerMenuItem
 			// 
-			this.GBPrinterViewerMenuItem.Name = "GBPrinterViewerMenuItem";
-			this.GBPrinterViewerMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.GBPrinterViewerMenuItem.Text = "&Printer Viewer";
 			this.GBPrinterViewerMenuItem.Click += new System.EventHandler(this.GbPrinterViewerMenuItem_Click);
 			// 
@@ -2155,36 +1627,26 @@ namespace BizHawk.Client.EmuHawk
 			this.PSXOptionsMenuItem,
 			this.PSXDiscControlsMenuItem,
 			this.PSXHashDiscsToolStripMenuItem});
-			this.PSXSubMenu.Name = "PSXSubMenu";
-			this.PSXSubMenu.Size = new System.Drawing.Size(37, 17);
 			this.PSXSubMenu.Text = "PSX";
 			this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
 			// 
 			// PSXControllerSettingsMenuItem
 			// 
-			this.PSXControllerSettingsMenuItem.Name = "PSXControllerSettingsMenuItem";
-			this.PSXControllerSettingsMenuItem.Size = new System.Drawing.Size(216, 22);
 			this.PSXControllerSettingsMenuItem.Text = "Controller / Memcard Settings";
 			this.PSXControllerSettingsMenuItem.Click += new System.EventHandler(this.PsxControllerSettingsMenuItem_Click);
 			// 
 			// PSXOptionsMenuItem
 			// 
-			this.PSXOptionsMenuItem.Name = "PSXOptionsMenuItem";
-			this.PSXOptionsMenuItem.Size = new System.Drawing.Size(216, 22);
 			this.PSXOptionsMenuItem.Text = "&Options";
 			this.PSXOptionsMenuItem.Click += new System.EventHandler(this.PsxOptionsMenuItem_Click);
 			// 
 			// PSXDiscControlsMenuItem
 			// 
-			this.PSXDiscControlsMenuItem.Name = "PSXDiscControlsMenuItem";
-			this.PSXDiscControlsMenuItem.Size = new System.Drawing.Size(216, 22);
 			this.PSXDiscControlsMenuItem.Text = "&Disc Controls";
 			this.PSXDiscControlsMenuItem.Click += new System.EventHandler(this.PsxDiscControlsMenuItem_Click);
 			// 
 			// PSXHashDiscsToolStripMenuItem
 			// 
-			this.PSXHashDiscsToolStripMenuItem.Name = "PSXHashDiscsToolStripMenuItem";
-			this.PSXHashDiscsToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
 			this.PSXHashDiscsToolStripMenuItem.Text = "&Hash Discs";
 			this.PSXHashDiscsToolStripMenuItem.Click += new System.EventHandler(this.PsxHashDiscsMenuItem_Click);
 			// 
@@ -2195,34 +1657,21 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator18,
 			this.SnesGfxDebuggerMenuItem,
 			this.SnesOptionsMenuItem});
-			this.SNESSubMenu.Name = "SNESSubMenu";
-			this.SNESSubMenu.Size = new System.Drawing.Size(44, 17);
 			this.SNESSubMenu.Text = "&SNES";
 			this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
 			// 
 			// SNESControllerConfigurationMenuItem
 			// 
-			this.SNESControllerConfigurationMenuItem.Name = "SNESControllerConfigurationMenuItem";
-			this.SNESControllerConfigurationMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.SNESControllerConfigurationMenuItem.Text = "Controller Configuration";
 			this.SNESControllerConfigurationMenuItem.Click += new System.EventHandler(this.SNESControllerConfigurationMenuItem_Click);
 			// 
-			// toolStripSeparator18
-			// 
-			this.toolStripSeparator18.Name = "toolStripSeparator18";
-			this.toolStripSeparator18.Size = new System.Drawing.Size(214, 6);
-			// 
 			// SnesGfxDebuggerMenuItem
 			// 
-			this.SnesGfxDebuggerMenuItem.Name = "SnesGfxDebuggerMenuItem";
-			this.SnesGfxDebuggerMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.SnesGfxDebuggerMenuItem.Text = "Graphics Debugger";
 			this.SnesGfxDebuggerMenuItem.Click += new System.EventHandler(this.SnesGfxDebuggerMenuItem_Click);
 			// 
 			// SnesOptionsMenuItem
 			// 
-			this.SnesOptionsMenuItem.Name = "SnesOptionsMenuItem";
-			this.SnesOptionsMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.SnesOptionsMenuItem.Text = "&Options";
 			this.SnesOptionsMenuItem.Click += new System.EventHandler(this.SnesOptionsMenuItem_Click);
 			// 
@@ -2233,34 +1682,21 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator35,
 			this.ColecoSkipBiosMenuItem,
 			this.ColecoUseSGMMenuItem});
-			this.ColecoSubMenu.Name = "ColecoSubMenu";
-			this.ColecoSubMenu.Size = new System.Drawing.Size(51, 17);
 			this.ColecoSubMenu.Text = "&Coleco";
 			this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
 			// 
 			// ColecoControllerSettingsMenuItem
 			// 
-			this.ColecoControllerSettingsMenuItem.Name = "ColecoControllerSettingsMenuItem";
-			this.ColecoControllerSettingsMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.ColecoControllerSettingsMenuItem.Text = "&Controller Settings...";
 			this.ColecoControllerSettingsMenuItem.Click += new System.EventHandler(this.ColecoControllerSettingsMenuItem_Click);
 			// 
-			// toolStripSeparator35
-			// 
-			this.toolStripSeparator35.Name = "toolStripSeparator35";
-			this.toolStripSeparator35.Size = new System.Drawing.Size(232, 6);
-			// 
 			// ColecoSkipBiosMenuItem
 			// 
-			this.ColecoSkipBiosMenuItem.Name = "ColecoSkipBiosMenuItem";
-			this.ColecoSkipBiosMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.ColecoSkipBiosMenuItem.Text = "&Skip BIOS intro (When Applicable)";
 			this.ColecoSkipBiosMenuItem.Click += new System.EventHandler(this.ColecoSkipBiosMenuItem_Click);
 			// 
 			// ColecoUseSGMMenuItem
 			// 
-			this.ColecoUseSGMMenuItem.Name = "ColecoUseSGMMenuItem";
-			this.ColecoUseSGMMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.ColecoUseSGMMenuItem.Text = "&Use the Super Game Module";
 			this.ColecoUseSGMMenuItem.Click += new System.EventHandler(this.ColecoUseSGMMenuItem_Click);
 			// 
@@ -2273,48 +1709,31 @@ namespace BizHawk.Client.EmuHawk
 			this.N64CircularAnalogRangeMenuItem,
 			this.MupenStyleLagMenuItem,
 			this.N64ExpansionSlotMenuItem});
-			this.N64SubMenu.Name = "N64SubMenu";
-			this.N64SubMenu.Size = new System.Drawing.Size(38, 17);
 			this.N64SubMenu.Text = "N64";
 			this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
 			// 
 			// N64PluginSettingsMenuItem
 			// 
-			this.N64PluginSettingsMenuItem.Name = "N64PluginSettingsMenuItem";
-			this.N64PluginSettingsMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.N64PluginSettingsMenuItem.Text = "Plugins";
 			this.N64PluginSettingsMenuItem.Click += new System.EventHandler(this.N64PluginSettingsMenuItem_Click);
 			// 
 			// N64ControllerSettingsMenuItem
 			// 
-			this.N64ControllerSettingsMenuItem.Name = "N64ControllerSettingsMenuItem";
-			this.N64ControllerSettingsMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.N64ControllerSettingsMenuItem.Text = "Controller Settings...";
 			this.N64ControllerSettingsMenuItem.Click += new System.EventHandler(this.N64ControllerSettingsMenuItem_Click);
 			// 
-			// toolStripSeparator23
-			// 
-			this.toolStripSeparator23.Name = "toolStripSeparator23";
-			this.toolStripSeparator23.Size = new System.Drawing.Size(177, 6);
-			// 
 			// N64CircularAnalogRangeMenuItem
 			// 
-			this.N64CircularAnalogRangeMenuItem.Name = "N64CircularAnalogRangeMenuItem";
-			this.N64CircularAnalogRangeMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.N64CircularAnalogRangeMenuItem.Text = "Circular Analog Range";
 			this.N64CircularAnalogRangeMenuItem.Click += new System.EventHandler(this.N64CircularAnalogRangeMenuItem_Click);
 			// 
 			// MupenStyleLagMenuItem
 			// 
-			this.MupenStyleLagMenuItem.Name = "MupenStyleLagMenuItem";
-			this.MupenStyleLagMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.MupenStyleLagMenuItem.Text = "&Non-VI Lag Frames";
 			this.MupenStyleLagMenuItem.Click += new System.EventHandler(this.MupenStyleLagMenuItem_Click);
 			// 
 			// N64ExpansionSlotMenuItem
 			// 
-			this.N64ExpansionSlotMenuItem.Name = "N64ExpansionSlotMenuItem";
-			this.N64ExpansionSlotMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.N64ExpansionSlotMenuItem.Text = "&Use Expansion Slot";
 			this.N64ExpansionSlotMenuItem.Click += new System.EventHandler(this.N64ExpansionSlotMenuItem_Click);
 			// 
@@ -2322,14 +1741,10 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.DGBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.DGBsettingsToolStripMenuItem});
-			this.DGBSubMenu.Name = "DGBSubMenu";
-			this.DGBSubMenu.Size = new System.Drawing.Size(53, 17);
 			this.DGBSubMenu.Text = "&GB Link";
 			// 
 			// DGBsettingsToolStripMenuItem
 			// 
-			this.DGBsettingsToolStripMenuItem.Name = "DGBsettingsToolStripMenuItem";
-			this.DGBsettingsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
 			this.DGBsettingsToolStripMenuItem.Text = "Settings...";
 			this.DGBsettingsToolStripMenuItem.Click += new System.EventHandler(this.DgbSettingsMenuItem_Click);
 			// 
@@ -2338,8 +1753,6 @@ namespace BizHawk.Client.EmuHawk
 			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.AppleDisksSubMenu,
 			this.settingsToolStripMenuItem1});
-			this.AppleSubMenu.Name = "AppleSubMenu";
-			this.AppleSubMenu.Size = new System.Drawing.Size(46, 17);
 			this.AppleSubMenu.Text = "Apple";
 			this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
 			// 
@@ -2347,20 +1760,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator31});
-			this.AppleDisksSubMenu.Name = "AppleDisksSubMenu";
-			this.AppleDisksSubMenu.Size = new System.Drawing.Size(125, 22);
 			this.AppleDisksSubMenu.Text = "Disks";
 			this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator31
-			// 
-			this.toolStripSeparator31.Name = "toolStripSeparator31";
-			this.toolStripSeparator31.Size = new System.Drawing.Size(57, 6);
-			// 
 			// settingsToolStripMenuItem1
 			// 
-			this.settingsToolStripMenuItem1.Name = "settingsToolStripMenuItem1";
-			this.settingsToolStripMenuItem1.Size = new System.Drawing.Size(125, 22);
 			this.settingsToolStripMenuItem1.Text = "&Settings...";
 			this.settingsToolStripMenuItem1.Click += new System.EventHandler(this.AppleIISettingsMenuItem_Click);
 			// 
@@ -2369,8 +1773,6 @@ namespace BizHawk.Client.EmuHawk
 			this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.C64DisksSubMenu,
 			this.C64SettingsMenuItem});
-			this.C64SubMenu.Name = "C64SubMenu";
-			this.C64SubMenu.Size = new System.Drawing.Size(38, 17);
 			this.C64SubMenu.Text = "&C64";
 			this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
 			// 
@@ -2378,20 +1780,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator36});
-			this.C64DisksSubMenu.Name = "C64DisksSubMenu";
-			this.C64DisksSubMenu.Size = new System.Drawing.Size(125, 22);
 			this.C64DisksSubMenu.Text = "Disks";
 			this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator36
-			// 
-			this.toolStripSeparator36.Name = "toolStripSeparator36";
-			this.toolStripSeparator36.Size = new System.Drawing.Size(57, 6);
-			// 
 			// C64SettingsMenuItem
 			// 
-			this.C64SettingsMenuItem.Name = "C64SettingsMenuItem";
-			this.C64SettingsMenuItem.Size = new System.Drawing.Size(125, 22);
 			this.C64SettingsMenuItem.Text = "&Settings...";
 			this.C64SettingsMenuItem.Click += new System.EventHandler(this.C64SettingsMenuItem_Click);
 			// 
@@ -2399,15 +1792,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.IntVControllerSettingsMenuItem});
-			this.IntvSubMenu.Name = "IntvSubMenu";
-			this.IntvSubMenu.Size = new System.Drawing.Size(39, 17);
 			this.IntvSubMenu.Text = "&Intv";
 			this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
 			// 
 			// IntVControllerSettingsMenuItem
 			// 
-			this.IntVControllerSettingsMenuItem.Name = "IntVControllerSettingsMenuItem";
-			this.IntVControllerSettingsMenuItem.Size = new System.Drawing.Size(175, 22);
 			this.IntVControllerSettingsMenuItem.Text = "Controller Settings...";
 			this.IntVControllerSettingsMenuItem.Click += new System.EventHandler(this.IntVControllerSettingsMenuItem_Click);
 			// 
@@ -2420,42 +1809,30 @@ namespace BizHawk.Client.EmuHawk
 			this.ZXSpectrumNonSyncSettingsMenuItem,
 			this.ZXSpectrumPokeMemoryMenuItem,
 			this.ZXSpectrumMediaMenuItem});
-			this.zXSpectrumToolStripMenuItem.Name = "zXSpectrumToolStripMenuItem";
-			this.zXSpectrumToolStripMenuItem.Size = new System.Drawing.Size(79, 17);
 			this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
 			// 
 			// ZXSpectrumCoreEmulationSettingsMenuItem
 			// 
-			this.ZXSpectrumCoreEmulationSettingsMenuItem.Name = "ZXSpectrumCoreEmulationSettingsMenuItem";
-			this.ZXSpectrumCoreEmulationSettingsMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumCoreEmulationSettingsMenuItem.Text = "Core Emulation Settings";
 			this.ZXSpectrumCoreEmulationSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumCoreEmulationSettingsMenuItem_Click);
 			// 
 			// ZXSpectrumControllerConfigurationMenuItem
 			// 
-			this.ZXSpectrumControllerConfigurationMenuItem.Name = "ZXSpectrumControllerConfigurationMenuItem";
-			this.ZXSpectrumControllerConfigurationMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumControllerConfigurationMenuItem.Text = "Joystick Configuration";
 			this.ZXSpectrumControllerConfigurationMenuItem.Click += new System.EventHandler(this.ZXSpectrumControllerConfigurationMenuItem_Click);
 			// 
 			// ZXSpectrumAudioSettingsMenuItem
 			// 
-			this.ZXSpectrumAudioSettingsMenuItem.Name = "ZXSpectrumAudioSettingsMenuItem";
-			this.ZXSpectrumAudioSettingsMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumAudioSettingsMenuItem.Text = "Audio Settings";
 			this.ZXSpectrumAudioSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumAudioSettingsMenuItem_Click);
 			// 
 			// ZXSpectrumNonSyncSettingsMenuItem
 			// 
-			this.ZXSpectrumNonSyncSettingsMenuItem.Name = "ZXSpectrumNonSyncSettingsMenuItem";
-			this.ZXSpectrumNonSyncSettingsMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumNonSyncSettingsMenuItem.Text = "Non-Sync Settings";
 			this.ZXSpectrumNonSyncSettingsMenuItem.Click += new System.EventHandler(this.ZXSpectrumNonSyncSettingsMenuItem_Click);
 			// 
 			// ZXSpectrumPokeMemoryMenuItem
 			// 
-			this.ZXSpectrumPokeMemoryMenuItem.Name = "ZXSpectrumPokeMemoryMenuItem";
-			this.ZXSpectrumPokeMemoryMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumPokeMemoryMenuItem.Text = "POKE Memory";
 			this.ZXSpectrumPokeMemoryMenuItem.Click += new System.EventHandler(this.ZXSpectrumPokeMemoryMenuItem_Click);
 			// 
@@ -2465,8 +1842,6 @@ namespace BizHawk.Client.EmuHawk
 			this.ZXSpectrumTapesSubMenu,
 			this.ZXSpectrumDisksSubMenu,
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem});
-			this.ZXSpectrumMediaMenuItem.Name = "ZXSpectrumMediaMenuItem";
-			this.ZXSpectrumMediaMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.ZXSpectrumMediaMenuItem.Text = "Media";
 			this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
 			// 
@@ -2474,43 +1849,31 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.zxt1ToolStripMenuItem});
-			this.ZXSpectrumTapesSubMenu.Name = "ZXSpectrumTapesSubMenu";
-			this.ZXSpectrumTapesSubMenu.Size = new System.Drawing.Size(154, 22);
 			this.ZXSpectrumTapesSubMenu.Text = "Tapes";
 			this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
 			// 
 			// zxt1ToolStripMenuItem
 			// 
-			this.zxt1ToolStripMenuItem.Name = "zxt1ToolStripMenuItem";
-			this.zxt1ToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
 			this.zxt1ToolStripMenuItem.Text = "zxt1";
 			// 
 			// ZXSpectrumDisksSubMenu
 			// 
 			this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.zxt2ToolStripMenuItem});
-			this.ZXSpectrumDisksSubMenu.Name = "ZXSpectrumDisksSubMenu";
-			this.ZXSpectrumDisksSubMenu.Size = new System.Drawing.Size(154, 22);
 			this.ZXSpectrumDisksSubMenu.Text = "Disks";
 			this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
 			// 
 			// zxt2ToolStripMenuItem
 			// 
-			this.zxt2ToolStripMenuItem.Name = "zxt2ToolStripMenuItem";
-			this.zxt2ToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
 			this.zxt2ToolStripMenuItem.Text = "zxt2";
 			// 
 			// ZXSpectrumExportSnapshotMenuItemMenuItem
 			// 
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Name = "ZXSpectrumExportSnapshotMenuItemMenuItem";
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Size = new System.Drawing.Size(154, 22);
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Text = "Export Snapshot";
 			this.ZXSpectrumExportSnapshotMenuItemMenuItem.Click += new System.EventHandler(this.ZXSpectrumExportSnapshotMenuItemMenuItem_Click);
 			// 
 			// GenericCoreSubMenu
 			// 
-			this.GenericCoreSubMenu.Name = "GenericCoreSubMenu";
-			this.GenericCoreSubMenu.Size = new System.Drawing.Size(56, 17);
 			this.GenericCoreSubMenu.Text = "&Core";
 			// 
 			// HelpSubMenu
@@ -2520,36 +1883,26 @@ namespace BizHawk.Client.EmuHawk
 			this.ForumsMenuItem,
 			this.FeaturesMenuItem,
 			this.AboutMenuItem});
-			this.HelpSubMenu.Name = "HelpSubMenu";
-			this.HelpSubMenu.Size = new System.Drawing.Size(40, 17);
 			this.HelpSubMenu.Text = "&Help";
 			this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
 			// 
 			// OnlineHelpMenuItem
 			// 
-			this.OnlineHelpMenuItem.Name = "OnlineHelpMenuItem";
-			this.OnlineHelpMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.OnlineHelpMenuItem.Text = "&Online Help...";
 			this.OnlineHelpMenuItem.Click += new System.EventHandler(this.OnlineHelpMenuItem_Click);
 			// 
 			// ForumsMenuItem
 			// 
-			this.ForumsMenuItem.Name = "ForumsMenuItem";
-			this.ForumsMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.ForumsMenuItem.Text = "Forums...";
 			this.ForumsMenuItem.Click += new System.EventHandler(this.ForumsMenuItem_Click);
 			// 
 			// FeaturesMenuItem
 			// 
-			this.FeaturesMenuItem.Name = "FeaturesMenuItem";
-			this.FeaturesMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.FeaturesMenuItem.Text = "&Features";
 			this.FeaturesMenuItem.Click += new System.EventHandler(this.FeaturesMenuItem_Click);
 			// 
 			// AboutMenuItem
 			// 
-			this.AboutMenuItem.Name = "AboutMenuItem";
-			this.AboutMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.AboutMenuItem.Text = "&About";
 			this.AboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
 			// 
@@ -2561,35 +1914,25 @@ namespace BizHawk.Client.EmuHawk
 			this.AmstradCPCNonSyncSettingsToolStripMenuItem,
 			this.AmstradCPCPokeMemoryToolStripMenuItem,
 			this.AmstradCPCMediaToolStripMenuItem});
-			this.amstradCPCToolStripMenuItem.Name = "amstradCPCToolStripMenuItem";
-			this.amstradCPCToolStripMenuItem.Size = new System.Drawing.Size(82, 17);
 			this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
 			// 
 			// amstradCPCCoreEmulationSettingsToolStripMenuItem
 			// 
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Name = "amstradCPCCoreEmulationSettingsToolStripMenuItem";
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Text = "Core Emulation Settings";
 			this.amstradCPCCoreEmulationSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcCoreEmulationSettingsMenuItem_Click);
 			// 
 			// AmstradCPCAudioSettingsToolStripMenuItem
 			// 
-			this.AmstradCPCAudioSettingsToolStripMenuItem.Name = "AmstradCPCAudioSettingsToolStripMenuItem";
-			this.AmstradCPCAudioSettingsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.AmstradCPCAudioSettingsToolStripMenuItem.Text = "Audio Settings";
 			this.AmstradCPCAudioSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcAudioSettingsMenuItem_Click);
 			// 
 			// AmstradCPCNonSyncSettingsToolStripMenuItem
 			// 
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Name = "AmstradCPCNonSyncSettingsToolStripMenuItem";
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Text = "Non-Sync Settings";
 			this.AmstradCPCNonSyncSettingsToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcNonSyncSettingsMenuItem_Click);
 			// 
 			// AmstradCPCPokeMemoryToolStripMenuItem
 			// 
-			this.AmstradCPCPokeMemoryToolStripMenuItem.Name = "AmstradCPCPokeMemoryToolStripMenuItem";
-			this.AmstradCPCPokeMemoryToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.AmstradCPCPokeMemoryToolStripMenuItem.Text = "POKE Memory";
 			this.AmstradCPCPokeMemoryToolStripMenuItem.Click += new System.EventHandler(this.AmstradCpcPokeMemoryMenuItem_Click);
 			// 
@@ -2598,8 +1941,6 @@ namespace BizHawk.Client.EmuHawk
 			this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.AmstradCPCTapesSubMenu,
 			this.AmstradCPCDisksSubMenu});
-			this.AmstradCPCMediaToolStripMenuItem.Name = "AmstradCPCMediaToolStripMenuItem";
-			this.AmstradCPCMediaToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
 			this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
 			this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
 			// 
@@ -2607,36 +1948,26 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.cpct1ToolStripMenuItem});
-			this.AmstradCPCTapesSubMenu.Name = "AmstradCPCTapesSubMenu";
-			this.AmstradCPCTapesSubMenu.Size = new System.Drawing.Size(103, 22);
 			this.AmstradCPCTapesSubMenu.Text = "Tapes";
 			this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
 			// 
 			// cpct1ToolStripMenuItem
 			// 
-			this.cpct1ToolStripMenuItem.Name = "cpct1ToolStripMenuItem";
-			this.cpct1ToolStripMenuItem.Size = new System.Drawing.Size(100, 22);
 			this.cpct1ToolStripMenuItem.Text = "cpct1";
 			// 
 			// AmstradCPCDisksSubMenu
 			// 
 			this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.cpcd1ToolStripMenuItem});
-			this.AmstradCPCDisksSubMenu.Name = "AmstradCPCDisksSubMenu";
-			this.AmstradCPCDisksSubMenu.Size = new System.Drawing.Size(103, 22);
 			this.AmstradCPCDisksSubMenu.Text = "Disks";
 			this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
 			// 
 			// cpcd1ToolStripMenuItem
 			// 
-			this.cpcd1ToolStripMenuItem.Name = "cpcd1ToolStripMenuItem";
-			this.cpcd1ToolStripMenuItem.Size = new System.Drawing.Size(102, 22);
 			this.cpcd1ToolStripMenuItem.Text = "cpcd1";
 			// 
 			// Atari7800HawkCoreMenuItem
 			// 
-			this.Atari7800HawkCoreMenuItem.Name = "Atari7800HawkCoreMenuItem";
-			this.Atari7800HawkCoreMenuItem.Size = new System.Drawing.Size(153, 22);
 			this.Atari7800HawkCoreMenuItem.Text = "Atari7800Hawk";
 			// 
 			// MainStatusBar
@@ -2682,11 +2013,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DumpStatusButton.Text = "No ROM loaded";
 			this.DumpStatusButton.Click += new System.EventHandler(this.DumpStatusButton_Click);
 			// 
-			// EmuStatus
-			// 
-			this.EmuStatus.Name = "EmuStatus";
-			this.EmuStatus.Size = new System.Drawing.Size(0, 17);
-			// 
 			// PlayRecordStatusButton
 			// 
 			this.PlayRecordStatusButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -2711,9 +2037,7 @@ namespace BizHawk.Client.EmuHawk
 			// RebootStatusBarIcon
 			// 
 			this.RebootStatusBarIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.RebootStatusBarIcon.Name = "RebootStatusBarIcon";
 			this.RebootStatusBarIcon.RightToLeft = System.Windows.Forms.RightToLeft.No;
-			this.RebootStatusBarIcon.Size = new System.Drawing.Size(0, 17);
 			this.RebootStatusBarIcon.Text = "Reboot";
 			this.RebootStatusBarIcon.ToolTipText = "A reboot of the core is needed for a setting change to take effect";
 			this.RebootStatusBarIcon.Click += new System.EventHandler(this.PowerMenuItem_Click);
@@ -2721,130 +2045,96 @@ namespace BizHawk.Client.EmuHawk
 			// AVIStatusLabel
 			// 
 			this.AVIStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.AVIStatusLabel.Name = "AVIStatusLabel";
-			this.AVIStatusLabel.Size = new System.Drawing.Size(0, 17);
 			this.AVIStatusLabel.Text = "AVI Capture";
 			// 
 			// LedLightStatusLabel
 			// 
-			this.LedLightStatusLabel.Name = "LedLightStatusLabel";
-			this.LedLightStatusLabel.Size = new System.Drawing.Size(0, 17);
 			this.LedLightStatusLabel.ToolTipText = "Disk Drive LED Light";
 			// 
 			// SaveSlotsStatusLabel
 			// 
 			this.SaveSlotsStatusLabel.BackColor = System.Drawing.SystemColors.Control;
-			this.SaveSlotsStatusLabel.Name = "SaveSlotsStatusLabel";
-			this.SaveSlotsStatusLabel.Size = new System.Drawing.Size(56, 17);
 			this.SaveSlotsStatusLabel.Text = "Save slots";
 			// 
 			// Slot1StatusButton
 			// 
-			this.Slot1StatusButton.Name = "Slot1StatusButton";
-			this.Slot1StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot1StatusButton.Text = "1";
 			this.Slot1StatusButton.ToolTipText = "Save slot 1";
 			this.Slot1StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot2StatusButton
 			// 
-			this.Slot2StatusButton.Name = "Slot2StatusButton";
-			this.Slot2StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot2StatusButton.Text = "2";
 			this.Slot2StatusButton.ToolTipText = "Save slot 2";
 			this.Slot2StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot3StatusButton
 			// 
-			this.Slot3StatusButton.Name = "Slot3StatusButton";
-			this.Slot3StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot3StatusButton.Text = "3";
 			this.Slot3StatusButton.ToolTipText = "Save slot 3";
 			this.Slot3StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot4StatusButton
 			// 
-			this.Slot4StatusButton.Name = "Slot4StatusButton";
-			this.Slot4StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot4StatusButton.Text = "4";
 			this.Slot4StatusButton.ToolTipText = "Save slot 4";
 			this.Slot4StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot5StatusButton
 			// 
-			this.Slot5StatusButton.Name = "Slot5StatusButton";
-			this.Slot5StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot5StatusButton.Text = "5";
 			this.Slot5StatusButton.ToolTipText = "Save slot 5";
 			this.Slot5StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot6StatusButton
 			// 
-			this.Slot6StatusButton.Name = "Slot6StatusButton";
-			this.Slot6StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot6StatusButton.Text = "6";
 			this.Slot6StatusButton.ToolTipText = "Save slot 6";
 			this.Slot6StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot7StatusButton
 			// 
-			this.Slot7StatusButton.Name = "Slot7StatusButton";
-			this.Slot7StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot7StatusButton.Text = "7";
 			this.Slot7StatusButton.ToolTipText = "Save slot 7";
 			this.Slot7StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot8StatusButton
 			// 
-			this.Slot8StatusButton.Name = "Slot8StatusButton";
-			this.Slot8StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot8StatusButton.Text = "8";
 			this.Slot8StatusButton.ToolTipText = "Save slot 8";
 			this.Slot8StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot9StatusButton
 			// 
-			this.Slot9StatusButton.Name = "Slot9StatusButton";
-			this.Slot9StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot9StatusButton.Text = "9";
 			this.Slot9StatusButton.ToolTipText = "Save slot 9";
 			this.Slot9StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// Slot0StatusButton
 			// 
-			this.Slot0StatusButton.Name = "Slot0StatusButton";
-			this.Slot0StatusButton.Size = new System.Drawing.Size(13, 17);
 			this.Slot0StatusButton.Text = "0";
 			this.Slot0StatusButton.ToolTipText = "Save slot 0";
 			this.Slot0StatusButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.SlotStatusButtons_MouseUp);
 			// 
 			// CheatStatusButton
 			// 
-			this.CheatStatusButton.Name = "CheatStatusButton";
-			this.CheatStatusButton.Size = new System.Drawing.Size(0, 17);
 			this.CheatStatusButton.Click += new System.EventHandler(this.FreezeStatus_Click);
 			// 
 			// KeyPriorityStatusLabel
 			// 
 			this.KeyPriorityStatusLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
 			this.KeyPriorityStatusLabel.Margin = new System.Windows.Forms.Padding(5, 3, 5, 0);
-			this.KeyPriorityStatusLabel.Name = "KeyPriorityStatusLabel";
-			this.KeyPriorityStatusLabel.Size = new System.Drawing.Size(0, 19);
 			this.KeyPriorityStatusLabel.Text = "KeyPriority";
 			this.KeyPriorityStatusLabel.Click += new System.EventHandler(this.KeyPriorityStatusLabel_Click);
 			// 
 			// CoreNameStatusBarButton
 			// 
-			this.CoreNameStatusBarButton.Name = "CoreNameStatusBarButton";
-			this.CoreNameStatusBarButton.Size = new System.Drawing.Size(50, 17);
 			this.CoreNameStatusBarButton.Text = "Neshawk";
 			// 
 			// ProfileFirstBootLabel
 			// 
 			this.ProfileFirstBootLabel.AutoToolTip = true;
 			this.ProfileFirstBootLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.ProfileFirstBootLabel.Name = "ProfileFirstBootLabel";
-			this.ProfileFirstBootLabel.Size = new System.Drawing.Size(0, 17);
 			this.ProfileFirstBootLabel.Text = "ProfileFirstBootLabel";
 			this.ProfileFirstBootLabel.ToolTipText = "Set up your profile before use";
 			this.ProfileFirstBootLabel.Visible = false;
@@ -2853,8 +2143,6 @@ namespace BizHawk.Client.EmuHawk
 			// LinkConnectStatusBarButton
 			// 
 			this.LinkConnectStatusBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-			this.LinkConnectStatusBarButton.Name = "LinkConnectStatusBarButton";
-			this.LinkConnectStatusBarButton.Size = new System.Drawing.Size(0, 17);
 			this.LinkConnectStatusBarButton.Text = "Link connection is currently enabled";
 			this.LinkConnectStatusBarButton.ToolTipText = "Link connection is currently enabled";
 			this.LinkConnectStatusBarButton.Click += new System.EventHandler(this.LinkConnectStatusBarButton_Click);
@@ -2863,8 +2151,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.UpdateNotification.IsLink = true;
 			this.UpdateNotification.LinkColor = System.Drawing.Color.Red;
-			this.UpdateNotification.Name = "UpdateNotification";
-			this.UpdateNotification.Size = new System.Drawing.Size(197, 17);
 			this.UpdateNotification.Spring = true;
 			this.UpdateNotification.Text = "New version available!";
 			this.UpdateNotification.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -2905,130 +2191,83 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// OpenRomContextMenuItem
 			// 
-			this.OpenRomContextMenuItem.Name = "OpenRomContextMenuItem";
-			this.OpenRomContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.OpenRomContextMenuItem.Text = "Open Rom";
 			this.OpenRomContextMenuItem.Click += new System.EventHandler(this.OpenRomMenuItem_Click);
 			// 
 			// LoadLastRomContextMenuItem
 			// 
-			this.LoadLastRomContextMenuItem.Name = "LoadLastRomContextMenuItem";
-			this.LoadLastRomContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.LoadLastRomContextMenuItem.Text = "Load Last ROM";
 			this.LoadLastRomContextMenuItem.Click += new System.EventHandler(this.LoadLastRomContextMenuItem_Click);
 			// 
 			// StopAVContextMenuItem
 			// 
-			this.StopAVContextMenuItem.Name = "StopAVContextMenuItem";
-			this.StopAVContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.StopAVContextMenuItem.Text = "Stop AVI/WAV";
 			this.StopAVContextMenuItem.Click += new System.EventHandler(this.StopAVMenuItem_Click);
 			// 
-			// ContextSeparator_AfterROM
-			// 
-			this.ContextSeparator_AfterROM.Name = "ContextSeparator_AfterROM";
-			this.ContextSeparator_AfterROM.Size = new System.Drawing.Size(198, 6);
-			// 
 			// RecordMovieContextMenuItem
 			// 
-			this.RecordMovieContextMenuItem.Name = "RecordMovieContextMenuItem";
-			this.RecordMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.RecordMovieContextMenuItem.Text = "Record Movie";
 			this.RecordMovieContextMenuItem.Click += new System.EventHandler(this.RecordMovieMenuItem_Click);
 			// 
 			// PlayMovieContextMenuItem
 			// 
-			this.PlayMovieContextMenuItem.Name = "PlayMovieContextMenuItem";
-			this.PlayMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.PlayMovieContextMenuItem.Text = "Play Movie";
 			this.PlayMovieContextMenuItem.Click += new System.EventHandler(this.PlayMovieMenuItem_Click);
 			// 
 			// RestartMovieContextMenuItem
 			// 
-			this.RestartMovieContextMenuItem.Name = "RestartMovieContextMenuItem";
-			this.RestartMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.RestartMovieContextMenuItem.Text = "Restart Movie";
 			this.RestartMovieContextMenuItem.Click += new System.EventHandler(this.PlayFromBeginningMenuItem_Click);
 			// 
 			// StopMovieContextMenuItem
 			// 
-			this.StopMovieContextMenuItem.Name = "StopMovieContextMenuItem";
-			this.StopMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.StopMovieContextMenuItem.Text = "Stop Movie";
 			this.StopMovieContextMenuItem.Click += new System.EventHandler(this.StopMovieMenuItem_Click);
 			// 
 			// LoadLastMovieContextMenuItem
 			// 
-			this.LoadLastMovieContextMenuItem.Name = "LoadLastMovieContextMenuItem";
-			this.LoadLastMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.LoadLastMovieContextMenuItem.Text = "Load Last Movie";
 			this.LoadLastMovieContextMenuItem.Click += new System.EventHandler(this.LoadLastMovieContextMenuItem_Click);
 			// 
 			// BackupMovieContextMenuItem
 			// 
-			this.BackupMovieContextMenuItem.Name = "BackupMovieContextMenuItem";
-			this.BackupMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.BackupMovieContextMenuItem.Text = "Backup Movie";
 			this.BackupMovieContextMenuItem.Click += new System.EventHandler(this.BackupMovieContextMenuItem_Click);
 			// 
 			// StopNoSaveContextMenuItem
 			// 
-			this.StopNoSaveContextMenuItem.Name = "StopNoSaveContextMenuItem";
-			this.StopNoSaveContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.StopNoSaveContextMenuItem.Text = "Stop Movie without Saving";
 			this.StopNoSaveContextMenuItem.Click += new System.EventHandler(this.StopMovieWithoutSavingMenuItem_Click);
 			// 
 			// ViewSubtitlesContextMenuItem
 			// 
-			this.ViewSubtitlesContextMenuItem.Name = "ViewSubtitlesContextMenuItem";
-			this.ViewSubtitlesContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ViewSubtitlesContextMenuItem.Text = "View Subtitles";
 			this.ViewSubtitlesContextMenuItem.Click += new System.EventHandler(this.ViewSubtitlesContextMenuItem_Click);
 			// 
 			// AddSubtitleContextMenuItem
 			// 
-			this.AddSubtitleContextMenuItem.Name = "AddSubtitleContextMenuItem";
-			this.AddSubtitleContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.AddSubtitleContextMenuItem.Text = "Add Subtitle";
 			this.AddSubtitleContextMenuItem.Click += new System.EventHandler(this.AddSubtitleContextMenuItem_Click);
 			// 
 			// ViewCommentsContextMenuItem
 			// 
-			this.ViewCommentsContextMenuItem.Name = "ViewCommentsContextMenuItem";
-			this.ViewCommentsContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ViewCommentsContextMenuItem.Text = "View Comments";
 			this.ViewCommentsContextMenuItem.Click += new System.EventHandler(this.ViewCommentsContextMenuItem_Click);
 			// 
 			// SaveMovieContextMenuItem
 			// 
-			this.SaveMovieContextMenuItem.Name = "SaveMovieContextMenuItem";
-			this.SaveMovieContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.SaveMovieContextMenuItem.Text = "Save Movie";
 			this.SaveMovieContextMenuItem.Click += new System.EventHandler(this.SaveMovieMenuItem_Click);
 			// 
 			// SaveMovieAsContextMenuItem
 			// 
-			this.SaveMovieAsContextMenuItem.Name = "SaveMovieAsContextMenuItem";
-			this.SaveMovieAsContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.SaveMovieAsContextMenuItem.Text = "Save Movie As...";
 			this.SaveMovieAsContextMenuItem.Click += new System.EventHandler(this.SaveMovieAsMenuItem_Click);
 			// 
-			// ContextSeparator_AfterMovie
-			// 
-			this.ContextSeparator_AfterMovie.Name = "ContextSeparator_AfterMovie";
-			this.ContextSeparator_AfterMovie.Size = new System.Drawing.Size(198, 6);
-			// 
 			// UndoSavestateContextMenuItem
 			// 
-			this.UndoSavestateContextMenuItem.Name = "UndoSavestateContextMenuItem";
-			this.UndoSavestateContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.UndoSavestateContextMenuItem.Text = "Undo Savestate";
 			this.UndoSavestateContextMenuItem.Click += new System.EventHandler(this.UndoSavestateContextMenuItem_Click);
-			// 
-			// ContextSeparator_AfterUndo
-			// 
-			this.ContextSeparator_AfterUndo.Name = "ContextSeparator_AfterUndo";
-			this.ContextSeparator_AfterUndo.Size = new System.Drawing.Size(198, 6);
 			// 
 			// ConfigContextMenuItem
 			// 
@@ -3047,136 +2286,90 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator30,
 			this.toolStripMenuItem66,
 			this.toolStripMenuItem67});
-			this.ConfigContextMenuItem.Name = "ConfigContextMenuItem";
-			this.ConfigContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ConfigContextMenuItem.Text = "Config";
 			// 
 			// toolStripMenuItem6
 			// 
-			this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-			this.toolStripMenuItem6.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem6.Text = "&Controllers...";
 			this.toolStripMenuItem6.Click += new System.EventHandler(this.ControllersMenuItem_Click);
 			// 
 			// toolStripMenuItem7
 			// 
-			this.toolStripMenuItem7.Name = "toolStripMenuItem7";
-			this.toolStripMenuItem7.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem7.Text = "&Hotkeys...";
 			this.toolStripMenuItem7.Click += new System.EventHandler(this.HotkeysMenuItem_Click);
 			// 
 			// toolStripMenuItem8
 			// 
-			this.toolStripMenuItem8.Name = "toolStripMenuItem8";
-			this.toolStripMenuItem8.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem8.Text = "Display...";
 			this.toolStripMenuItem8.Click += new System.EventHandler(this.DisplayConfigMenuItem_Click);
 			// 
 			// toolStripMenuItem9
 			// 
-			this.toolStripMenuItem9.Name = "toolStripMenuItem9";
-			this.toolStripMenuItem9.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem9.Text = "&Sound...";
 			this.toolStripMenuItem9.Click += new System.EventHandler(this.SoundMenuItem_Click);
 			// 
 			// toolStripMenuItem10
 			// 
-			this.toolStripMenuItem10.Name = "toolStripMenuItem10";
-			this.toolStripMenuItem10.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem10.Text = "Paths...";
 			this.toolStripMenuItem10.Click += new System.EventHandler(this.PathsMenuItem_Click);
 			// 
 			// toolStripMenuItem11
 			// 
-			this.toolStripMenuItem11.Name = "toolStripMenuItem11";
-			this.toolStripMenuItem11.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem11.Text = "&Firmwares...";
 			this.toolStripMenuItem11.Click += new System.EventHandler(this.FirmwaresMenuItem_Click);
 			// 
 			// toolStripMenuItem12
 			// 
-			this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-			this.toolStripMenuItem12.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem12.Text = "&Messages...";
 			this.toolStripMenuItem12.Click += new System.EventHandler(this.MessagesMenuItem_Click);
 			// 
 			// toolStripMenuItem13
 			// 
-			this.toolStripMenuItem13.Name = "toolStripMenuItem13";
-			this.toolStripMenuItem13.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem13.Text = "&Autofire...";
 			this.toolStripMenuItem13.Click += new System.EventHandler(this.AutofireMenuItem_Click);
 			// 
 			// toolStripMenuItem14
 			// 
-			this.toolStripMenuItem14.Name = "toolStripMenuItem14";
-			this.toolStripMenuItem14.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem14.Text = "&Rewind...";
 			this.toolStripMenuItem14.Click += new System.EventHandler(this.RewindOptionsMenuItem_Click);
 			// 
 			// toolStripMenuItem15
 			// 
-			this.toolStripMenuItem15.Name = "toolStripMenuItem15";
-			this.toolStripMenuItem15.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem15.Text = "File Extensions...";
 			this.toolStripMenuItem15.Click += new System.EventHandler(this.FileExtensionsMenuItem_Click);
 			// 
 			// customizeToolStripMenuItem
 			// 
-			this.customizeToolStripMenuItem.Name = "customizeToolStripMenuItem";
-			this.customizeToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.customizeToolStripMenuItem.Text = "Customize...";
 			this.customizeToolStripMenuItem.Click += new System.EventHandler(this.CustomizeMenuItem_Click);
 			// 
-			// toolStripSeparator30
-			// 
-			this.toolStripSeparator30.Name = "toolStripSeparator30";
-			this.toolStripSeparator30.Size = new System.Drawing.Size(154, 6);
-			// 
 			// toolStripMenuItem66
 			// 
-			this.toolStripMenuItem66.Name = "toolStripMenuItem66";
-			this.toolStripMenuItem66.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem66.Text = "Save Config";
 			this.toolStripMenuItem66.Click += new System.EventHandler(this.SaveConfigMenuItem_Click);
 			// 
 			// toolStripMenuItem67
 			// 
-			this.toolStripMenuItem67.Name = "toolStripMenuItem67";
-			this.toolStripMenuItem67.Size = new System.Drawing.Size(157, 22);
 			this.toolStripMenuItem67.Text = "Load Config";
 			this.toolStripMenuItem67.Click += new System.EventHandler(this.LoadConfigMenuItem_Click);
 			// 
 			// ScreenshotContextMenuItem
 			// 
-			this.ScreenshotContextMenuItem.Name = "ScreenshotContextMenuItem";
-			this.ScreenshotContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ScreenshotContextMenuItem.Text = "Screenshot";
 			this.ScreenshotContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
 			// 
 			// CloseRomContextMenuItem
 			// 
-			this.CloseRomContextMenuItem.Name = "CloseRomContextMenuItem";
-			this.CloseRomContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.CloseRomContextMenuItem.Text = "Close ROM";
 			this.CloseRomContextMenuItem.Click += new System.EventHandler(this.CloseRomMenuItem_Click);
 			// 
 			// ClearSRAMContextMenuItem
 			// 
-			this.ClearSRAMContextMenuItem.Name = "ClearSRAMContextMenuItem";
-			this.ClearSRAMContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ClearSRAMContextMenuItem.Text = "Close and Clear SRAM";
 			this.ClearSRAMContextMenuItem.Click += new System.EventHandler(this.ClearSramContextMenuItem_Click);
 			// 
-			// ShowMenuContextMenuSeparator
-			// 
-			this.ShowMenuContextMenuSeparator.Name = "ShowMenuContextMenuSeparator";
-			this.ShowMenuContextMenuSeparator.Size = new System.Drawing.Size(198, 6);
-			// 
 			// ShowMenuContextMenuItem
 			// 
-			this.ShowMenuContextMenuItem.Name = "ShowMenuContextMenuItem";
-			this.ShowMenuContextMenuItem.Size = new System.Drawing.Size(201, 22);
 			this.ShowMenuContextMenuItem.Text = "Show Menu";
 			this.ShowMenuContextMenuItem.Click += new System.EventHandler(this.ShowMenuContextMenuItem_Click);
 			// 
@@ -3192,22 +2385,16 @@ namespace BizHawk.Client.EmuHawk
 				this.NdsSettingsMenuItem,
 				this.NdsSyncSettingsMenuItem
 			});
-			this.NDSSubMenu.Name = "NDSSubMenu";
-			this.NDSSubMenu.Size = new System.Drawing.Size(42, 19);
 			this.NDSSubMenu.Text = "NDS";
 			this.NDSSubMenu.DropDownOpened += new System.EventHandler(this.NDSSubMenu_DropDownOpened);
 			// 
 			// NDSSyncSettingsMenuItem
 			// 
-			this.NdsSyncSettingsMenuItem.Name = "NdsSyncSettingsMenuItem";
-			this.NdsSyncSettingsMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.NdsSyncSettingsMenuItem.Text = "Sync Settings...";
 			this.NdsSyncSettingsMenuItem.Click += new System.EventHandler(this.NDSSyncSettingsMenuItem_Click);
 			// 
 			// NDSSettingsMenuItem
 			// 
-			this.NdsSettingsMenuItem.Name = "NdsSettingsMenuItem";
-			this.NdsSettingsMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.NdsSettingsMenuItem.Text = "Settings...";
 			this.NdsSettingsMenuItem.Click += new System.EventHandler(this.NDSSettingsMenuItem_Click);
 			// 
@@ -3239,360 +2426,360 @@ namespace BizHawk.Client.EmuHawk
 
 		#endregion
 
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem OpenRomMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveStateSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SaveState1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState8MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState9MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveState0MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadStateSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
-		private System.Windows.Forms.ToolStripMenuItem LoadState1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState8MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState9MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadState0MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EmulationSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ViewSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ConfigSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ToolsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem HelpSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PauseMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem RebootCoreMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SoftResetMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OnlineHelpMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AboutMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ControllersMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem HotkeysMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RamWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RamSearchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem HexEditorMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem WindowSizeSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem DisplayFPSMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayFrameCounterMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayInputMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayLagCounterMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LuaConsoleMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentRomSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem SaveSlotSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot8MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot9MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectSlot0MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PreviousSlotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NextSlotMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-		private System.Windows.Forms.ToolStripMenuItem SaveToCurrentSlotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadCurrentSlotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CloseRomMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripMenuItem SaveNamedStateMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem LoadNamedStateMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem x1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem x2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem x3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem x4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem x5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem mzMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MovieSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem RecentMovieSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem RecordMovieMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PlayMovieMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopMovieMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PlayFromBeginningMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
-		private System.Windows.Forms.ToolStripMenuItem SoundMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SpeedSkipSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem VsyncThrottleMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
-		private System.Windows.Forms.ToolStripMenuItem MinimizeSkippingMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NeverSkipMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem5;
-		private System.Windows.Forms.ToolStripMenuItem Speed50MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Speed75MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Speed100MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Speed150MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Speed200MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClockThrottleMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
-		private System.Windows.Forms.ToolStripMenuItem SaveConfigMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadConfigMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NESSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NESPPUViewerMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
-		private System.Windows.Forms.ToolStripMenuItem CheatsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NESNametableViewerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ToolBoxMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
-		private System.Windows.Forms.ToolStripMenuItem SwitchToFullscreenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenRomMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem1;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveStateSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState8MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState9MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveState0MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadStateSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem2;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState8MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState9MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadState0MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EmulationSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ConfigSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToolsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HelpSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PauseMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RebootCoreMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SoftResetMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OnlineHelpMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AboutMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ControllersMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HotkeysMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RamWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RamSearchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HexEditorMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WindowSizeSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayFPSMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayFrameCounterMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayInputMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayLagCounterMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LuaConsoleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentRomSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSlotSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot8MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot9MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectSlot0MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviousSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NextSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveToCurrentSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadCurrentSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseRomMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveNamedStateMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadNamedStateMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx x5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx mzMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentMovieSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecordMovieMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PlayMovieMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopMovieMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PlayFromBeginningMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator9;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SoundMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SpeedSkipSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VsyncThrottleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem3;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MinimizeSkippingMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NeverSkipMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem5;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed50MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed75MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed100MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed150MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed200MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClockThrottleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator10;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveConfigMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadConfigMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NESSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NESPPUViewerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator11;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CheatsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NESNametableViewerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToolBoxMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator12;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SwitchToFullscreenMenuItem;
 		private StatusStripEx MainStatusBar;
-		private System.Windows.Forms.ToolStripStatusLabel EmuStatus;
-		private System.Windows.Forms.ToolStripMenuItem MessagesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem TI83SubMenu;
-		private System.Windows.Forms.ToolStripMenuItem AutoloadKeypadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem KeypadMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
-		private System.Windows.Forms.ToolStripMenuItem PathsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
-		private System.Windows.Forms.ToolStripMenuItem ReadonlyMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator15;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator16;
-		private System.Windows.Forms.ToolStripMenuItem DisplayRerecordCountMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem TAStudioMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem4;
-		private System.Windows.Forms.ToolStripMenuItem DisplayStatusBarMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
-		private System.Windows.Forms.ToolStripMenuItem NESGraphicSettingsMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx EmuStatus;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MessagesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TI83SubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadKeypadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx KeypadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator13;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PathsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator14;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReadonlyMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator15;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator16;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayRerecordCountMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TAStudioMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem4;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayStatusBarMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator17;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NESGraphicSettingsMenuItem;
 		private System.Windows.Forms.ContextMenuStrip MainFormContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem OpenRomContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadLastRomContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextSeparator_AfterROM;
-		private System.Windows.Forms.ToolStripMenuItem RecordMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PlayMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadLastMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextSeparator_AfterMovie;
-		private System.Windows.Forms.ToolStripMenuItem AddSubtitleContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UndoSavestateContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextSeparator_AfterUndo;
-		private System.Windows.Forms.ToolStripMenuItem CloseRomContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem BackupMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutomaticallyBackupMoviesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenRomContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadLastRomContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextSeparator_AfterROM;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecordMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PlayMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadLastMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextSeparator_AfterMovie;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddSubtitleContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UndoSavestateContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextSeparator_AfterUndo;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseRomContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BackupMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutomaticallyBackupMoviesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopMovieContextMenuItem;
 		private System.Windows.Forms.ToolStripDropDownButton PauseStatusButton;
 		private System.Windows.Forms.ToolStripDropDownButton PlayRecordStatusButton;
 		private System.Windows.Forms.ToolStripDropDownButton DumpStatusButton;
-		private System.Windows.Forms.ToolStripMenuItem ViewSubtitlesContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewSubtitlesContextMenuItem;
 		private MenuStripEx MainformMenu;
-		private System.Windows.Forms.ToolStripMenuItem GBSubMenu;
-		private System.Windows.Forms.ToolStripStatusLabel SaveSlotsStatusLabel;
-		private System.Windows.Forms.ToolStripStatusLabel Slot1StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot2StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot3StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot4StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot5StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot6StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot7StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot8StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot9StatusButton;
-		private System.Windows.Forms.ToolStripStatusLabel Slot0StatusButton;
-		private System.Windows.Forms.ToolStripMenuItem ViewCommentsContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayLogWindowMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplaySubtitlesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AVSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ConfigAndRecordAVMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopAVIMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel AVIStatusLabel;
-		private System.Windows.Forms.ToolStripMenuItem RestartMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel CheatStatusButton;
-		private System.Windows.Forms.ToolStripMenuItem AutofireMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoloadLastSlotMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator21;
-		private System.Windows.Forms.ToolStripMenuItem ShowMenuContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ImportMoviesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ForumsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem A7800SubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NESSoundChannelsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SNESSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SnesGfxDebuggerMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator18;
-		private System.Windows.Forms.ToolStripMenuItem HardResetMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator19;
-		private System.Windows.Forms.ToolStripMenuItem CaptureOSDMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator20;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotCaptureOSDMenuItem1;
-		private System.Windows.Forms.ToolStripStatusLabel RebootStatusBarIcon;
-		private System.Windows.Forms.ToolStripMenuItem TraceLoggerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FDSControlsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMovieMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMovieContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VirtualPadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GBGPUViewerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GBPrinterViewerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AudioThrottleMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator27;
-		private System.Windows.Forms.ToolStripMenuItem VsyncEnabledMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator28;
-		private System.Windows.Forms.ToolStripMenuItem ColecoSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ColecoSkipBiosMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ColecoUseSGMMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ColecoControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel LedLightStatusLabel;
-		private System.Windows.Forms.ToolStripMenuItem KeyPrioritySubMenu;
-		private System.Windows.Forms.ToolStripMenuItem BothHkAndControllerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InputOverHkMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem HkOverInputMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel KeyPriorityStatusLabel;
-		private System.Windows.Forms.ToolStripMenuItem SnesOptionsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FullMovieLoadstatesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopNoSaveContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopMovieWithoutSavingMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator29;
-		private System.Windows.Forms.ToolStripMenuItem N64SubMenu;
-		private System.Windows.Forms.ToolStripMenuItem N64PluginSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ConfigContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RewindOptionsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FirmwaresMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadTIFileMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearSRAMContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ShowMenuContextMenuSeparator;
-		private System.Windows.Forms.ToolStripMenuItem StopAVContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FdsEjectDiskMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DGBSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem DGBsettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GenericCoreSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem A7800ControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem A7800FilterSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MovieSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CoresSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem BatchRunnerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayConfigMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem extensionsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel CoreNameStatusBarButton;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem6;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem7;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem8;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem9;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem10;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem11;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem12;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem13;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem14;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem15;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator30;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem66;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem67;
-		private System.Windows.Forms.ToolStripMenuItem ClientOptionsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem customizeToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem N64ControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GBcoreSettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NesControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator22;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator23;
-		private System.Windows.Forms.ToolStripMenuItem N64CircularAnalogRangeMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem paletteToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ProfilesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SynclessRecordingMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel ProfileFirstBootLabel;
-		private System.Windows.Forms.ToolStripMenuItem MovieEndSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem MovieEndFinishMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MovieEndRecordMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MovieEndStopMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MovieEndPauseMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotClientClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MupenStyleLagMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel LinkConnectStatusBarButton;
-		private System.Windows.Forms.ToolStripMenuItem N64ExpansionSlotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem BarcodeReaderMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FeaturesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DebuggerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PSXSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PSXOptionsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveRAMSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem FlushSaveRAMMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PSXDiscControlsMenuItem;
-		private System.Windows.Forms.ToolStripStatusLabel UpdateNotification;
-		private System.Windows.Forms.ToolStripMenuItem PSXControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MacroToolMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AppleSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem AppleDisksSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator31;
-		private System.Windows.Forms.ToolStripMenuItem MultiDiskBundlerFileMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MusicRipperMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator35;
-		private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem1;
-		private System.Windows.Forms.ToolStripMenuItem PSXHashDiscsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GBSubMenu;
+		private BizHawk.WinForms.Controls.StatusLabelEx SaveSlotsStatusLabel;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot1StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot2StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot3StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot4StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot5StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot6StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot7StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot8StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot9StatusButton;
+		private BizHawk.WinForms.Controls.StatusLabelEx Slot0StatusButton;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewCommentsContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayLogWindowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplaySubtitlesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AVSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ConfigAndRecordAVMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAVIMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx AVIStatusLabel;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestartMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx CheatStatusButton;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutofireMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadLastSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator21;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ShowMenuContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ImportMoviesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ForumsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx A7800SubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NESSoundChannelsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SNESSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SnesGfxDebuggerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator18;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HardResetMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator19;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CaptureOSDMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator20;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotCaptureOSDMenuItem1;
+		private BizHawk.WinForms.Controls.StatusLabelEx RebootStatusBarIcon;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TraceLoggerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FDSControlsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMovieMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMovieContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VirtualPadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GBGPUViewerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GBPrinterViewerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AudioThrottleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator27;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VsyncEnabledMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator28;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColecoSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColecoSkipBiosMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColecoUseSGMMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColecoControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx LedLightStatusLabel;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx KeyPrioritySubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BothHkAndControllerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InputOverHkMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HkOverInputMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx KeyPriorityStatusLabel;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SnesOptionsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FullMovieLoadstatesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopNoSaveContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopMovieWithoutSavingMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator29;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx N64SubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx N64PluginSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ConfigContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RewindOptionsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FirmwaresMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadTIFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearSRAMContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ShowMenuContextMenuSeparator;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAVContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FdsEjectDiskMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DGBSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DGBsettingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GenericCoreSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx A7800ControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx A7800FilterSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CoresSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BatchRunnerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayConfigMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx extensionsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx CoreNameStatusBarButton;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem6;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem7;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem8;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem9;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem10;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem11;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem12;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem13;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem14;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem15;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator30;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem66;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem67;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClientOptionsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx customizeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx N64ControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GBcoreSettingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NesControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator22;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator23;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx N64CircularAnalogRangeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx paletteToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ProfilesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SynclessRecordingMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx ProfileFirstBootLabel;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieEndSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieEndFinishMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieEndRecordMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieEndStopMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MovieEndPauseMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotClientClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MupenStyleLagMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx LinkConnectStatusBarButton;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx N64ExpansionSlotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BarcodeReaderMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FeaturesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DebuggerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXOptionsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveRAMSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FlushSaveRAMMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXDiscControlsMenuItem;
+		private BizHawk.WinForms.Controls.StatusLabelEx UpdateNotification;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MacroToolMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppleSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppleDisksSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator31;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MultiDiskBundlerFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MusicRipperMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator35;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx settingsToolStripMenuItem1;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PSXHashDiscsToolStripMenuItem;
 		private System.Windows.Forms.Timer timerMouseIdle;
-		private System.Windows.Forms.ToolStripMenuItem miUnthrottled;
-		private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem17;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip9MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Frameskip8MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Speed400MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem BasicBotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayMessagesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem C64SubMenu;
-		private System.Windows.Forms.ToolStripMenuItem C64SettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ExternalToolMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CodeDataLoggerMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenAdvancedMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GameSharkConverterMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem dummyExternalTool;
-		private System.Windows.Forms.ToolStripMenuItem RecordAVMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveConfigAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadConfigFromMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMovieAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMovieAsContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VSControlsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VSInsertCoinP1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VSInsertCoinP2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VSServiceSwitchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VSSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem IntvSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem IntVControllerSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SNESControllerConfigurationMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem C64DisksSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator36;
-		private System.Windows.Forms.ToolStripMenuItem Atari7800HawkCoreMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem zXSpectrumToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumControllerConfigurationMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumCoreEmulationSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumNonSyncSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumAudioSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumPokeMemoryMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumMediaMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumTapesSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumDisksSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem zxt1ToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem zxt2ToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ZXSpectrumExportSnapshotMenuItemMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem amstradCPCToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem amstradCPCCoreEmulationSettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCAudioSettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCPokeMemoryToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCMediaToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCTapesSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem cpct1ToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCDisksSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem cpcd1ToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AmstradCPCNonSyncSettingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NDSSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NdsSyncSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NdsSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miUnthrottled;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem17;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip9MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Frameskip8MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Speed400MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BasicBotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayMessagesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx C64SubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx C64SettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExternalToolMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CodeDataLoggerMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenAdvancedMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GameSharkConverterMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx dummyExternalTool;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecordAVMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveConfigAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadConfigFromMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMovieAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMovieAsContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VSControlsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VSInsertCoinP1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VSInsertCoinP2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VSServiceSwitchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VSSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx IntvSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx IntVControllerSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SNESControllerConfigurationMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx C64DisksSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator36;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Atari7800HawkCoreMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx zXSpectrumToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumControllerConfigurationMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumCoreEmulationSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumNonSyncSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumAudioSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumPokeMemoryMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumMediaMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumTapesSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumDisksSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx zxt1ToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx zxt2ToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ZXSpectrumExportSnapshotMenuItemMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx amstradCPCToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx amstradCPCCoreEmulationSettingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCAudioSettingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCPokeMemoryToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCMediaToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCTapesSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx cpct1ToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCDisksSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx cpcd1ToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AmstradCPCNonSyncSettingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NDSSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NdsSyncSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NdsSettingsMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig.Designer.cs
@@ -39,9 +39,9 @@
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.pictureBox1 = new System.Windows.Forms.PictureBox();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.loadDefaultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.testToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.loadDefaultsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.clearToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.label3 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -169,22 +169,16 @@
 			// 
 			// testToolStripMenuItem
 			// 
-			this.testToolStripMenuItem.Name = "testToolStripMenuItem";
-			this.testToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.testToolStripMenuItem.Text = "Save Defaults";
 			this.testToolStripMenuItem.Click += new System.EventHandler(this.ButtonSaveDefaults_Click);
 			// 
 			// loadDefaultsToolStripMenuItem
 			// 
-			this.loadDefaultsToolStripMenuItem.Name = "loadDefaultsToolStripMenuItem";
-			this.loadDefaultsToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.loadDefaultsToolStripMenuItem.Text = "Load Defaults";
 			this.loadDefaultsToolStripMenuItem.Click += new System.EventHandler(this.ButtonLoadDefaults_Click);
 			// 
 			// clearToolStripMenuItem
 			// 
-			this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
-			this.clearToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.clearToolStripMenuItem.Text = "Clear";
 			this.clearToolStripMenuItem.Click += new System.EventHandler(this.ClearBtn_Click);
 			// 
@@ -275,9 +269,9 @@
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
 		private System.Windows.Forms.ToolTip toolTip1;
 		private MenuButton btnMisc;
-				private System.Windows.Forms.ToolStripMenuItem testToolStripMenuItem;
-				private System.Windows.Forms.ToolStripMenuItem loadDefaultsToolStripMenuItem;
-				private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx testToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx loadDefaultsToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearToolStripMenuItem;
 				private BizHawk.WinForms.Controls.LocLabelEx label3;
 				private BizHawk.WinForms.Controls.LocLabelEx label2;
 				private BizHawk.WinForms.Controls.LocLabelEx label38;

--- a/src/BizHawk.Client.EmuHawk/config/ControllerConfig/ControllerConfigPanel.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ControllerConfig/ControllerConfigPanel.Designer.cs
@@ -30,7 +30,7 @@
 		{
 			this.components = new System.ComponentModel.Container();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.clearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.clearToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.contextMenuStrip1.SuspendLayout();
 			this.SuspendLayout();
 			// 
@@ -43,8 +43,6 @@
 			// 
 			// clearToolStripMenuItem
 			// 
-			this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
-			this.clearToolStripMenuItem.Size = new System.Drawing.Size(99, 22);
 			this.clearToolStripMenuItem.Text = "&Clear";
 			this.clearToolStripMenuItem.Click += new System.EventHandler(this.ClearToolStripMenuItem_Click);
 			// 
@@ -62,6 +60,6 @@
 		#endregion
 
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem clearToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
@@ -42,10 +42,10 @@ namespace BizHawk.Client.EmuHawk
 			this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.lvFirmwaresContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.tsmiSetCustomization = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiClearCustomization = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiInfo = new System.Windows.Forms.ToolStripMenuItem();
-			this.tsmiCopy = new System.Windows.Forms.ToolStripMenuItem();
+			this.tsmiSetCustomization = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.tsmiClearCustomization = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.tsmiInfo = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.tsmiCopy = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.panel1 = new System.Windows.Forms.Panel();
 			this.toolStrip1 = new ToolStripEx();
 			this.tbbGroup = new System.Windows.Forms.ToolStripButton();
@@ -156,29 +156,21 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// tsmiSetCustomization
 			// 
-			this.tsmiSetCustomization.Name = "tsmiSetCustomization";
-			this.tsmiSetCustomization.Size = new System.Drawing.Size(181, 22);
 			this.tsmiSetCustomization.Text = "&Set Customization";
 			this.tsmiSetCustomization.Click += new System.EventHandler(this.tsmiSetCustomization_Click);
 			// 
 			// tsmiClearCustomization
 			// 
-			this.tsmiClearCustomization.Name = "tsmiClearCustomization";
-			this.tsmiClearCustomization.Size = new System.Drawing.Size(181, 22);
 			this.tsmiClearCustomization.Text = "C&lear Customization";
 			this.tsmiClearCustomization.Click += new System.EventHandler(this.tsmiClearCustomization_Click);
 			// 
 			// tsmiInfo
 			// 
-			this.tsmiInfo.Name = "tsmiInfo";
-			this.tsmiInfo.Size = new System.Drawing.Size(181, 22);
 			this.tsmiInfo.Text = "&Info";
 			this.tsmiInfo.Click += new System.EventHandler(this.tsmiInfo_Click);
 			// 
 			// tsmiCopy
 			// 
-			this.tsmiCopy.Name = "tsmiCopy";
-			this.tsmiCopy.Size = new System.Drawing.Size(181, 22);
 			this.tsmiCopy.Text = "&Copy";
 			this.tsmiCopy.Click += new System.EventHandler(this.tsmiCopy_Click);
 			// 
@@ -391,10 +383,10 @@ namespace BizHawk.Client.EmuHawk
 				private System.Windows.Forms.ColumnHeader columnHeader3;
 				private System.Windows.Forms.ColumnHeader columnHeader7;
 				private System.Windows.Forms.ContextMenuStrip lvFirmwaresContextMenuStrip;
-				private System.Windows.Forms.ToolStripMenuItem tsmiSetCustomization;
-				private System.Windows.Forms.ToolStripMenuItem tsmiClearCustomization;
-				private System.Windows.Forms.ToolStripMenuItem tsmiInfo;
-				private System.Windows.Forms.ToolStripMenuItem tsmiCopy;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiSetCustomization;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiClearCustomization;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiInfo;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiCopy;
 				private System.Windows.Forms.Panel panel2;
 				private System.Windows.Forms.LinkLabel linkBasePath;
 				private BizHawk.WinForms.Controls.LocLabelEx label1;

--- a/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
@@ -49,12 +49,12 @@ namespace BizHawk.Client.EmuHawk
 			this.panel1 = new System.Windows.Forms.Panel();
 			this.toolStrip1 = new ToolStripEx();
 			this.tbbGroup = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.tbbScan = new System.Windows.Forms.ToolStripButton();
 			this.tbbOrganize = new System.Windows.Forms.ToolStripButton();
 			this.tbbImport = new System.Windows.Forms.ToolStripButton();
 			this.tbbClose = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.tbbCloseReload = new System.Windows.Forms.ToolStripButton();
 			this.tbbOpenFolder = new System.Windows.Forms.ToolStripButton();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -212,11 +212,6 @@ namespace BizHawk.Client.EmuHawk
 			this.tbbGroup.Text = "Group";
 			this.tbbGroup.Click += new System.EventHandler(this.tbbGroup_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			// 
 			// tbbScan
 			// 
 			this.tbbScan.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
@@ -254,12 +249,7 @@ namespace BizHawk.Client.EmuHawk
 			this.tbbClose.Size = new System.Drawing.Size(40, 22);
 			this.tbbClose.Text = "Close";
 			this.tbbClose.Click += new System.EventHandler(this.tbbClose_Click);
-			// 
-			// toolStripSeparator1
-			// 
 			this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
 			this.toolStripSeparator1.Visible = false;
 			// 
 			// tbbCloseReload
@@ -373,7 +363,7 @@ namespace BizHawk.Client.EmuHawk
 				private System.Windows.Forms.Panel panel1;
 				private ToolStripEx toolStrip1;
 				private System.Windows.Forms.ToolStripButton tbbGroup;
-				private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+				private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 				private System.Windows.Forms.ToolStripButton tbbScan;
 				private System.Windows.Forms.ToolStripButton tbbOrganize;
 				private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
@@ -394,7 +384,7 @@ namespace BizHawk.Client.EmuHawk
 				private System.Windows.Forms.ColumnHeader columnHeader8;
 				private System.Windows.Forms.ToolStripButton tbbClose;
 				private System.Windows.Forms.ToolStripButton tbbCloseReload;
-				private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+				private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
         private System.Windows.Forms.ToolStripButton tbbOpenFolder;
     }

--- a/src/BizHawk.Client.EmuHawk/config/FirmwaresConfigInfo.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwaresConfigInfo.Designer.cs
@@ -43,7 +43,7 @@
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.lblFirmware = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.lvmiOptionsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.tsmiOptionsCopy = new System.Windows.Forms.ToolStripMenuItem();
+			this.tsmiOptionsCopy = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.tableLayoutPanel1.SuspendLayout();
 			this.flowLayoutPanel1.SuspendLayout();
@@ -173,8 +173,6 @@
 			// 
 			// tsmiOptionsCopy
 			// 
-			this.tsmiOptionsCopy.Name = "tsmiOptionsCopy";
-			this.tsmiOptionsCopy.Size = new System.Drawing.Size(99, 22);
 			this.tsmiOptionsCopy.Text = "&Copy";
 			this.tsmiOptionsCopy.Click += new System.EventHandler(this.TsmiOptionsCopy_Click);
 			// 
@@ -212,7 +210,7 @@
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
 		public BizHawk.WinForms.Controls.LocLabelEx lblFirmware;
 		private System.Windows.Forms.ContextMenuStrip lvmiOptionsContextMenuStrip;
-		private System.Windows.Forms.ToolStripMenuItem tsmiOptionsCopy;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiOptionsCopy;
 		private System.Windows.Forms.ColumnHeader colInfo;
 		private System.Windows.Forms.ImageList imageList1;
 		private System.Windows.Forms.ColumnHeader colSize;

--- a/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.Designer.cs
@@ -45,7 +45,7 @@
 			this.clearAllToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.clearCurrentTabToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.restoreDefaultsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.HotkeyTabControl.SuspendLayout();
 			this.clearBtnContextMenu.SuspendLayout();
 			this.SuspendLayout();
@@ -184,11 +184,6 @@
 			this.restoreDefaultsToolStripMenuItem.Text = "Restore Defaults";
 			this.restoreDefaultsToolStripMenuItem.Click += new System.EventHandler(this.RestoreDefaultsToolStripMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(164, 6);
-			// 
 			// HotkeyConfig
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -235,6 +230,6 @@
 				private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearAllToolStripMenuItem;
 				private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearCurrentTabToolStripMenuItem;
 				private BizHawk.WinForms.Controls.ToolStripMenuItemEx restoreDefaultsToolStripMenuItem;
-				private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+				private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/HotkeyConfig.Designer.cs
@@ -42,9 +42,9 @@
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.MiscButton = new BizHawk.Client.EmuHawk.MenuButton();
 			this.clearBtnContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.clearAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.clearCurrentTabToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.restoreDefaultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.clearAllToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.clearCurrentTabToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.restoreDefaultsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
 			this.HotkeyTabControl.SuspendLayout();
 			this.clearBtnContextMenu.SuspendLayout();
@@ -171,22 +171,16 @@
 			// 
 			// clearAllToolStripMenuItem
 			// 
-			this.clearAllToolStripMenuItem.Name = "clearAllToolStripMenuItem";
-			this.clearAllToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.clearAllToolStripMenuItem.Text = "Clear All";
 			this.clearAllToolStripMenuItem.Click += new System.EventHandler(this.ClearAllToolStripMenuItem_Click);
 			// 
 			// clearCurrentTabToolStripMenuItem
 			// 
-			this.clearCurrentTabToolStripMenuItem.Name = "clearCurrentTabToolStripMenuItem";
-			this.clearCurrentTabToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.clearCurrentTabToolStripMenuItem.Text = "Clear Current Tab";
 			this.clearCurrentTabToolStripMenuItem.Click += new System.EventHandler(this.ClearCurrentTabToolStripMenuItem_Click);
 			// 
 			// restoreDefaultsToolStripMenuItem
 			// 
-			this.restoreDefaultsToolStripMenuItem.Name = "restoreDefaultsToolStripMenuItem";
-			this.restoreDefaultsToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.restoreDefaultsToolStripMenuItem.Text = "Restore Defaults";
 			this.restoreDefaultsToolStripMenuItem.Click += new System.EventHandler(this.RestoreDefaultsToolStripMenuItem_Click);
 			// 
@@ -238,9 +232,9 @@
 				private System.Windows.Forms.ToolTip toolTip1;
 				private MenuButton MiscButton;
 				private System.Windows.Forms.ContextMenuStrip clearBtnContextMenu;
-				private System.Windows.Forms.ToolStripMenuItem clearAllToolStripMenuItem;
-				private System.Windows.Forms.ToolStripMenuItem clearCurrentTabToolStripMenuItem;
-				private System.Windows.Forms.ToolStripMenuItem restoreDefaultsToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearAllToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearCurrentTabToolStripMenuItem;
+				private BizHawk.WinForms.Controls.ToolStripMenuItemEx restoreDefaultsToolStripMenuItem;
 				private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/movie/PlayMovie.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/PlayMovie.Designer.cs
@@ -45,7 +45,7 @@
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.MatchHashCheckBox = new System.Windows.Forms.CheckBox();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.editToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StopOnFrameCheckbox = new System.Windows.Forms.CheckBox();
 			this.StopOnFrameTextBox = new BizHawk.Client.EmuHawk.WatchValueBox();
 			this.MovieView = new System.Windows.Forms.ListView();
@@ -225,8 +225,6 @@
 			// 
 			// editToolStripMenuItem
 			// 
-			this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-			this.editToolStripMenuItem.Size = new System.Drawing.Size(92, 22);
 			this.editToolStripMenuItem.Text = "&Edit";
 			this.editToolStripMenuItem.Click += new System.EventHandler(this.EditMenuItem_Click);
 			// 
@@ -387,7 +385,7 @@
 		private System.Windows.Forms.ToolTip toolTip1;
 		private System.Windows.Forms.CheckBox MatchHashCheckBox;
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx editToolStripMenuItem;
 		private System.Windows.Forms.CheckBox StopOnFrameCheckbox;
 		private WatchValueBox StopOnFrameTextBox;
 		private System.Windows.Forms.CheckBox LastFrameCheckbox;

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -32,25 +32,25 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.BotMenu = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OptionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.MemoryDomainsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MemoryDomainsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.DataSizeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this._1ByteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this._2ByteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this._4ByteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BigEndianMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DataSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this._1ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this._2ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this._4ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.TurboWhileBottingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.TurboWhileBottingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RunBtn = new System.Windows.Forms.Button();
 			this.BotStatusStrip = new System.Windows.Forms.StatusStrip();
 			this.BotStatusButton = new System.Windows.Forms.ToolStripStatusLabel();
@@ -120,9 +120,9 @@ namespace BizHawk.Client.EmuHawk
 			this.InvisibleEmulationCheckBox = new System.Windows.Forms.CheckBox();
 			this.panel2 = new System.Windows.Forms.Panel();
 			this.StatsContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.ClearStatsContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearStatsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-			this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.helpToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BotMenu.SuspendLayout();
 			this.BotStatusStrip.SuspendLayout();
 			this.ControlsBox.SuspendLayout();
@@ -163,41 +163,31 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSubMenu,
 			this.toolStripSeparator1,
 			this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// NewMenuItem
 			// 
-			this.NewMenuItem.Name = "NewMenuItem";
 			this.NewMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.NewMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.NewMenuItem.Text = "&New";
 			this.NewMenuItem.Click += new System.EventHandler(this.NewMenuItem_Click);
 			// 
 			// OpenMenuItem
 			// 
-			this.OpenMenuItem.Name = "OpenMenuItem";
 			this.OpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.OpenMenuItem.Text = "&Open...";
 			this.OpenMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
 			// SaveMenuItem
 			// 
-			this.SaveMenuItem.Name = "SaveMenuItem";
 			this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveMenuItem.Text = "&Save";
 			this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
 			// SaveAsMenuItem
 			// 
-			this.SaveAsMenuItem.Name = "SaveAsMenuItem";
 			this.SaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
 			| System.Windows.Forms.Keys.S)));
-			this.SaveAsMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveAsMenuItem.Text = "Save &As...";
 			this.SaveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItem_Click);
 			// 
@@ -205,8 +195,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator2});
-			this.RecentSubMenu.Name = "RecentSubMenu";
-			this.RecentSubMenu.Size = new System.Drawing.Size(195, 22);
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
@@ -222,9 +210,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -236,8 +222,6 @@ namespace BizHawk.Client.EmuHawk
 			this.BigEndianMenuItem,
 			this.toolStripSeparator4,
 			this.TurboWhileBottingMenuItem});
-			this.OptionsSubMenu.Name = "OptionsSubMenu";
-			this.OptionsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.OptionsSubMenu.Text = "&Options";
 			this.OptionsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
@@ -245,8 +229,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.MemoryDomainsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
 			this.toolStripSeparator3});
-			this.MemoryDomainsMenuItem.Name = "MemoryDomainsMenuItem";
-			this.MemoryDomainsMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.MemoryDomainsMenuItem.Text = "Memory Domains";
 			this.MemoryDomainsMenuItem.DropDownOpened += new System.EventHandler(this.MemoryDomainsMenuItem_DropDownOpened);
 			// 
@@ -261,36 +243,26 @@ namespace BizHawk.Client.EmuHawk
 			this._1ByteMenuItem,
 			this._2ByteMenuItem,
 			this._4ByteMenuItem});
-			this.DataSizeMenuItem.Name = "DataSizeMenuItem";
-			this.DataSizeMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.DataSizeMenuItem.Text = "Data Size";
 			this.DataSizeMenuItem.DropDownOpened += new System.EventHandler(this.DataSizeMenuItem_DropDownOpened);
 			// 
 			// _1ByteMenuItem
 			// 
-			this._1ByteMenuItem.Name = "_1ByteMenuItem";
-			this._1ByteMenuItem.Size = new System.Drawing.Size(111, 22);
 			this._1ByteMenuItem.Text = "1 Byte";
 			this._1ByteMenuItem.Click += new System.EventHandler(this._1ByteMenuItem_Click);
 			// 
 			// _2ByteMenuItem
 			// 
-			this._2ByteMenuItem.Name = "_2ByteMenuItem";
-			this._2ByteMenuItem.Size = new System.Drawing.Size(111, 22);
 			this._2ByteMenuItem.Text = "2 Bytes";
 			this._2ByteMenuItem.Click += new System.EventHandler(this._2ByteMenuItem_Click);
 			// 
 			// _4ByteMenuItem
 			// 
-			this._4ByteMenuItem.Name = "_4ByteMenuItem";
-			this._4ByteMenuItem.Size = new System.Drawing.Size(111, 22);
 			this._4ByteMenuItem.Text = "4 Bytes";
 			this._4ByteMenuItem.Click += new System.EventHandler(this._4ByteMenuItem_Click);
 			// 
 			// BigEndianMenuItem
 			// 
-			this.BigEndianMenuItem.Name = "BigEndianMenuItem";
-			this.BigEndianMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.BigEndianMenuItem.Text = "Big Endian";
 			this.BigEndianMenuItem.Click += new System.EventHandler(this.BigEndianMenuItem_Click);
 			// 
@@ -301,8 +273,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// TurboWhileBottingMenuItem
 			// 
-			this.TurboWhileBottingMenuItem.Name = "TurboWhileBottingMenuItem";
-			this.TurboWhileBottingMenuItem.Size = new System.Drawing.Size(181, 22);
 			this.TurboWhileBottingMenuItem.Text = "Turbo While Botting";
 			this.TurboWhileBottingMenuItem.Click += new System.EventHandler(this.TurboWhileBottingMenuItem_Click);
 			// 
@@ -1069,15 +1039,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearStatsContextMenuItem
 			// 
-			this.ClearStatsContextMenuItem.Name = "ClearStatsContextMenuItem";
-			this.ClearStatsContextMenuItem.Size = new System.Drawing.Size(101, 22);
 			this.ClearStatsContextMenuItem.Text = "&Clear";
 			this.ClearStatsContextMenuItem.Click += new System.EventHandler(this.ClearStatsContextMenuItem_Click);
 			// 
 			// helpToolStripMenuItem
 			// 
-			this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-			this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
 			this.helpToolStripMenuItem.Text = "Help";
 			this.helpToolStripMenuItem.Click += new System.EventHandler(this.HelpToolStripMenuItem_Click);
 			// 
@@ -1135,12 +1101,12 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx BotMenu;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.Button RunBtn;
-		private System.Windows.Forms.ToolStripMenuItem OpenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 		private System.Windows.Forms.StatusStrip BotStatusStrip;
 		private System.Windows.Forms.GroupBox ControlsBox;
@@ -1150,7 +1116,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
 		private BizHawk.WinForms.Controls.LocLabelEx AttemptsLabel;
 		private BizHawk.WinForms.Controls.LocLabelEx FramesLabel;
-		private System.Windows.Forms.ToolStripMenuItem OptionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
 		private System.Windows.Forms.GroupBox GoalGroupBox;
 		private BizHawk.WinForms.Controls.LocLabelEx label6;
 		private HexTextBox TieBreaker1Box;
@@ -1177,25 +1143,25 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label17;
 		private BizHawk.WinForms.Controls.LocLabelEx BestAttemptLogLabel;
 		private System.Windows.Forms.Button ClearBestButton;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem NewMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewMenuItem;
 		private System.Windows.Forms.Button PlayBestButton;
 		private System.Windows.Forms.ToolStripStatusLabel MessageLabel;
 		private System.Windows.Forms.GroupBox ControlGroupBox;
-		private System.Windows.Forms.ToolStripMenuItem TurboWhileBottingMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MemoryDomainsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TurboWhileBottingMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
 		private System.Windows.Forms.Panel panel2;
 		private System.Windows.Forms.ContextMenuStrip StatsContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem ClearStatsContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearStatsContextMenuItem;
 		private System.Windows.Forms.ToolStripStatusLabel BotStatusButton;
-		private System.Windows.Forms.ToolStripMenuItem BigEndianMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BigEndianMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem DataSizeMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem _1ByteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem _2ByteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem _4ByteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx _1ByteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx _2ByteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx _4ByteMenuItem;
         private System.Windows.Forms.ComboBox Tiebreak2Operator;
         private System.Windows.Forms.ComboBox Tiebreak1Operator;
 		private System.Windows.Forms.Panel panel6;
@@ -1224,7 +1190,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx maximizeLabeltext;
 		private System.Windows.Forms.Button btnCopyBestInput;
 		private System.Windows.Forms.ToolTip toolTip1;
-		private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx helpToolStripMenuItem;
 		private System.Windows.Forms.CheckBox InvisibleEmulationCheckBox;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -38,18 +38,18 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemoryDomainsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DataSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this._1ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this._2ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this._4ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.TurboWhileBottingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RunBtn = new System.Windows.Forms.Button();
 			this.BotStatusStrip = new System.Windows.Forms.StatusStrip();
@@ -198,16 +198,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(192, 6);
-			// 
 			// ExitMenuItem
 			// 
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
@@ -231,11 +221,6 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator3});
 			this.MemoryDomainsMenuItem.Text = "Memory Domains";
 			this.MemoryDomainsMenuItem.DropDownOpened += new System.EventHandler(this.MemoryDomainsMenuItem_DropDownOpened);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(57, 6);
 			// 
 			// DataSizeMenuItem
 			// 
@@ -265,11 +250,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.BigEndianMenuItem.Text = "Big Endian";
 			this.BigEndianMenuItem.Click += new System.EventHandler(this.BigEndianMenuItem_Click);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(178, 6);
 			// 
 			// TurboWhileBottingMenuItem
 			// 
@@ -1107,7 +1087,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private System.Windows.Forms.StatusStrip BotStatusStrip;
 		private System.Windows.Forms.GroupBox ControlsBox;
 		private System.Windows.Forms.Panel ControlProbabilityPanel;
@@ -1144,20 +1124,20 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx BestAttemptLogLabel;
 		private System.Windows.Forms.Button ClearBestButton;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewMenuItem;
 		private System.Windows.Forms.Button PlayBestButton;
 		private System.Windows.Forms.ToolStripStatusLabel MessageLabel;
 		private System.Windows.Forms.GroupBox ControlGroupBox;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TurboWhileBottingMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private System.Windows.Forms.Panel panel2;
 		private System.Windows.Forms.ContextMenuStrip StatsContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearStatsContextMenuItem;
 		private System.Windows.Forms.ToolStripStatusLabel BotStatusButton;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BigEndianMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx _1ByteMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx _2ByteMenuItem;

--- a/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
@@ -41,17 +41,17 @@ namespace BizHawk.Client.EmuHawk
 			this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.miAutoStart = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.miAutoSave = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ClearMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisassembleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStrip1 = new ToolStripEx();
 			this.tsbLoggingActive = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.tsbViewUpdate = new System.Windows.Forms.ToolStripButton();
 			this.tsbViewStyle = new System.Windows.Forms.ToolStripComboBox();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.tsbExportText = new System.Windows.Forms.ToolStripButton();
 			this.lvCDL = new InputRoll();
 			this.miAutoResume = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -138,11 +138,6 @@ namespace BizHawk.Client.EmuHawk
 			this.miAutoSave.Text = "Auto-Save";
 			this.miAutoSave.Click += new System.EventHandler(this.miAutoSave_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(190, 6);
-			// 
 			// ClearMenuItem
 			// 
 			this.ClearMenuItem.Text = "&Clear";
@@ -152,11 +147,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.DisassembleMenuItem.Text = "&Disassemble...";
 			this.DisassembleMenuItem.Click += new System.EventHandler(this.DisassembleMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(190, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -187,11 +177,6 @@ namespace BizHawk.Client.EmuHawk
 			this.tsbLoggingActive.Text = "Active";
 			this.tsbLoggingActive.CheckedChanged += new System.EventHandler(this.tsbLoggingActive_CheckedChanged);
 			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
-			// 
 			// tsbViewUpdate
 			// 
 			this.tsbViewUpdate.Checked = true;
@@ -213,11 +198,6 @@ namespace BizHawk.Client.EmuHawk
 			this.tsbViewStyle.Name = "tsbViewStyle";
 			this.tsbViewStyle.Size = new System.Drawing.Size(121, 25);
 			this.tsbViewStyle.SelectedIndexChanged += new System.EventHandler(this.tsbViewStyle_SelectedIndexChanged);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
 			// 
 			// tsbExportText
 			// 
@@ -283,18 +263,18 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisassembleMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
 		private System.Windows.Forms.ToolStripButton tsbLoggingActive;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private System.Windows.Forms.ToolStripButton tsbViewUpdate;
 		private System.Windows.Forms.ToolStripComboBox tsbViewStyle;
 		private InputRoll lvCDL;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private System.Windows.Forms.ToolStripButton tsbExportText;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miAutoStart;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miAutoSave;

--- a/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
@@ -31,21 +31,21 @@ namespace BizHawk.Client.EmuHawk
 		private void InitializeComponent()
 		{
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AppendMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.noneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.miAutoStart = new System.Windows.Forms.ToolStripMenuItem();
-			this.miAutoSave = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppendMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.miAutoStart = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.miAutoSave = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ClearMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisassembleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisassembleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStrip1 = new ToolStripEx();
 			this.tsbLoggingActive = new System.Windows.Forms.ToolStripButton();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
@@ -54,7 +54,7 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
 			this.tsbExportText = new System.Windows.Forms.ToolStripButton();
 			this.lvCDL = new InputRoll();
-			this.miAutoResume = new System.Windows.Forms.ToolStripMenuItem();
+			this.miAutoResume = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.menuStrip1.SuspendLayout();
 			this.toolStrip1.SuspendLayout();
 			this.SuspendLayout();
@@ -84,48 +84,36 @@ namespace BizHawk.Client.EmuHawk
             this.DisassembleMenuItem,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// NewMenuItem
 			// 
-			this.NewMenuItem.Name = "NewMenuItem";
 			this.NewMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.NewMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.NewMenuItem.Text = "&New";
 			this.NewMenuItem.Click += new System.EventHandler(this.NewMenuItem_Click);
 			// 
 			// OpenMenuItem
 			// 
-			this.OpenMenuItem.Name = "OpenMenuItem";
 			this.OpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.OpenMenuItem.Text = "&Open...";
 			this.OpenMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
 			// SaveMenuItem
 			// 
-			this.SaveMenuItem.Name = "SaveMenuItem";
 			this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.SaveMenuItem.Text = "&Save";
 			this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
 			// SaveAsMenuItem
 			// 
-			this.SaveAsMenuItem.Name = "SaveAsMenuItem";
 			this.SaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveAsMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.SaveAsMenuItem.Text = "&Save As...";
 			this.SaveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItem_Click);
 			// 
 			// AppendMenuItem
 			// 
-			this.AppendMenuItem.Name = "AppendMenuItem";
-			this.AppendMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.AppendMenuItem.Text = "&Append File...";
 			this.AppendMenuItem.Click += new System.EventHandler(this.AppendMenuItem_Click);
 			// 
@@ -133,28 +121,20 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.noneToolStripMenuItem});
-			this.RecentSubMenu.Name = "RecentSubMenu";
-			this.RecentSubMenu.Size = new System.Drawing.Size(193, 22);
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
 			// noneToolStripMenuItem
 			// 
-			this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
-			this.noneToolStripMenuItem.Size = new System.Drawing.Size(99, 22);
 			this.noneToolStripMenuItem.Text = "None";
 			// 
 			// miAutoStart
 			// 
-			this.miAutoStart.Name = "miAutoStart";
-			this.miAutoStart.Size = new System.Drawing.Size(193, 22);
 			this.miAutoStart.Text = "Auto-Start";
 			this.miAutoStart.Click += new System.EventHandler(this.miAutoStart_Click);
 			// 
 			// miAutoSave
 			// 
-			this.miAutoSave.Name = "miAutoSave";
-			this.miAutoSave.Size = new System.Drawing.Size(193, 22);
 			this.miAutoSave.Text = "Auto-Save";
 			this.miAutoSave.Click += new System.EventHandler(this.miAutoSave_Click);
 			// 
@@ -165,15 +145,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearMenuItem
 			// 
-			this.ClearMenuItem.Name = "ClearMenuItem";
-			this.ClearMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.ClearMenuItem.Text = "&Clear";
 			this.ClearMenuItem.Click += new System.EventHandler(this.ClearMenuItem_Click);
 			// 
 			// DisassembleMenuItem
 			// 
-			this.DisassembleMenuItem.Name = "DisassembleMenuItem";
-			this.DisassembleMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.DisassembleMenuItem.Text = "&Disassemble...";
 			this.DisassembleMenuItem.Click += new System.EventHandler(this.DisassembleMenuItem_Click);
 			// 
@@ -184,9 +160,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(193, 22);
 			this.ExitMenuItem.Text = "&Close";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -270,8 +244,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// miAutoResume
 			// 
-			this.miAutoResume.Name = "miAutoResume";
-			this.miAutoResume.Size = new System.Drawing.Size(193, 22);
 			this.miAutoResume.Text = "Auto-Resume";
 			this.miAutoResume.Click += new System.EventHandler(this.miAutoResume_Click);
 			// 
@@ -304,19 +276,19 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ClearMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AppendMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NewMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisassembleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisassembleMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem noneToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
 		private System.Windows.Forms.ToolStripButton tsbLoggingActive;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
 		private System.Windows.Forms.ToolStripButton tsbViewUpdate;
@@ -324,9 +296,9 @@ namespace BizHawk.Client.EmuHawk
 		private InputRoll lvCDL;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
 		private System.Windows.Forms.ToolStripButton tsbExportText;
-		private System.Windows.Forms.ToolStripMenuItem miAutoStart;
-		private System.Windows.Forms.ToolStripMenuItem miAutoSave;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miAutoStart;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miAutoSave;
 		private ToolStripEx toolStrip1;
-		private System.Windows.Forms.ToolStripMenuItem miAutoResume;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx miAutoResume;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
@@ -45,43 +45,43 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AppendMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CheatsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveCheatMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ToggleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisableAllCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GameGenieSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.GameGenieSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.OpenGameGenieEncoderDecoderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AlwaysLoadCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutoSaveCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisableCheatsOnLoadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.AutoloadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveWindowPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RestoreWindowSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStrip1 = new ToolStripEx();
 			this.NewToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.OpenToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.SaveToolBarItem = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RemoveToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.SeparatorToolbarItem = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MoveUpToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.MoveDownToolbarItem = new System.Windows.Forms.ToolStripButton();
-			this.GameGenieToolbarSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.GameGenieToolbarSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.LoadGameGenieToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.TotalLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.MessageLabel = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -211,16 +211,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(192, 6);
-			// 
 			// ExitMenuItem
 			// 
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
@@ -256,11 +246,6 @@ namespace BizHawk.Client.EmuHawk
 			this.InsertSeparatorMenuItem.Text = "Insert Separator";
 			this.InsertSeparatorMenuItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
 			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(230, 6);
-			// 
 			// MoveUpMenuItem
 			// 
 			this.MoveUpMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
@@ -279,11 +264,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(230, 6);
-			// 
 			// ToggleMenuItem
 			// 
 			this.ToggleMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Enter)));
@@ -297,11 +277,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DisableAllCheatsMenuItem.ShortcutKeyDisplayString = "Ctrl + Backspace";
 			this.DisableAllCheatsMenuItem.Text = "Disable all";
 			this.DisableAllCheatsMenuItem.Click += new System.EventHandler(this.DisableAllCheatsMenuItem_Click);
-			// 
-			// GameGenieSeparator
-			// 
-			this.GameGenieSeparator.Name = "GameGenieSeparator";
-			this.GameGenieSeparator.Size = new System.Drawing.Size(230, 6);
 			// 
 			// OpenGameGenieEncoderDecoderMenuItem
 			// 
@@ -339,11 +314,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DisableCheatsOnLoadMenuItem.Text = "Disable Cheats on Load";
 			this.DisableCheatsOnLoadMenuItem.Click += new System.EventHandler(this.CheatsOnOffLoadMenuItem_Click);
 			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(196, 6);
-			// 
 			// AutoloadMenuItem
 			// 
 			this.AutoloadMenuItem.Text = "Autoload";
@@ -363,11 +333,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.FloatingWindowMenuItem.Text = "Floating Window";
 			this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
-			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(196, 6);
 			// 
 			// RestoreWindowSizeMenuItem
 			// 
@@ -419,11 +384,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveToolBarItem.Text = "&Save";
 			this.SaveToolBarItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
-			// toolStripSeparator
-			// 
-			this.toolStripSeparator.Name = "toolStripSeparator";
-			this.toolStripSeparator.Size = new System.Drawing.Size(6, 25);
-			// 
 			// RemoveToolbarItem
 			// 
 			this.RemoveToolbarItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -442,11 +402,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SeparatorToolbarItem.Text = "Insert Separator";
 			this.SeparatorToolbarItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			// 
 			// MoveUpToolbarItem
 			// 
 			this.MoveUpToolbarItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -464,11 +419,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MoveDownToolbarItem.Size = new System.Drawing.Size(23, 22);
 			this.MoveDownToolbarItem.Text = "Move Down";
 			this.MoveDownToolbarItem.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
-			// 
-			// GameGenieToolbarSeparator
-			// 
-			this.GameGenieToolbarSeparator.Name = "GameGenieToolbarSeparator";
-			this.GameGenieToolbarSeparator.Size = new System.Drawing.Size(6, 25);
 			// 
 			// LoadGameGenieToolbarItem
 			// 
@@ -555,19 +505,19 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CheatsSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveCheatMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeparatorMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableAllCheatsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator GameGenieSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx GameGenieSeparator;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenGameGenieEncoderDecoderMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysLoadCheatsMenuItem;
@@ -575,16 +525,16 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableCheatsOnLoadMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveWindowPositionMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestoreWindowSizeMenuItem;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton NewToolBarItem;
 		private System.Windows.Forms.ToolStripButton OpenToolBarItem;
 		private System.Windows.Forms.ToolStripButton SaveToolBarItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator;
 		private System.Windows.Forms.ToolStripButton RemoveToolbarItem;
 		private System.Windows.Forms.ToolStripButton SeparatorToolbarItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private System.Windows.Forms.ToolStripButton MoveUpToolbarItem;
 		private System.Windows.Forms.ToolStripButton MoveDownToolbarItem;
 		private System.Windows.Forms.ToolStripButton LoadGameGenieToolbarItem;
@@ -592,14 +542,14 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx MessageLabel;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysOnTopMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleMenuItem;
-		private System.Windows.Forms.ToolStripSeparator GameGenieToolbarSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx GameGenieToolbarSeparator;
 		private System.Windows.Forms.ContextMenuStrip CheatsContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableAllContextMenuItem;
 		private System.Windows.Forms.GroupBox CheatGroupBox;
 		private CheatEdit CheatEditor;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FloatingWindowMenuItem;
 	}

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
@@ -33,44 +33,44 @@ namespace BizHawk.Client.EmuHawk
 			this.components = new System.ComponentModel.Container();
 			this.CheatListView = new InputRoll();
 			this.CheatsContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.ToggleContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisableAllContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ViewInHexEditorContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ToggleContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisableAllContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ViewInHexEditorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CheatsMenu = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AppendMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppendMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CheatsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveCheatMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertSeparatorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CheatsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveCheatMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.MoveUpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MoveDownMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.ToggleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisableAllCheatsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ToggleMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisableAllCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.GameGenieSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.OpenGameGenieEncoderDecoderMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OptionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.AlwaysLoadCheatsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoSaveCheatsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisableCheatsOnLoadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.OpenGameGenieEncoderDecoderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AlwaysLoadCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutoSaveCheatsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisableCheatsOnLoadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoloadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveWindowPositionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AlwaysOnTopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FloatingWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoloadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveWindowPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.RestoreWindowSizeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RestoreWindowSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStrip1 = new ToolStripEx();
 			this.NewToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.OpenToolBarItem = new System.Windows.Forms.ToolStripButton();
@@ -131,31 +131,23 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ToggleContextMenuItem
 			// 
-			this.ToggleContextMenuItem.Name = "ToggleContextMenuItem";
 			this.ToggleContextMenuItem.ShortcutKeyDisplayString = "Enter";
-			this.ToggleContextMenuItem.Size = new System.Drawing.Size(169, 22);
 			this.ToggleContextMenuItem.Text = "&Toggle";
 			this.ToggleContextMenuItem.Click += new System.EventHandler(this.ToggleMenuItem_Click);
 			// 
 			// RemoveContextMenuItem
 			// 
-			this.RemoveContextMenuItem.Name = "RemoveContextMenuItem";
 			this.RemoveContextMenuItem.ShortcutKeyDisplayString = "Delete";
-			this.RemoveContextMenuItem.Size = new System.Drawing.Size(169, 22);
 			this.RemoveContextMenuItem.Text = "&Remove";
 			this.RemoveContextMenuItem.Click += new System.EventHandler(this.RemoveCheatMenuItem_Click);
 			// 
 			// DisableAllContextMenuItem
 			// 
-			this.DisableAllContextMenuItem.Name = "DisableAllContextMenuItem";
-			this.DisableAllContextMenuItem.Size = new System.Drawing.Size(169, 22);
 			this.DisableAllContextMenuItem.Text = "&Disable All";
 			this.DisableAllContextMenuItem.Click += new System.EventHandler(this.DisableAllCheatsMenuItem_Click);
 			// 
 			// ViewInHexEditorContextMenuItem
 			// 
-			this.ViewInHexEditorContextMenuItem.Name = "ViewInHexEditorContextMenuItem";
-			this.ViewInHexEditorContextMenuItem.Size = new System.Drawing.Size(169, 22);
 			this.ViewInHexEditorContextMenuItem.Text = "View in Hex Editor";
 			this.ViewInHexEditorContextMenuItem.Click += new System.EventHandler(this.ViewInHexEditorContextMenuItem_Click);
 			// 
@@ -180,56 +172,42 @@ namespace BizHawk.Client.EmuHawk
             this.RecentSubMenu,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// NewMenuItem
 			// 
-			this.NewMenuItem.Name = "NewMenuItem";
 			this.NewMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.NewMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.NewMenuItem.Text = "&New";
 			this.NewMenuItem.Click += new System.EventHandler(this.NewMenuItem_Click);
 			// 
 			// OpenMenuItem
 			// 
-			this.OpenMenuItem.Name = "OpenMenuItem";
 			this.OpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.OpenMenuItem.Text = "&Open...";
 			this.OpenMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
 			// SaveMenuItem
 			// 
-			this.SaveMenuItem.Name = "SaveMenuItem";
 			this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveMenuItem.Text = "&Save";
 			this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
 			// SaveAsMenuItem
 			// 
-			this.SaveAsMenuItem.Name = "SaveAsMenuItem";
 			this.SaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveAsMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveAsMenuItem.Text = "Save &As...";
 			this.SaveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItem_Click);
 			// 
 			// AppendMenuItem
 			// 
-			this.AppendMenuItem.Name = "AppendMenuItem";
-			this.AppendMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.AppendMenuItem.Text = "Append File";
 			// 
 			// RecentSubMenu
 			// 
 			this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator4});
-			this.RecentSubMenu.Name = "RecentSubMenu";
-			this.RecentSubMenu.Size = new System.Drawing.Size(195, 22);
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
@@ -245,9 +223,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -265,24 +241,18 @@ namespace BizHawk.Client.EmuHawk
             this.DisableAllCheatsMenuItem,
             this.GameGenieSeparator,
             this.OpenGameGenieEncoderDecoderMenuItem});
-			this.CheatsSubMenu.Name = "CheatsSubMenu";
-			this.CheatsSubMenu.Size = new System.Drawing.Size(55, 20);
 			this.CheatsSubMenu.Text = "&Cheats";
 			this.CheatsSubMenu.DropDownOpened += new System.EventHandler(this.CheatsSubMenu_DropDownOpened);
 			// 
 			// RemoveCheatMenuItem
 			// 
-			this.RemoveCheatMenuItem.Name = "RemoveCheatMenuItem";
 			this.RemoveCheatMenuItem.ShortcutKeyDisplayString = "Delete";
-			this.RemoveCheatMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.RemoveCheatMenuItem.Text = "&Remove Cheat";
 			this.RemoveCheatMenuItem.Click += new System.EventHandler(this.RemoveCheatMenuItem_Click);
 			// 
 			// InsertSeparatorMenuItem
 			// 
-			this.InsertSeparatorMenuItem.Name = "InsertSeparatorMenuItem";
 			this.InsertSeparatorMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-			this.InsertSeparatorMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.InsertSeparatorMenuItem.Text = "Insert Separator";
 			this.InsertSeparatorMenuItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
 			// 
@@ -293,25 +263,19 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// MoveUpMenuItem
 			// 
-			this.MoveUpMenuItem.Name = "MoveUpMenuItem";
 			this.MoveUpMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
-			this.MoveUpMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.MoveUpMenuItem.Text = "Move &Up";
 			this.MoveUpMenuItem.Click += new System.EventHandler(this.MoveUpMenuItem_Click);
 			// 
 			// MoveDownMenuItem
 			// 
-			this.MoveDownMenuItem.Name = "MoveDownMenuItem";
 			this.MoveDownMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
-			this.MoveDownMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.MoveDownMenuItem.Text = "Move &Down";
 			this.MoveDownMenuItem.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
 			// 
 			// SelectAllMenuItem
 			// 
-			this.SelectAllMenuItem.Name = "SelectAllMenuItem";
 			this.SelectAllMenuItem.ShortcutKeyDisplayString = "Ctrl+A";
-			this.SelectAllMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
@@ -322,19 +286,15 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ToggleMenuItem
 			// 
-			this.ToggleMenuItem.Name = "ToggleMenuItem";
 			this.ToggleMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Enter)));
 			this.ToggleMenuItem.ShortcutKeyDisplayString = "Ctrl + Enter";
-			this.ToggleMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.ToggleMenuItem.Text = "&Toggle";
 			this.ToggleMenuItem.Click += new System.EventHandler(this.ToggleMenuItem_Click);
 			// 
 			// DisableAllCheatsMenuItem
 			// 
-			this.DisableAllCheatsMenuItem.Name = "DisableAllCheatsMenuItem";
 			this.DisableAllCheatsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Back)));
 			this.DisableAllCheatsMenuItem.ShortcutKeyDisplayString = "Ctrl + Backspace";
-			this.DisableAllCheatsMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.DisableAllCheatsMenuItem.Text = "Disable all";
 			this.DisableAllCheatsMenuItem.Click += new System.EventHandler(this.DisableAllCheatsMenuItem_Click);
 			// 
@@ -345,8 +305,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// OpenGameGenieEncoderDecoderMenuItem
 			// 
-			this.OpenGameGenieEncoderDecoderMenuItem.Name = "OpenGameGenieEncoderDecoderMenuItem";
-			this.OpenGameGenieEncoderDecoderMenuItem.Size = new System.Drawing.Size(233, 22);
 			this.OpenGameGenieEncoderDecoderMenuItem.Text = "Code Converter";
 			this.OpenGameGenieEncoderDecoderMenuItem.Click += new System.EventHandler(this.OpenGameGenieEncoderDecoderMenuItem_Click);
 			// 
@@ -363,29 +321,21 @@ namespace BizHawk.Client.EmuHawk
             this.FloatingWindowMenuItem,
             this.toolStripSeparator5,
             this.RestoreWindowSizeMenuItem});
-			this.OptionsSubMenu.Name = "OptionsSubMenu";
-			this.OptionsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.OptionsSubMenu.Text = "&Options";
 			this.OptionsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
 			// AlwaysLoadCheatsMenuItem
 			// 
-			this.AlwaysLoadCheatsMenuItem.Name = "AlwaysLoadCheatsMenuItem";
-			this.AlwaysLoadCheatsMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.AlwaysLoadCheatsMenuItem.Text = "Always load cheats";
 			this.AlwaysLoadCheatsMenuItem.Click += new System.EventHandler(this.AlwaysLoadCheatsMenuItem_Click);
 			// 
 			// AutoSaveCheatsMenuItem
 			// 
-			this.AutoSaveCheatsMenuItem.Name = "AutoSaveCheatsMenuItem";
-			this.AutoSaveCheatsMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.AutoSaveCheatsMenuItem.Text = "Autosave cheats";
 			this.AutoSaveCheatsMenuItem.Click += new System.EventHandler(this.AutoSaveCheatsMenuItem_Click);
 			// 
 			// DisableCheatsOnLoadMenuItem
 			// 
-			this.DisableCheatsOnLoadMenuItem.Name = "DisableCheatsOnLoadMenuItem";
-			this.DisableCheatsOnLoadMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.DisableCheatsOnLoadMenuItem.Text = "Disable Cheats on Load";
 			this.DisableCheatsOnLoadMenuItem.Click += new System.EventHandler(this.CheatsOnOffLoadMenuItem_Click);
 			// 
@@ -396,29 +346,21 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// AutoloadMenuItem
 			// 
-			this.AutoloadMenuItem.Name = "AutoloadMenuItem";
-			this.AutoloadMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.AutoloadMenuItem.Text = "Autoload";
 			this.AutoloadMenuItem.Click += new System.EventHandler(this.AutoloadMenuItem_Click);
 			// 
 			// SaveWindowPositionMenuItem
 			// 
-			this.SaveWindowPositionMenuItem.Name = "SaveWindowPositionMenuItem";
-			this.SaveWindowPositionMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.SaveWindowPositionMenuItem.Text = "Save Window Position";
 			this.SaveWindowPositionMenuItem.Click += new System.EventHandler(this.SaveWindowPositionMenuItem_Click);
 			// 
 			// AlwaysOnTopMenuItem
 			// 
-			this.AlwaysOnTopMenuItem.Name = "AlwaysOnTopMenuItem";
-			this.AlwaysOnTopMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.AlwaysOnTopMenuItem.Text = "Always on &Top";
 			this.AlwaysOnTopMenuItem.Click += new System.EventHandler(this.AlwaysOnTopMenuItem_Click);
 			// 
 			// FloatingWindowMenuItem
 			// 
-			this.FloatingWindowMenuItem.Name = "FloatingWindowMenuItem";
-			this.FloatingWindowMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.FloatingWindowMenuItem.Text = "Floating Window";
 			this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
 			// 
@@ -429,8 +371,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// RestoreWindowSizeMenuItem
 			// 
-			this.RestoreWindowSizeMenuItem.Name = "RestoreWindowSizeMenuItem";
-			this.RestoreWindowSizeMenuItem.Size = new System.Drawing.Size(199, 22);
 			this.RestoreWindowSizeMenuItem.Text = "Restore Default Settings";
 			this.RestoreWindowSizeMenuItem.Click += new System.EventHandler(this.RestoreDefaultsMenuItem_Click);
 			// 
@@ -608,35 +548,35 @@ namespace BizHawk.Client.EmuHawk
 
 		private InputRoll CheatListView;
 		private MenuStripEx CheatsMenu;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NewMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AppendMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CheatsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem RemoveCheatMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertSeparatorMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CheatsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveCheatMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeparatorMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem MoveUpMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MoveDownMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripMenuItem DisableAllCheatsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableAllCheatsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator GameGenieSeparator;
-		private System.Windows.Forms.ToolStripMenuItem OpenGameGenieEncoderDecoderMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OptionsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem AlwaysLoadCheatsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoSaveCheatsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisableCheatsOnLoadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoloadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveWindowPositionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenGameGenieEncoderDecoderMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysLoadCheatsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoSaveCheatsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableCheatsOnLoadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveWindowPositionMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-		private System.Windows.Forms.ToolStripMenuItem RestoreWindowSizeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestoreWindowSizeMenuItem;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton NewToolBarItem;
 		private System.Windows.Forms.ToolStripButton OpenToolBarItem;
@@ -650,17 +590,17 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton LoadGameGenieToolbarItem;
 		private BizHawk.WinForms.Controls.LocLabelEx TotalLabel;
 		private BizHawk.WinForms.Controls.LocLabelEx MessageLabel;
-		private System.Windows.Forms.ToolStripMenuItem AlwaysOnTopMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ToggleMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysOnTopMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleMenuItem;
 		private System.Windows.Forms.ToolStripSeparator GameGenieToolbarSeparator;
 		private System.Windows.Forms.ContextMenuStrip CheatsContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem ToggleContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisableAllContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableAllContextMenuItem;
 		private System.Windows.Forms.GroupBox CheatGroupBox;
 		private CheatEdit CheatEditor;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem ViewInHexEditorContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FloatingWindowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FloatingWindowMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
@@ -32,14 +32,14 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.menuStrip1 = new MenuStripEx();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DebugSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.StepIntoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StepOverMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StepOutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DebugSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StepIntoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StepOverMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StepOutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.RefreshMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RefreshMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RegistersGroupBox = new System.Windows.Forms.GroupBox();
 			this.RegisterPanel = new BizHawk.Client.EmuHawk.RegisterBoxControl();
 			this.BreakpointsGroupBox = new System.Windows.Forms.GroupBox();
@@ -49,7 +49,7 @@ namespace BizHawk.Client.EmuHawk
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.DisassemblerView = new InputRoll();
 			this.DisassemblerContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.AddBreakpointContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AddBreakpointContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StepOutBtn = new System.Windows.Forms.Button();
 			this.StepIntoBtn = new System.Windows.Forms.Button();
 			this.StepOverBtn = new System.Windows.Forms.Button();
@@ -78,15 +78,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ExitMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
 			this.fileToolStripMenuItem.Text = "&File";
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(151, 22);
 			this.ExitMenuItem.Text = "&Close";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -98,34 +94,26 @@ namespace BizHawk.Client.EmuHawk
             this.StepOutMenuItem,
             this.toolStripSeparator1,
             this.RefreshMenuItem});
-			this.DebugSubMenu.Name = "DebugSubMenu";
-			this.DebugSubMenu.Size = new System.Drawing.Size(50, 20);
 			this.DebugSubMenu.Text = "&Debug";
 			// 
 			// StepIntoMenuItem
 			// 
 			this.StepIntoMenuItem.Enabled = false;
-			this.StepIntoMenuItem.Name = "StepIntoMenuItem";
 			this.StepIntoMenuItem.ShortcutKeyDisplayString = "F11";
-			this.StepIntoMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.StepIntoMenuItem.Text = "Step &Into";
 			this.StepIntoMenuItem.Click += new System.EventHandler(this.StepIntoMenuItem_Click);
 			// 
 			// StepOverMenuItem
 			// 
 			this.StepOverMenuItem.Enabled = false;
-			this.StepOverMenuItem.Name = "StepOverMenuItem";
 			this.StepOverMenuItem.ShortcutKeyDisplayString = "F10";
-			this.StepOverMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.StepOverMenuItem.Text = "Step O&ver";
 			this.StepOverMenuItem.Click += new System.EventHandler(this.StepOverMenuItem_Click);
 			// 
 			// StepOutMenuItem
 			// 
 			this.StepOutMenuItem.Enabled = false;
-			this.StepOutMenuItem.Name = "StepOutMenuItem";
 			this.StepOutMenuItem.ShortcutKeyDisplayString = "Shift+F11";
-			this.StepOutMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.StepOutMenuItem.Text = "Step Ou&t";
 			this.StepOutMenuItem.Click += new System.EventHandler(this.StepOutMenuItem_Click);
 			// 
@@ -136,9 +124,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// RefreshMenuItem
 			// 
-			this.RefreshMenuItem.Name = "RefreshMenuItem";
 			this.RefreshMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
-			this.RefreshMenuItem.Size = new System.Drawing.Size(183, 22);
 			this.RefreshMenuItem.Text = "Refresh";
 			this.RefreshMenuItem.Click += new System.EventHandler(this.RefreshMenuItem_Click);
 			// 
@@ -258,8 +244,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// AddBreakpointContextMenuItem
 			// 
-			this.AddBreakpointContextMenuItem.Name = "AddBreakpointContextMenuItem";
-			this.AddBreakpointContextMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.AddBreakpointContextMenuItem.Text = "Add Breakpoint";
 			this.AddBreakpointContextMenuItem.Click += new System.EventHandler(this.AddBreakpointContextMenuItem_Click);
 			// 
@@ -378,8 +362,8 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.GroupBox RegistersGroupBox;
 		private RegisterBoxControl RegisterPanel;
 		private System.Windows.Forms.GroupBox BreakpointsGroupBox;
@@ -390,19 +374,19 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.Button StepOutBtn;
 		private System.Windows.Forms.Button StepIntoBtn;
 		private System.Windows.Forms.Button StepOverBtn;
-		private System.Windows.Forms.ToolStripMenuItem DebugSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem StepIntoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StepOverMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StepOutMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DebugSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StepIntoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StepOverMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StepOutMenuItem;
 		private System.Windows.Forms.ToolTip toolTip1;
 		private System.Windows.Forms.Button SeekToBtn;
 		private HexTextBox SeekToBox;
 		private System.Windows.Forms.Button CancelSeekBtn;
 		private System.Windows.Forms.Button ToPCBtn;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem RefreshMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RefreshMenuItem;
 		private System.Windows.Forms.ContextMenuStrip DisassemblerContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem AddBreakpointContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddBreakpointContextMenuItem;
 		private System.Windows.Forms.Button RunBtn;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
@@ -38,7 +38,7 @@ namespace BizHawk.Client.EmuHawk
 			this.StepIntoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StepOverMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StepOutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RefreshMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RegistersGroupBox = new System.Windows.Forms.GroupBox();
 			this.RegisterPanel = new BizHawk.Client.EmuHawk.RegisterBoxControl();
@@ -116,11 +116,6 @@ namespace BizHawk.Client.EmuHawk
 			this.StepOutMenuItem.ShortcutKeyDisplayString = "Shift+F11";
 			this.StepOutMenuItem.Text = "Step Ou&t";
 			this.StepOutMenuItem.Click += new System.EventHandler(this.StepOutMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(180, 6);
 			// 
 			// RefreshMenuItem
 			// 
@@ -383,7 +378,7 @@ namespace BizHawk.Client.EmuHawk
 		private HexTextBox SeekToBox;
 		private System.Windows.Forms.Button CancelSeekBtn;
 		private System.Windows.Forms.Button ToPCBtn;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RefreshMenuItem;
 		private System.Windows.Forms.ContextMenuStrip DisassemblerContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddBreakpointContextMenuItem;

--- a/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.Designer.cs
@@ -32,10 +32,10 @@
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.paperScroll = new System.Windows.Forms.VScrollBar();
 			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.saveImageToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.editToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.copyToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -54,15 +54,11 @@
             // 
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveImageToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // saveImageToolStripMenuItem
             // 
-            this.saveImageToolStripMenuItem.Name = "saveImageToolStripMenuItem";
             this.saveImageToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveImageToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
             this.saveImageToolStripMenuItem.Text = "&Save Image...";
             this.saveImageToolStripMenuItem.Click += new System.EventHandler(this.saveImageToolStripMenuItem_Click);
             // 
@@ -70,15 +66,11 @@
             // 
             this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem});
-            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem.Text = "&Edit";
             // 
             // copyToolStripMenuItem
             // 
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
             this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.copyToolStripMenuItem.Text = "&Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
 			//
@@ -134,10 +126,10 @@
 
 		#endregion
 		private System.Windows.Forms.MenuStrip menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveImageToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveImageToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx editToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx copyToolStripMenuItem;
 		private BmpView paperView;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
 		private System.Windows.Forms.VScrollBar paperScroll;

--- a/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
@@ -42,14 +42,14 @@ namespace BizHawk.Client.EmuHawk
 			this.bmpViewNTB = new BizHawk.Client.EmuHawk.BmpView();
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveBGAScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveBGBScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveTilesScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveWindowScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.savePaletteScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveBGAScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveBGBScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveTilesScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveWindowScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.savePaletteScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.closeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
 			this.groupBox3.SuspendLayout();
@@ -173,42 +173,30 @@ namespace BizHawk.Client.EmuHawk
             this.savePaletteScreenshotToolStripMenuItem,
             this.toolStripSeparator1,
             this.closeToolStripMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
 			this.fileToolStripMenuItem.Text = "&File";
 			// 
 			// saveBGAScreenshotToolStripMenuItem
 			// 
-			this.saveBGAScreenshotToolStripMenuItem.Name = "saveBGAScreenshotToolStripMenuItem";
-			this.saveBGAScreenshotToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.saveBGAScreenshotToolStripMenuItem.Text = "Save BG A Screenshot...";
 			this.saveBGAScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveBGAScreenshotToolStripMenuItem_Click);
 			// 
 			// saveBGBScreenshotToolStripMenuItem
 			// 
-			this.saveBGBScreenshotToolStripMenuItem.Name = "saveBGBScreenshotToolStripMenuItem";
-			this.saveBGBScreenshotToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.saveBGBScreenshotToolStripMenuItem.Text = "Save BG B Screenshot...";
 			this.saveBGBScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveBGBScreenshotToolStripMenuItem_Click);
 			// 
 			// saveTilesScreenshotToolStripMenuItem
 			// 
-			this.saveTilesScreenshotToolStripMenuItem.Name = "saveTilesScreenshotToolStripMenuItem";
-			this.saveTilesScreenshotToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.saveTilesScreenshotToolStripMenuItem.Text = "Save Tiles Screenshot...";
 			this.saveTilesScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveTilesScreenshotToolStripMenuItem_Click);
 			// 
 			// saveWindowScreenshotToolStripMenuItem
 			// 
-			this.saveWindowScreenshotToolStripMenuItem.Name = "saveWindowScreenshotToolStripMenuItem";
-			this.saveWindowScreenshotToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.saveWindowScreenshotToolStripMenuItem.Text = "Save Window Screenshot...";
 			this.saveWindowScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveWindowScreenshotToolStripMenuItem_Click);
 			// 
 			// savePaletteScreenshotToolStripMenuItem
 			// 
-			this.savePaletteScreenshotToolStripMenuItem.Name = "savePaletteScreenshotToolStripMenuItem";
-			this.savePaletteScreenshotToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.savePaletteScreenshotToolStripMenuItem.Text = "Save Palette Screenshot...";
 			this.savePaletteScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SavePaletteScreenshotToolStripMenuItem_Click);
 			// 
@@ -219,9 +207,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// closeToolStripMenuItem
 			// 
-			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
 			this.closeToolStripMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.closeToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.closeToolStripMenuItem.Text = "&Close";
 			this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseMenuItem_Click);
 			// 
@@ -270,13 +256,13 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.GroupBox groupBox5;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveBGAScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveBGBScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveTilesScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveWindowScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem savePaletteScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBGAScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBGBScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveTilesScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveWindowScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx savePaletteScreenshotToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem closeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx closeToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
@@ -48,7 +48,7 @@ namespace BizHawk.Client.EmuHawk
 			this.saveTilesScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveWindowScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.savePaletteScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.closeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -200,11 +200,6 @@ namespace BizHawk.Client.EmuHawk
 			this.savePaletteScreenshotToolStripMenuItem.Text = "Save Palette Screenshot...";
 			this.savePaletteScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SavePaletteScreenshotToolStripMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(205, 6);
-			// 
 			// closeToolStripMenuItem
 			// 
 			this.closeToolStripMenuItem.ShortcutKeyDisplayString = "Alt+F4";
@@ -262,7 +257,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveTilesScreenshotToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveWindowScreenshotToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx savePaletteScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx closeToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
@@ -32,62 +32,62 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.HexMenuStrip = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsBinaryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsTextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importAsBinaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsBinaryMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsTextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.importAsBinaryToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.LoadTableFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CloseTableFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentTablesSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.noneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.LoadTableFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloseTableFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentTablesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ExportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PasteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExportMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PasteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.FindMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FindNextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FindPrevMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OptionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.MemoryDomainsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FindNextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FindPrevMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MemoryDomainsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.DataSizeSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.DataSizeByteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DataSizeWordMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DataSizeDWordMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BigEndianMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DataSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DataSizeByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DataSizeWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DataSizeDWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.GoToAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddToRamWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FreezeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UnfreezeAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PokeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.CustomColorsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetColorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.GoToAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddToRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UnfreezeAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PokeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CustomColorsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetColorsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-			this.ResetColorsToDefaultMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ResetColorsToDefaultMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.resetToDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.resetToDefaultToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ViewerContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.CopyContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ExportContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PasteContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FreezeContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddToRamWatchContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UnfreezeAllContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PokeContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.CopyContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExportContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PasteContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FreezeContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddToRamWatchContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UnfreezeAllContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PokeContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ContextSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.IncrementContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DecrementContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.IncrementContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DecrementContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ContextSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.GoToContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.GoToContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.viewN64MatrixToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.viewN64MatrixToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemoryViewerBox = new System.Windows.Forms.GroupBox();
 			this.HexScrollBar = new System.Windows.Forms.VScrollBar();
 			this.AddressLabel = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -122,40 +122,30 @@ namespace BizHawk.Client.EmuHawk
             this.RecentTablesSubMenu,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// SaveMenuItem
 			// 
-			this.SaveMenuItem.Name = "SaveMenuItem";
 			this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.SaveMenuItem.Text = "Save";
 			this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
 			// SaveAsBinaryMenuItem
 			// 
-			this.SaveAsBinaryMenuItem.Name = "SaveAsBinaryMenuItem";
 			this.SaveAsBinaryMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveAsBinaryMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.SaveAsBinaryMenuItem.Text = "Save as binary...";
 			this.SaveAsBinaryMenuItem.Click += new System.EventHandler(this.SaveAsBinaryMenuItem_Click);
 			// 
 			// SaveAsTextMenuItem
 			// 
-			this.SaveAsTextMenuItem.Name = "SaveAsTextMenuItem";
-			this.SaveAsTextMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.SaveAsTextMenuItem.Text = "Save as text...";
 			this.SaveAsTextMenuItem.Click += new System.EventHandler(this.SaveAsTextMenuItem_Click);
 			// 
 			// importAsBinaryToolStripMenuItem
 			// 
-			this.importAsBinaryToolStripMenuItem.Name = "importAsBinaryToolStripMenuItem";
 			this.importAsBinaryToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-			this.importAsBinaryToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.importAsBinaryToolStripMenuItem.Text = "Import as binary...";
 			this.importAsBinaryToolStripMenuItem.Click += new System.EventHandler(this.importAsBinaryToolStripMenuItem_Click);
 			// 
@@ -166,15 +156,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// LoadTableFileMenuItem
 			// 
-			this.LoadTableFileMenuItem.Name = "LoadTableFileMenuItem";
-			this.LoadTableFileMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.LoadTableFileMenuItem.Text = "&Load .tbl file";
 			this.LoadTableFileMenuItem.Click += new System.EventHandler(this.LoadTableFileMenuItem_Click);
 			// 
 			// CloseTableFileMenuItem
 			// 
-			this.CloseTableFileMenuItem.Name = "CloseTableFileMenuItem";
-			this.CloseTableFileMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.CloseTableFileMenuItem.Text = "Close .tbl file";
 			this.CloseTableFileMenuItem.Click += new System.EventHandler(this.CloseTableFileMenuItem_Click);
 			// 
@@ -182,15 +168,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentTablesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.noneToolStripMenuItem});
-			this.RecentTablesSubMenu.Name = "RecentTablesSubMenu";
-			this.RecentTablesSubMenu.Size = new System.Drawing.Size(229, 22);
 			this.RecentTablesSubMenu.Text = "Recent";
 			this.RecentTablesSubMenu.DropDownOpened += new System.EventHandler(this.RecentTablesSubMenu_DropDownOpened);
 			// 
 			// noneToolStripMenuItem
 			// 
-			this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
-			this.noneToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
 			this.noneToolStripMenuItem.Text = "None";
 			// 
 			// toolStripSeparator1
@@ -200,9 +182,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -216,32 +196,24 @@ namespace BizHawk.Client.EmuHawk
             this.FindMenuItem,
             this.FindNextMenuItem,
             this.FindPrevMenuItem});
-			this.EditMenuItem.Name = "EditMenuItem";
-			this.EditMenuItem.Size = new System.Drawing.Size(39, 20);
 			this.EditMenuItem.Text = "&Edit";
 			this.EditMenuItem.DropDownOpened += new System.EventHandler(this.EditMenuItem_DropDownOpened);
 			// 
 			// CopyMenuItem
 			// 
-			this.CopyMenuItem.Name = "CopyMenuItem";
 			this.CopyMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.CopyMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.CopyMenuItem.Text = "&Copy";
 			this.CopyMenuItem.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// ExportMenuItem
 			// 
-			this.ExportMenuItem.Name = "ExportMenuItem";
 			this.ExportMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-			this.ExportMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.ExportMenuItem.Text = "&Export";
 			this.ExportMenuItem.Click += new System.EventHandler(this.ExportMenuItem_Click);
 			// 
 			// PasteMenuItem
 			// 
-			this.PasteMenuItem.Name = "PasteMenuItem";
 			this.PasteMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-			this.PasteMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.PasteMenuItem.Text = "&Paste";
 			this.PasteMenuItem.Click += new System.EventHandler(this.PasteMenuItem_Click);
 			// 
@@ -252,25 +224,19 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// FindMenuItem
 			// 
-			this.FindMenuItem.Name = "FindMenuItem";
 			this.FindMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-			this.FindMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.FindMenuItem.Text = "&Find...";
 			this.FindMenuItem.Click += new System.EventHandler(this.FindMenuItem_Click);
 			// 
 			// FindNextMenuItem
 			// 
-			this.FindNextMenuItem.Name = "FindNextMenuItem";
 			this.FindNextMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-			this.FindNextMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.FindNextMenuItem.Text = "Find Next";
 			this.FindNextMenuItem.Click += new System.EventHandler(this.FindNextMenuItem_Click);
 			// 
 			// FindPrevMenuItem
 			// 
-			this.FindPrevMenuItem.Name = "FindPrevMenuItem";
 			this.FindPrevMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F2;
-			this.FindPrevMenuItem.Size = new System.Drawing.Size(147, 22);
 			this.FindPrevMenuItem.Text = "Find Prev";
 			this.FindPrevMenuItem.Click += new System.EventHandler(this.FindPrevMenuItem_Click);
 			// 
@@ -286,8 +252,6 @@ namespace BizHawk.Client.EmuHawk
             this.FreezeAddressMenuItem,
             this.UnfreezeAllMenuItem,
             this.PokeAddressMenuItem});
-			this.OptionsSubMenu.Name = "OptionsSubMenu";
-			this.OptionsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.OptionsSubMenu.Text = "&Options";
 			this.OptionsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
@@ -295,8 +259,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.MemoryDomainsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator3});
-			this.MemoryDomainsMenuItem.Name = "MemoryDomainsMenuItem";
-			this.MemoryDomainsMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.MemoryDomainsMenuItem.Text = "&Memory Domains";
 			this.MemoryDomainsMenuItem.DropDownOpened += new System.EventHandler(this.MemoryDomainsMenuItem_DropDownOpened);
 			// 
@@ -311,35 +273,25 @@ namespace BizHawk.Client.EmuHawk
             this.DataSizeByteMenuItem,
             this.DataSizeWordMenuItem,
             this.DataSizeDWordMenuItem});
-			this.DataSizeSubMenu.Name = "DataSizeSubMenu";
-			this.DataSizeSubMenu.Size = new System.Drawing.Size(221, 22);
 			this.DataSizeSubMenu.Text = "Data Size";
 			// 
 			// DataSizeByteMenuItem
 			// 
-			this.DataSizeByteMenuItem.Name = "DataSizeByteMenuItem";
-			this.DataSizeByteMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.DataSizeByteMenuItem.Text = "1 Byte";
 			this.DataSizeByteMenuItem.Click += new System.EventHandler(this.DataSizeByteMenuItem_Click);
 			// 
 			// DataSizeWordMenuItem
 			// 
-			this.DataSizeWordMenuItem.Name = "DataSizeWordMenuItem";
-			this.DataSizeWordMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.DataSizeWordMenuItem.Text = "2 Byte";
 			this.DataSizeWordMenuItem.Click += new System.EventHandler(this.DataSizeWordMenuItem_Click);
 			// 
 			// DataSizeDWordMenuItem
 			// 
-			this.DataSizeDWordMenuItem.Name = "DataSizeDWordMenuItem";
-			this.DataSizeDWordMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.DataSizeDWordMenuItem.Text = "4 Byte";
 			this.DataSizeDWordMenuItem.Click += new System.EventHandler(this.DataSizeDWordMenuItem_Click);
 			// 
 			// BigEndianMenuItem
 			// 
-			this.BigEndianMenuItem.Name = "BigEndianMenuItem";
-			this.BigEndianMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.BigEndianMenuItem.Text = "Big Endian";
 			this.BigEndianMenuItem.Click += new System.EventHandler(this.BigEndianMenuItem_Click);
 			// 
@@ -350,41 +302,31 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// GoToAddressMenuItem
 			// 
-			this.GoToAddressMenuItem.Name = "GoToAddressMenuItem";
 			this.GoToAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-			this.GoToAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.GoToAddressMenuItem.Text = "&Go to Address...";
 			this.GoToAddressMenuItem.Click += new System.EventHandler(this.GoToAddressMenuItem_Click);
 			// 
 			// AddToRamWatchMenuItem
 			// 
-			this.AddToRamWatchMenuItem.Name = "AddToRamWatchMenuItem";
 			this.AddToRamWatchMenuItem.ShortcutKeyDisplayString = "Ctrl+W";
-			this.AddToRamWatchMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.AddToRamWatchMenuItem.Text = "Add to RAM Watch";
 			this.AddToRamWatchMenuItem.Click += new System.EventHandler(this.AddToRamWatchMenuItem_Click);
 			// 
 			// FreezeAddressMenuItem
 			// 
-			this.FreezeAddressMenuItem.Name = "FreezeAddressMenuItem";
 			this.FreezeAddressMenuItem.ShortcutKeyDisplayString = "Space";
-			this.FreezeAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.FreezeAddressMenuItem.Text = "&Freeze Address";
 			this.FreezeAddressMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
 			// 
 			// UnfreezeAllMenuItem
 			// 
-			this.UnfreezeAllMenuItem.Name = "UnfreezeAllMenuItem";
 			this.UnfreezeAllMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Delete)));
-			this.UnfreezeAllMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.UnfreezeAllMenuItem.Text = "Unfreeze All";
 			this.UnfreezeAllMenuItem.Click += new System.EventHandler(this.UnfreezeAllMenuItem_Click);
 			// 
 			// PokeAddressMenuItem
 			// 
-			this.PokeAddressMenuItem.Name = "PokeAddressMenuItem";
 			this.PokeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-			this.PokeAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.PokeAddressMenuItem.Text = "&Poke Address";
 			this.PokeAddressMenuItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
 			// 
@@ -392,8 +334,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SettingsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.CustomColorsSubMenu});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.SettingsSubMenu.Text = "&Settings";
 			// 
 			// CustomColorsSubMenu
@@ -402,14 +342,10 @@ namespace BizHawk.Client.EmuHawk
             this.SetColorsMenuItem,
             this.toolStripSeparator8,
             this.ResetColorsToDefaultMenuItem});
-			this.CustomColorsSubMenu.Name = "CustomColorsSubMenu";
-			this.CustomColorsSubMenu.Size = new System.Drawing.Size(153, 22);
 			this.CustomColorsSubMenu.Text = "Custom Colors";
 			// 
 			// SetColorsMenuItem
 			// 
-			this.SetColorsMenuItem.Name = "SetColorsMenuItem";
-			this.SetColorsMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.SetColorsMenuItem.Text = "Set Colors";
 			this.SetColorsMenuItem.Click += new System.EventHandler(this.SetColorsMenuItem_Click);
 			// 
@@ -420,8 +356,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ResetColorsToDefaultMenuItem
 			// 
-			this.ResetColorsToDefaultMenuItem.Name = "ResetColorsToDefaultMenuItem";
-			this.ResetColorsToDefaultMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.ResetColorsToDefaultMenuItem.Text = "Reset to Default";
 			this.ResetColorsToDefaultMenuItem.Click += new System.EventHandler(this.ResetColorsToDefaultMenuItem_Click);
 			// 
@@ -432,8 +366,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// resetToDefaultToolStripMenuItem
 			// 
-			this.resetToDefaultToolStripMenuItem.Name = "resetToDefaultToolStripMenuItem";
-			this.resetToDefaultToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
 			this.resetToDefaultToolStripMenuItem.Text = "Reset to Default";
 			// 
 			// ViewerContextMenuStrip
@@ -459,56 +391,42 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CopyContextItem
 			// 
-			this.CopyContextItem.Name = "CopyContextItem";
 			this.CopyContextItem.ShortcutKeyDisplayString = "Ctrl+C";
-			this.CopyContextItem.Size = new System.Drawing.Size(221, 22);
 			this.CopyContextItem.Text = "&Copy";
 			this.CopyContextItem.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// ExportContextItem
 			// 
-			this.ExportContextItem.Name = "ExportContextItem";
 			this.ExportContextItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-			this.ExportContextItem.Size = new System.Drawing.Size(221, 22);
 			this.ExportContextItem.Text = "&Export";
 			// 
 			// PasteContextItem
 			// 
-			this.PasteContextItem.Name = "PasteContextItem";
 			this.PasteContextItem.ShortcutKeyDisplayString = "Ctrl+V";
-			this.PasteContextItem.Size = new System.Drawing.Size(221, 22);
 			this.PasteContextItem.Text = "&Paste";
 			this.PasteContextItem.Click += new System.EventHandler(this.PasteMenuItem_Click);
 			// 
 			// FreezeContextItem
 			// 
-			this.FreezeContextItem.Name = "FreezeContextItem";
 			this.FreezeContextItem.ShortcutKeyDisplayString = "Space";
-			this.FreezeContextItem.Size = new System.Drawing.Size(221, 22);
 			this.FreezeContextItem.Text = "&Freeze";
 			this.FreezeContextItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
 			// 
 			// AddToRamWatchContextItem
 			// 
-			this.AddToRamWatchContextItem.Name = "AddToRamWatchContextItem";
 			this.AddToRamWatchContextItem.ShortcutKeyDisplayString = "Ctrl+W";
-			this.AddToRamWatchContextItem.Size = new System.Drawing.Size(221, 22);
 			this.AddToRamWatchContextItem.Text = "&Add to RAM Watch";
 			this.AddToRamWatchContextItem.Click += new System.EventHandler(this.AddToRamWatchMenuItem_Click);
 			// 
 			// UnfreezeAllContextItem
 			// 
-			this.UnfreezeAllContextItem.Name = "UnfreezeAllContextItem";
 			this.UnfreezeAllContextItem.ShortcutKeyDisplayString = "Shift+Del";
-			this.UnfreezeAllContextItem.Size = new System.Drawing.Size(221, 22);
 			this.UnfreezeAllContextItem.Text = "&Unfreeze All";
 			this.UnfreezeAllContextItem.Click += new System.EventHandler(this.UnfreezeAllMenuItem_Click);
 			// 
 			// PokeContextItem
 			// 
-			this.PokeContextItem.Name = "PokeContextItem";
 			this.PokeContextItem.ShortcutKeyDisplayString = "Ctrl+P";
-			this.PokeContextItem.Size = new System.Drawing.Size(221, 22);
 			this.PokeContextItem.Text = "&Poke Address";
 			this.PokeContextItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
 			// 
@@ -519,17 +437,13 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// IncrementContextItem
 			// 
-			this.IncrementContextItem.Name = "IncrementContextItem";
 			this.IncrementContextItem.ShortcutKeyDisplayString = "+";
-			this.IncrementContextItem.Size = new System.Drawing.Size(221, 22);
 			this.IncrementContextItem.Text = "&Increment";
 			this.IncrementContextItem.Click += new System.EventHandler(this.IncrementContextItem_Click);
 			// 
 			// DecrementContextItem
 			// 
-			this.DecrementContextItem.Name = "DecrementContextItem";
 			this.DecrementContextItem.ShortcutKeyDisplayString = "-";
-			this.DecrementContextItem.Size = new System.Drawing.Size(221, 22);
 			this.DecrementContextItem.Text = "&Decrement";
 			this.DecrementContextItem.Click += new System.EventHandler(this.DecrementContextItem_Click);
 			// 
@@ -540,9 +454,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// GoToContextItem
 			// 
-			this.GoToContextItem.Name = "GoToContextItem";
 			this.GoToContextItem.ShortcutKeyDisplayString = "Ctrl+G";
-			this.GoToContextItem.Size = new System.Drawing.Size(221, 22);
 			this.GoToContextItem.Text = "&Go to Address...";
 			this.GoToContextItem.Click += new System.EventHandler(this.GoToAddressMenuItem_Click);
 			// 
@@ -553,8 +465,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// viewN64MatrixToolStripMenuItem
 			// 
-			this.viewN64MatrixToolStripMenuItem.Name = "viewN64MatrixToolStripMenuItem";
-			this.viewN64MatrixToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.viewN64MatrixToolStripMenuItem.Text = "View N64 Matrix";
 			this.viewN64MatrixToolStripMenuItem.Click += new System.EventHandler(this.viewN64MatrixToolStripMenuItem_Click);
 			// 
@@ -645,66 +555,66 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		public MenuStripEx HexMenuStrip;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsTextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsTextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OptionsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem MemoryDomainsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DataSizeSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem DataSizeByteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DataSizeWordMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DataSizeDWordMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem GoToAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem BigEndianMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeByteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeWordMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DataSizeDWordMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GoToAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BigEndianMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ViewerContextMenuStrip;
-		private System.Windows.Forms.ToolStripMenuItem FreezeContextItem;
-		private System.Windows.Forms.ToolStripMenuItem AddToRamWatchContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchContextItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem AddToRamWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FreezeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
 		public System.Windows.Forms.GroupBox MemoryViewerBox;
 		private BizHawk.WinForms.Controls.LocLabelEx AddressesLabel;
 		private System.Windows.Forms.VScrollBar HexScrollBar;
-		private System.Windows.Forms.ToolStripMenuItem UnfreezeAllMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UnfreezeAllContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextItem;
 		private System.Windows.Forms.ToolStripSeparator ContextSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem IncrementContextItem;
-		private System.Windows.Forms.ToolStripMenuItem DecrementContextItem;
-		private System.Windows.Forms.ToolStripMenuItem GoToContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx IncrementContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DecrementContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GoToContextItem;
 		private System.Windows.Forms.ToolStripSeparator ContextSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem EditMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PasteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FindMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FindMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsBinaryMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsBinaryMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem resetToDefaultToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CustomColorsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SetColorsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx resetToDefaultToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CustomColorsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetColorsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-		private System.Windows.Forms.ToolStripMenuItem ResetColorsToDefaultMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ResetColorsToDefaultMenuItem;
 		public BizHawk.WinForms.Controls.LocLabelEx Header;
 		private BizHawk.WinForms.Controls.LocLabelEx AddressLabel;
-		private System.Windows.Forms.ToolStripMenuItem CopyContextItem;
-		private System.Windows.Forms.ToolStripMenuItem PasteContextItem;
-		private System.Windows.Forms.ToolStripMenuItem FindNextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FindPrevMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FindNextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FindPrevMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeContextItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem LoadTableFileMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentTablesSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem noneToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CloseTableFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadTableFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentTablesSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseTableFileMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
 		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
-		private System.Windows.Forms.ToolStripMenuItem viewN64MatrixToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ExportContextItem;
-		private System.Windows.Forms.ToolStripMenuItem ExportMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem importAsBinaryToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx viewN64MatrixToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExportContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExportMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx importAsBinaryToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
@@ -37,30 +37,30 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveAsBinaryMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveAsTextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.importAsBinaryToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.LoadTableFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CloseTableFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentTablesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.EditMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ExportMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PasteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.FindMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FindNextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FindPrevMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemoryDomainsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DataSizeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DataSizeByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DataSizeWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DataSizeDWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.GoToAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AddToRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -69,9 +69,9 @@ namespace BizHawk.Client.EmuHawk
 			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CustomColorsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetColorsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ResetColorsToDefaultMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.resetToDefaultToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ViewerContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.CopyContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -81,12 +81,12 @@ namespace BizHawk.Client.EmuHawk
 			this.AddToRamWatchContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UnfreezeAllContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PokeContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.ContextSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.IncrementContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DecrementContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.ContextSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.GoToContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.viewN64MatrixToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemoryViewerBox = new System.Windows.Forms.GroupBox();
 			this.HexScrollBar = new System.Windows.Forms.VScrollBar();
@@ -149,11 +149,6 @@ namespace BizHawk.Client.EmuHawk
 			this.importAsBinaryToolStripMenuItem.Text = "Import as binary...";
 			this.importAsBinaryToolStripMenuItem.Click += new System.EventHandler(this.importAsBinaryToolStripMenuItem_Click);
 			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(226, 6);
-			// 
 			// LoadTableFileMenuItem
 			// 
 			this.LoadTableFileMenuItem.Text = "&Load .tbl file";
@@ -174,11 +169,6 @@ namespace BizHawk.Client.EmuHawk
 			// noneToolStripMenuItem
 			// 
 			this.noneToolStripMenuItem.Text = "None";
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(226, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -216,11 +206,6 @@ namespace BizHawk.Client.EmuHawk
 			this.PasteMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
 			this.PasteMenuItem.Text = "&Paste";
 			this.PasteMenuItem.Click += new System.EventHandler(this.PasteMenuItem_Click);
-			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(144, 6);
 			// 
 			// FindMenuItem
 			// 
@@ -262,11 +247,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MemoryDomainsMenuItem.Text = "&Memory Domains";
 			this.MemoryDomainsMenuItem.DropDownOpened += new System.EventHandler(this.MemoryDomainsMenuItem_DropDownOpened);
 			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(57, 6);
-			// 
 			// DataSizeSubMenu
 			// 
 			this.DataSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -294,11 +274,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.BigEndianMenuItem.Text = "Big Endian";
 			this.BigEndianMenuItem.Click += new System.EventHandler(this.BigEndianMenuItem_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(218, 6);
 			// 
 			// GoToAddressMenuItem
 			// 
@@ -349,20 +324,10 @@ namespace BizHawk.Client.EmuHawk
 			this.SetColorsMenuItem.Text = "Set Colors";
 			this.SetColorsMenuItem.Click += new System.EventHandler(this.SetColorsMenuItem_Click);
 			// 
-			// toolStripSeparator8
-			// 
-			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(154, 6);
-			// 
 			// ResetColorsToDefaultMenuItem
 			// 
 			this.ResetColorsToDefaultMenuItem.Text = "Reset to Default";
 			this.ResetColorsToDefaultMenuItem.Click += new System.EventHandler(this.ResetColorsToDefaultMenuItem_Click);
-			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(154, 6);
 			// 
 			// resetToDefaultToolStripMenuItem
 			// 
@@ -430,11 +395,6 @@ namespace BizHawk.Client.EmuHawk
 			this.PokeContextItem.Text = "&Poke Address";
 			this.PokeContextItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
 			// 
-			// ContextSeparator1
-			// 
-			this.ContextSeparator1.Name = "ContextSeparator1";
-			this.ContextSeparator1.Size = new System.Drawing.Size(218, 6);
-			// 
 			// IncrementContextItem
 			// 
 			this.IncrementContextItem.ShortcutKeyDisplayString = "+";
@@ -447,21 +407,11 @@ namespace BizHawk.Client.EmuHawk
 			this.DecrementContextItem.Text = "&Decrement";
 			this.DecrementContextItem.Click += new System.EventHandler(this.DecrementContextItem_Click);
 			// 
-			// ContextSeparator2
-			// 
-			this.ContextSeparator2.Name = "ContextSeparator2";
-			this.ContextSeparator2.Size = new System.Drawing.Size(218, 6);
-			// 
 			// GoToContextItem
 			// 
 			this.GoToContextItem.ShortcutKeyDisplayString = "Ctrl+G";
 			this.GoToContextItem.Text = "&Go to Address...";
 			this.GoToContextItem.Click += new System.EventHandler(this.GoToAddressMenuItem_Click);
-			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(218, 6);
 			// 
 			// viewN64MatrixToolStripMenuItem
 			// 
@@ -557,7 +507,7 @@ namespace BizHawk.Client.EmuHawk
 		public MenuStripEx HexMenuStrip;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsTextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsMenuItem;
@@ -571,7 +521,7 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ContextMenuStrip ViewerContextMenuStrip;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchContextItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
 		public System.Windows.Forms.GroupBox MemoryViewerBox;
@@ -579,22 +529,22 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.VScrollBar HexScrollBar;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextItem;
-		private System.Windows.Forms.ToolStripSeparator ContextSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx IncrementContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DecrementContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GoToContextItem;
-		private System.Windows.Forms.ToolStripSeparator ContextSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FindMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsBinaryMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx resetToDefaultToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CustomColorsSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetColorsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ResetColorsToDefaultMenuItem;
 		public BizHawk.WinForms.Controls.LocLabelEx Header;
 		private BizHawk.WinForms.Controls.LocLabelEx AddressLabel;
@@ -605,13 +555,13 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeAddressMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeContextItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadTableFileMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentTablesSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseTableFileMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripMenuItem1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx viewN64MatrixToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExportContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExportMenuItem;

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
@@ -32,63 +32,63 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.ScriptListContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.ToggleScriptContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PauseScriptContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditScriptContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveScriptContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertSeperatorContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ToggleScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PauseScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertSeperatorContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScriptContextSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.StopAllScriptsContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearRegisteredFunctionsContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.StopAllScriptsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearRegisteredFunctionsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewSessionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenSessionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveSessionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveSessionAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewSessionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenSessionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSessionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSessionAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-			this.RecentSessionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.RecentSessionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-			this.RecentScriptsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.RecentScriptsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScriptSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RefreshScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ToggleScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PauseScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DuplicateScriptMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScriptSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RefreshScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ToggleScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PauseScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DuplicateScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.InsertSeparatorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MoveUpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MoveDownMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.StopAllScriptsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RegisteredFunctionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisableScriptsOnLoadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ReturnAllIfNoneSelectedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ReloadWhenScriptFileChangesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.StopAllScriptsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RegisteredFunctionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisableScriptsOnLoadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ReturnAllIfNoneSelectedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ReloadWhenScriptFileChangesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.RegisterToTextEditorsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.RegisterSublimeText2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RegisterNotePadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HelpSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.FunctionsListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OnlineDocsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RegisterToTextEditorsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RegisterSublimeText2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RegisterNotePadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FunctionsListMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OnlineDocsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OutputBox = new System.Windows.Forms.RichTextBox();
 			this.ConsoleContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.ClearConsoleContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopyContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearConsoleContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopyContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.RegisteredFunctionsContextItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearRegisteredFunctionsLogContextItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RegisteredFunctionsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearRegisteredFunctionsLogContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.InputBox = new System.Windows.Forms.TextBox();
 			this.NumberOfScripts = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -138,36 +138,26 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ToggleScriptContextItem
 			// 
-			this.ToggleScriptContextItem.Name = "ToggleScriptContextItem";
-			this.ToggleScriptContextItem.Size = new System.Drawing.Size(203, 22);
 			this.ToggleScriptContextItem.Text = "&Toggle";
 			this.ToggleScriptContextItem.Click += new System.EventHandler(this.ToggleScriptMenuItem_Click);
 			// 
 			// PauseScriptContextItem
 			// 
-			this.PauseScriptContextItem.Name = "PauseScriptContextItem";
-			this.PauseScriptContextItem.Size = new System.Drawing.Size(203, 22);
 			this.PauseScriptContextItem.Text = "Pause or Resume";
 			this.PauseScriptContextItem.Click += new System.EventHandler(this.PauseScriptMenuItem_Click);
 			// 
 			// EditScriptContextItem
 			// 
-			this.EditScriptContextItem.Name = "EditScriptContextItem";
-			this.EditScriptContextItem.Size = new System.Drawing.Size(203, 22);
 			this.EditScriptContextItem.Text = "&Edit";
 			this.EditScriptContextItem.Click += new System.EventHandler(this.EditScriptMenuItem_Click);
 			// 
 			// RemoveScriptContextItem
 			// 
-			this.RemoveScriptContextItem.Name = "RemoveScriptContextItem";
-			this.RemoveScriptContextItem.Size = new System.Drawing.Size(203, 22);
 			this.RemoveScriptContextItem.Text = "&Remove";
 			this.RemoveScriptContextItem.Click += new System.EventHandler(this.RemoveScriptMenuItem_Click);
 			// 
 			// InsertSeperatorContextItem
 			// 
-			this.InsertSeperatorContextItem.Name = "InsertSeperatorContextItem";
-			this.InsertSeperatorContextItem.Size = new System.Drawing.Size(203, 22);
 			this.InsertSeperatorContextItem.Text = "Insert Seperator";
 			this.InsertSeperatorContextItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
 			// 
@@ -178,15 +168,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// StopAllScriptsContextItem
 			// 
-			this.StopAllScriptsContextItem.Name = "StopAllScriptsContextItem";
-			this.StopAllScriptsContextItem.Size = new System.Drawing.Size(203, 22);
 			this.StopAllScriptsContextItem.Text = "Stop All Scripts";
 			this.StopAllScriptsContextItem.Click += new System.EventHandler(this.StopAllScriptsMenuItem_Click);
 			// 
 			// ClearRegisteredFunctionsContextItem
 			// 
-			this.ClearRegisteredFunctionsContextItem.Name = "ClearRegisteredFunctionsContextItem";
-			this.ClearRegisteredFunctionsContextItem.Size = new System.Drawing.Size(203, 22);
 			this.ClearRegisteredFunctionsContextItem.Text = "Clear Registered Functions";
 			this.ClearRegisteredFunctionsContextItem.Click += new System.EventHandler(this.ClearRegisteredFunctionsContextMenuItem_Click);
 			// 
@@ -213,43 +199,33 @@ namespace BizHawk.Client.EmuHawk
             this.RecentScriptsSubMenu,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// NewSessionMenuItem
 			// 
-			this.NewSessionMenuItem.Name = "NewSessionMenuItem";
 			this.NewSessionMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.N)));
-			this.NewSessionMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.NewSessionMenuItem.Text = "&New Session";
 			this.NewSessionMenuItem.Click += new System.EventHandler(this.NewSessionMenuItem_Click);
 			// 
 			// OpenSessionMenuItem
 			// 
-			this.OpenSessionMenuItem.Name = "OpenSessionMenuItem";
 			this.OpenSessionMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.O)));
-			this.OpenSessionMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.OpenSessionMenuItem.Text = "&Open Session...";
 			this.OpenSessionMenuItem.Click += new System.EventHandler(this.OpenSessionMenuItem_Click);
 			// 
 			// SaveSessionMenuItem
 			// 
-			this.SaveSessionMenuItem.Name = "SaveSessionMenuItem";
 			this.SaveSessionMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveSessionMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.SaveSessionMenuItem.Text = "&Save Session";
 			this.SaveSessionMenuItem.Click += new System.EventHandler(this.SaveSessionMenuItem_Click);
 			// 
 			// SaveSessionAsMenuItem
 			// 
-			this.SaveSessionAsMenuItem.Name = "SaveSessionAsMenuItem";
 			this.SaveSessionAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveSessionAsMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.SaveSessionAsMenuItem.Text = "Save Session &As...";
 			this.SaveSessionAsMenuItem.Click += new System.EventHandler(this.SaveSessionAsMenuItem_Click);
 			// 
@@ -262,8 +238,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentSessionsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator8});
-			this.RecentSessionsSubMenu.Name = "RecentSessionsSubMenu";
-			this.RecentSessionsSubMenu.Size = new System.Drawing.Size(232, 22);
 			this.RecentSessionsSubMenu.Text = "Recent Sessions";
 			this.RecentSessionsSubMenu.DropDownOpened += new System.EventHandler(this.RecentSessionsSubMenu_DropDownOpened);
 			// 
@@ -276,8 +250,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentScriptsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator3});
-			this.RecentScriptsSubMenu.Name = "RecentScriptsSubMenu";
-			this.RecentScriptsSubMenu.Size = new System.Drawing.Size(232, 22);
 			this.RecentScriptsSubMenu.Text = "Recent Scripts";
 			this.RecentScriptsSubMenu.DropDownOpened += new System.EventHandler(this.RecentScriptsSubMenu_DropDownOpened);
 			// 
@@ -293,9 +265,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -318,70 +288,52 @@ namespace BizHawk.Client.EmuHawk
             this.toolStripSeparator6,
             this.StopAllScriptsMenuItem,
             this.RegisteredFunctionsMenuItem});
-			this.ScriptSubMenu.Name = "ScriptSubMenu";
-			this.ScriptSubMenu.Size = new System.Drawing.Size(46, 20);
 			this.ScriptSubMenu.Text = "&Script";
 			this.ScriptSubMenu.DropDownOpened += new System.EventHandler(this.ScriptSubMenu_DropDownOpened);
 			// 
 			// NewScriptMenuItem
 			// 
-			this.NewScriptMenuItem.Name = "NewScriptMenuItem";
 			this.NewScriptMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.NewScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.NewScriptMenuItem.Text = "New Script";
 			this.NewScriptMenuItem.Click += new System.EventHandler(this.NewScriptMenuItem_Click);
 			// 
 			// OpenScriptMenuItem
 			// 
-			this.OpenScriptMenuItem.Name = "OpenScriptMenuItem";
 			this.OpenScriptMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.OpenScriptMenuItem.Text = "&Open Script...";
 			this.OpenScriptMenuItem.Click += new System.EventHandler(this.OpenScriptMenuItem_Click);
 			// 
 			// RefreshScriptMenuItem
 			// 
-			this.RefreshScriptMenuItem.Name = "RefreshScriptMenuItem";
 			this.RefreshScriptMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
-			this.RefreshScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.RefreshScriptMenuItem.Text = "&Re&fresh";
 			this.RefreshScriptMenuItem.Click += new System.EventHandler(this.RefreshScriptMenuItem_Click);
 			// 
 			// ToggleScriptMenuItem
 			// 
-			this.ToggleScriptMenuItem.Name = "ToggleScriptMenuItem";
 			this.ToggleScriptMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
-			this.ToggleScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.ToggleScriptMenuItem.Text = "&Toggle";
 			this.ToggleScriptMenuItem.Click += new System.EventHandler(this.ToggleScriptMenuItem_Click);
 			// 
 			// PauseScriptMenuItem
 			// 
-			this.PauseScriptMenuItem.Name = "PauseScriptMenuItem";
-			this.PauseScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.PauseScriptMenuItem.Text = "Pause or Resume";
 			this.PauseScriptMenuItem.Click += new System.EventHandler(this.PauseScriptMenuItem_Click);
 			// 
 			// EditScriptMenuItem
 			// 
-			this.EditScriptMenuItem.Name = "EditScriptMenuItem";
 			this.EditScriptMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-			this.EditScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.EditScriptMenuItem.Text = "&Edit Script";
 			this.EditScriptMenuItem.Click += new System.EventHandler(this.EditScriptMenuItem_Click);
 			// 
 			// RemoveScriptMenuItem
 			// 
-			this.RemoveScriptMenuItem.Name = "RemoveScriptMenuItem";
 			this.RemoveScriptMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.RemoveScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.RemoveScriptMenuItem.Text = "&Remove Script";
 			this.RemoveScriptMenuItem.Click += new System.EventHandler(this.RemoveScriptMenuItem_Click);
 			// 
 			// DuplicateScriptMenuItem
 			// 
-			this.DuplicateScriptMenuItem.Name = "DuplicateScriptMenuItem";
-			this.DuplicateScriptMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.DuplicateScriptMenuItem.Text = "&Duplicate Script";
 			this.DuplicateScriptMenuItem.Click += new System.EventHandler(this.DuplicateScriptMenuItem_Click);
 			// 
@@ -392,33 +344,25 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// InsertSeparatorMenuItem
 			// 
-			this.InsertSeparatorMenuItem.Name = "InsertSeparatorMenuItem";
 			this.InsertSeparatorMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-			this.InsertSeparatorMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.InsertSeparatorMenuItem.Text = "Insert Separator";
 			this.InsertSeparatorMenuItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
 			// 
 			// MoveUpMenuItem
 			// 
-			this.MoveUpMenuItem.Name = "MoveUpMenuItem";
 			this.MoveUpMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
-			this.MoveUpMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.MoveUpMenuItem.Text = "Move &Up";
 			this.MoveUpMenuItem.Click += new System.EventHandler(this.MoveUpMenuItem_Click);
 			// 
 			// MoveDownMenuItem
 			// 
-			this.MoveDownMenuItem.Name = "MoveDownMenuItem";
 			this.MoveDownMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
-			this.MoveDownMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.MoveDownMenuItem.Text = "Move &Down";
 			this.MoveDownMenuItem.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
 			// 
 			// SelectAllMenuItem
 			// 
-			this.SelectAllMenuItem.Name = "SelectAllMenuItem";
 			this.SelectAllMenuItem.ShortcutKeyDisplayString = "Ctrl+A";
-			this.SelectAllMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
@@ -429,16 +373,12 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// StopAllScriptsMenuItem
 			// 
-			this.StopAllScriptsMenuItem.Name = "StopAllScriptsMenuItem";
-			this.StopAllScriptsMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.StopAllScriptsMenuItem.Text = "Stop All Scripts";
 			this.StopAllScriptsMenuItem.Click += new System.EventHandler(this.StopAllScriptsMenuItem_Click);
 			// 
 			// RegisteredFunctionsMenuItem
 			// 
-			this.RegisteredFunctionsMenuItem.Name = "RegisteredFunctionsMenuItem";
 			this.RegisteredFunctionsMenuItem.ShortcutKeyDisplayString = "F12";
-			this.RegisteredFunctionsMenuItem.Size = new System.Drawing.Size(212, 22);
 			this.RegisteredFunctionsMenuItem.Text = "&Registered Functions...";
 			this.RegisteredFunctionsMenuItem.Click += new System.EventHandler(this.RegisteredFunctionsMenuItem_Click);
 			// 
@@ -450,29 +390,21 @@ namespace BizHawk.Client.EmuHawk
             this.ReloadWhenScriptFileChangesMenuItem,
             this.toolStripSeparator4,
             this.RegisterToTextEditorsSubMenu});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(58, 20);
 			this.SettingsSubMenu.Text = "&Settings";
 			this.SettingsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
 			// DisableScriptsOnLoadMenuItem
 			// 
-			this.DisableScriptsOnLoadMenuItem.Name = "DisableScriptsOnLoadMenuItem";
-			this.DisableScriptsOnLoadMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.DisableScriptsOnLoadMenuItem.Text = "Disable Scripts on Load";
 			this.DisableScriptsOnLoadMenuItem.Click += new System.EventHandler(this.DisableScriptsOnLoadMenuItem_Click);
 			// 
 			// ReturnAllIfNoneSelectedMenuItem
 			// 
-			this.ReturnAllIfNoneSelectedMenuItem.Name = "ReturnAllIfNoneSelectedMenuItem";
-			this.ReturnAllIfNoneSelectedMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.ReturnAllIfNoneSelectedMenuItem.Text = "Toggle All if None Selected";
 			this.ReturnAllIfNoneSelectedMenuItem.Click += new System.EventHandler(this.ToggleAllIfNoneSelectedMenuItem_Click);
 			// 
 			// ReloadWhenScriptFileChangesMenuItem
 			// 
-			this.ReloadWhenScriptFileChangesMenuItem.Name = "ReloadWhenScriptFileChangesMenuItem";
-			this.ReloadWhenScriptFileChangesMenuItem.Size = new System.Drawing.Size(232, 22);
 			this.ReloadWhenScriptFileChangesMenuItem.Text = "Reload When Script File Changes";
 			this.ReloadWhenScriptFileChangesMenuItem.Click += new System.EventHandler(this.ReloadWhenScriptFileChangesMenuItem_Click);
 			// 
@@ -486,22 +418,16 @@ namespace BizHawk.Client.EmuHawk
 			this.RegisterToTextEditorsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.RegisterSublimeText2MenuItem,
             this.RegisterNotePadMenuItem});
-			this.RegisterToTextEditorsSubMenu.Name = "RegisterToTextEditorsSubMenu";
-			this.RegisterToTextEditorsSubMenu.Size = new System.Drawing.Size(232, 22);
 			this.RegisterToTextEditorsSubMenu.Text = "Register To Text Editors";
 			this.RegisterToTextEditorsSubMenu.DropDownOpened += new System.EventHandler(this.RegisterToTextEditorsSubMenu_DropDownOpened);
 			// 
 			// RegisterSublimeText2MenuItem
 			// 
-			this.RegisterSublimeText2MenuItem.Name = "RegisterSublimeText2MenuItem";
-			this.RegisterSublimeText2MenuItem.Size = new System.Drawing.Size(144, 22);
 			this.RegisterSublimeText2MenuItem.Text = "&Sublime Text 2";
 			this.RegisterSublimeText2MenuItem.Click += new System.EventHandler(this.RegisterSublimeText2MenuItem_Click);
 			// 
 			// RegisterNotePadMenuItem
 			// 
-			this.RegisterNotePadMenuItem.Name = "RegisterNotePadMenuItem";
-			this.RegisterNotePadMenuItem.Size = new System.Drawing.Size(144, 22);
 			this.RegisterNotePadMenuItem.Text = "Notepad++";
 			this.RegisterNotePadMenuItem.Click += new System.EventHandler(this.RegisterNotePadMenuItem_Click);
 			// 
@@ -510,22 +436,16 @@ namespace BizHawk.Client.EmuHawk
 			this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.FunctionsListMenuItem,
             this.OnlineDocsMenuItem});
-			this.HelpSubMenu.Name = "HelpSubMenu";
-			this.HelpSubMenu.Size = new System.Drawing.Size(40, 20);
 			this.HelpSubMenu.Text = "&Help";
 			// 
 			// FunctionsListMenuItem
 			// 
-			this.FunctionsListMenuItem.Name = "FunctionsListMenuItem";
 			this.FunctionsListMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-			this.FunctionsListMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.FunctionsListMenuItem.Text = "&Lua Functions List";
 			this.FunctionsListMenuItem.Click += new System.EventHandler(this.FunctionsListMenuItem_Click);
 			// 
 			// OnlineDocsMenuItem
 			// 
-			this.OnlineDocsMenuItem.Name = "OnlineDocsMenuItem";
-			this.OnlineDocsMenuItem.Size = new System.Drawing.Size(189, 22);
 			this.OnlineDocsMenuItem.Text = "Documentation online...";
 			this.OnlineDocsMenuItem.Click += new System.EventHandler(this.OnlineDocsMenuItem_Click);
 			// 
@@ -560,22 +480,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearConsoleContextItem
 			// 
-			this.ClearConsoleContextItem.Name = "ClearConsoleContextItem";
-			this.ClearConsoleContextItem.Size = new System.Drawing.Size(203, 22);
 			this.ClearConsoleContextItem.Text = "&Clear";
 			this.ClearConsoleContextItem.Click += new System.EventHandler(this.ClearConsoleContextItem_Click);
 			// 
 			// SelectAllContextItem
 			// 
-			this.SelectAllContextItem.Name = "SelectAllContextItem";
-			this.SelectAllContextItem.Size = new System.Drawing.Size(203, 22);
 			this.SelectAllContextItem.Text = "Select &All";
 			this.SelectAllContextItem.Click += new System.EventHandler(this.SelectAllContextItem_Click);
 			// 
 			// CopyContextItem
 			// 
-			this.CopyContextItem.Name = "CopyContextItem";
-			this.CopyContextItem.Size = new System.Drawing.Size(203, 22);
 			this.CopyContextItem.Text = "Copy";
 			this.CopyContextItem.Click += new System.EventHandler(this.CopyContextItem_Click);
 			// 
@@ -586,15 +500,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// RegisteredFunctionsContextItem
 			// 
-			this.RegisteredFunctionsContextItem.Name = "RegisteredFunctionsContextItem";
-			this.RegisteredFunctionsContextItem.Size = new System.Drawing.Size(203, 22);
 			this.RegisteredFunctionsContextItem.Text = "&Registered Functions";
 			this.RegisteredFunctionsContextItem.Click += new System.EventHandler(this.RegisteredFunctionsMenuItem_Click);
 			// 
 			// ClearRegisteredFunctionsLogContextItem
 			// 
-			this.ClearRegisteredFunctionsLogContextItem.Name = "ClearRegisteredFunctionsLogContextItem";
-			this.ClearRegisteredFunctionsLogContextItem.Size = new System.Drawing.Size(203, 22);
 			this.ClearRegisteredFunctionsLogContextItem.Text = "Clear Registered Functions";
 			this.ClearRegisteredFunctionsLogContextItem.Click += new System.EventHandler(this.ClearRegisteredFunctionsContextMenuItem_Click);
 			// 
@@ -861,35 +771,35 @@ namespace BizHawk.Client.EmuHawk
 
 		private InputRoll LuaListView;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SaveSessionMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveSessionAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSessionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSessionAsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScriptSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem EditScriptMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ToggleScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScriptSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleScriptMenuItem;
 		private System.Windows.Forms.GroupBox groupBox1;
-		private System.Windows.Forms.ToolStripMenuItem NewSessionMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewSessionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
 		private BizHawk.WinForms.Controls.LocLabelEx NumberOfScripts;
-		private System.Windows.Forms.ToolStripMenuItem InsertSeparatorMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StopAllScriptsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeparatorMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAllScriptsMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ScriptListContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem RecentScriptsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentScriptsSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem StopAllScriptsContextItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveScriptContextItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertSeperatorContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAllScriptsContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveScriptContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeperatorContextItem;
 		private System.Windows.Forms.ToolStripSeparator ScriptContextSeparator;
-		private System.Windows.Forms.ToolStripMenuItem EditScriptContextItem;
-		private System.Windows.Forms.ToolStripMenuItem ToggleScriptContextItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditScriptContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleScriptContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveScriptMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem MoveUpMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MoveDownMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton OpenScriptToolbarItem;
 		private System.Windows.Forms.ToolStripButton RemoveScriptToolbarItem;
@@ -899,44 +809,44 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton MoveUpToolbarItem;
 		private System.Windows.Forms.ToolStripButton toolStripButtonMoveDown;
 		private System.Windows.Forms.ToolStripButton EditToolbarItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenScriptMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenSessionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenSessionMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
-		private System.Windows.Forms.ToolStripMenuItem RecentSessionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSessionsSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-		private System.Windows.Forms.ToolStripMenuItem HelpSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem FunctionsListMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HelpSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FunctionsListMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ConsoleContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem ClearConsoleContextItem;
-		private System.Windows.Forms.ToolStripMenuItem DisableScriptsOnLoadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PauseScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearConsoleContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisableScriptsOnLoadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PauseScriptMenuItem;
 		private System.Windows.Forms.ToolStripButton PauseToolbarItem;
-		private System.Windows.Forms.ToolStripMenuItem PauseScriptContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PauseScriptContextItem;
 		public System.Windows.Forms.RichTextBox OutputBox;
 		private BizHawk.WinForms.Controls.LocLabelEx OutputMessages;
-		private System.Windows.Forms.ToolStripMenuItem OnlineDocsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NewScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OnlineDocsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewScriptMenuItem;
 		private System.Windows.Forms.ToolStripButton NewScriptToolbarItem;
-		private System.Windows.Forms.ToolStripMenuItem RegisteredFunctionsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RegisteredFunctionsContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisteredFunctionsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisteredFunctionsContextItem;
 		private System.Windows.Forms.ToolStripButton RefreshScriptToolbarItem;
-		private System.Windows.Forms.ToolStripMenuItem RefreshScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RefreshScriptMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
 		private System.Windows.Forms.ToolStripButton EraseToolbarItem;
 		private System.Windows.Forms.ToolStripButton DuplicateToolbarButton;
-		private System.Windows.Forms.ToolStripMenuItem DuplicateScriptMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DuplicateScriptMenuItem;
         private System.Windows.Forms.TextBox InputBox;
 		private System.Windows.Forms.SplitContainer splitContainer1;
-		private System.Windows.Forms.ToolStripMenuItem ReturnAllIfNoneSelectedMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ReloadWhenScriptFileChangesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReturnAllIfNoneSelectedMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReloadWhenScriptFileChangesMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem RegisterToTextEditorsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem RegisterSublimeText2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RegisterNotePadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllContextItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyContextItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearRegisteredFunctionsContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterToTextEditorsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterSublimeText2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterNotePadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearRegisteredFunctionsContextItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-		private System.Windows.Forms.ToolStripMenuItem ClearRegisteredFunctionsLogContextItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearRegisteredFunctionsLogContextItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
@@ -37,7 +37,7 @@ namespace BizHawk.Client.EmuHawk
 			this.EditScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveScriptContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertSeperatorContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ScriptContextSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.ScriptContextSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.StopAllScriptsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearRegisteredFunctionsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.menuStrip1 = new MenuStripEx();
@@ -46,12 +46,12 @@ namespace BizHawk.Client.EmuHawk
 			this.OpenSessionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveSessionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveSessionAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RecentSessionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RecentScriptsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScriptSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NewScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -62,19 +62,19 @@ namespace BizHawk.Client.EmuHawk
 			this.EditScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DuplicateScriptMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.StopAllScriptsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RegisteredFunctionsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisableScriptsOnLoadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ReturnAllIfNoneSelectedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ReloadWhenScriptFileChangesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RegisterToTextEditorsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RegisterSublimeText2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RegisterNotePadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -86,7 +86,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ClearConsoleContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectAllContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RegisteredFunctionsContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearRegisteredFunctionsLogContextItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -102,11 +102,11 @@ namespace BizHawk.Client.EmuHawk
 			this.EditToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.RemoveScriptToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.DuplicateToolbarButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MoveUpToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.toolStripButtonMoveDown = new System.Windows.Forms.ToolStripButton();
 			this.InsertSeparatorToolbarItem = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.EraseToolbarItem = new System.Windows.Forms.ToolStripButton();
 			this.LuaListView = new BizHawk.Client.EmuHawk.InputRoll();
 			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
@@ -160,11 +160,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.InsertSeperatorContextItem.Text = "Insert Seperator";
 			this.InsertSeperatorContextItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
-			// 
-			// ScriptContextSeparator
-			// 
-			this.ScriptContextSeparator.Name = "ScriptContextSeparator";
-			this.ScriptContextSeparator.Size = new System.Drawing.Size(200, 6);
 			// 
 			// StopAllScriptsContextItem
 			// 
@@ -229,11 +224,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveSessionAsMenuItem.Text = "Save Session &As...";
 			this.SaveSessionAsMenuItem.Click += new System.EventHandler(this.SaveSessionAsMenuItem_Click);
 			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			this.toolStripSeparator9.Size = new System.Drawing.Size(229, 6);
-			// 
 			// RecentSessionsSubMenu
 			// 
 			this.RecentSessionsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -241,27 +231,12 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSessionsSubMenu.Text = "Recent Sessions";
 			this.RecentSessionsSubMenu.DropDownOpened += new System.EventHandler(this.RecentSessionsSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator8
-			// 
-			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(57, 6);
-			// 
 			// RecentScriptsSubMenu
 			// 
 			this.RecentScriptsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator3});
 			this.RecentScriptsSubMenu.Text = "Recent Scripts";
 			this.RecentScriptsSubMenu.DropDownOpened += new System.EventHandler(this.RecentScriptsSubMenu_DropDownOpened);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(229, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -337,11 +312,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DuplicateScriptMenuItem.Text = "&Duplicate Script";
 			this.DuplicateScriptMenuItem.Click += new System.EventHandler(this.DuplicateScriptMenuItem_Click);
 			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(209, 6);
-			// 
 			// InsertSeparatorMenuItem
 			// 
 			this.InsertSeparatorMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
@@ -365,11 +335,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SelectAllMenuItem.ShortcutKeyDisplayString = "Ctrl+A";
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
-			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(209, 6);
 			// 
 			// StopAllScriptsMenuItem
 			// 
@@ -407,11 +372,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ReloadWhenScriptFileChangesMenuItem.Text = "Reload When Script File Changes";
 			this.ReloadWhenScriptFileChangesMenuItem.Click += new System.EventHandler(this.ReloadWhenScriptFileChangesMenuItem_Click);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(229, 6);
 			// 
 			// RegisterToTextEditorsSubMenu
 			// 
@@ -492,11 +452,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.CopyContextItem.Text = "Copy";
 			this.CopyContextItem.Click += new System.EventHandler(this.CopyContextItem_Click);
-			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(200, 6);
 			// 
 			// RegisteredFunctionsContextItem
 			// 
@@ -639,11 +594,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DuplicateToolbarButton.Text = "Duplicate Script";
 			this.DuplicateToolbarButton.Click += new System.EventHandler(this.DuplicateScriptMenuItem_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			// 
 			// MoveUpToolbarItem
 			// 
 			this.MoveUpToolbarItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -670,11 +620,6 @@ namespace BizHawk.Client.EmuHawk
 			this.InsertSeparatorToolbarItem.Size = new System.Drawing.Size(23, 22);
 			this.InsertSeparatorToolbarItem.Text = "Insert Separator";
 			this.InsertSeparatorToolbarItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
-			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			this.toolStripSeparator10.Size = new System.Drawing.Size(6, 25);
 			// 
 			// EraseToolbarItem
 			// 
@@ -774,7 +719,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSessionMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSessionAsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScriptSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditScriptMenuItem;
@@ -787,16 +732,16 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAllScriptsMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ScriptListContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentScriptsSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StopAllScriptsContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveScriptContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeperatorContextItem;
-		private System.Windows.Forms.ToolStripSeparator ScriptContextSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ScriptContextSeparator;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditScriptContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToggleScriptContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveScriptMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
@@ -805,15 +750,15 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton RemoveScriptToolbarItem;
 		private System.Windows.Forms.ToolStripButton ToggleScriptToolbarItem;
 		private System.Windows.Forms.ToolStripButton InsertSeparatorToolbarItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private System.Windows.Forms.ToolStripButton MoveUpToolbarItem;
 		private System.Windows.Forms.ToolStripButton toolStripButtonMoveDown;
 		private System.Windows.Forms.ToolStripButton EditToolbarItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenScriptMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenSessionMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator9;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSessionsSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HelpSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FunctionsListMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ConsoleContextMenu;
@@ -831,7 +776,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisteredFunctionsContextItem;
 		private System.Windows.Forms.ToolStripButton RefreshScriptToolbarItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RefreshScriptMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator10;
 		private System.Windows.Forms.ToolStripButton EraseToolbarItem;
 		private System.Windows.Forms.ToolStripButton DuplicateToolbarButton;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DuplicateScriptMenuItem;
@@ -839,14 +784,14 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.SplitContainer splitContainer1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReturnAllIfNoneSelectedMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReloadWhenScriptFileChangesMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterToTextEditorsSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterSublimeText2MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RegisterNotePadMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyContextItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearRegisteredFunctionsContextItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearRegisteredFunctionsLogContextItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaRegisteredFunctionsList.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaRegisteredFunctionsList.Designer.cs
@@ -37,8 +37,8 @@
 			this.CallButton = new System.Windows.Forms.Button();
 			this.RemoveButton = new System.Windows.Forms.Button();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.callToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.removeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.callToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.removeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveAllBtn = new System.Windows.Forms.Button();
 			this.contextMenuStrip1.SuspendLayout();
 			this.SuspendLayout();
@@ -126,15 +126,11 @@
 			// 
 			// callToolStripMenuItem
 			// 
-			this.callToolStripMenuItem.Name = "callToolStripMenuItem";
-			this.callToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
 			this.callToolStripMenuItem.Text = "&Call";
 			this.callToolStripMenuItem.Click += new System.EventHandler(this.CallButton_Click);
 			// 
 			// removeToolStripMenuItem
 			// 
-			this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-			this.removeToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
 			this.removeToolStripMenuItem.Text = "&Remove";
 			this.removeToolStripMenuItem.Click += new System.EventHandler(this.RemoveButton_Click);
 			// 
@@ -181,8 +177,8 @@
 		private System.Windows.Forms.Button CallButton;
 		private System.Windows.Forms.Button RemoveButton;
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem callToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx callToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx removeToolStripMenuItem;
 		private System.Windows.Forms.Button RemoveAllBtn;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
@@ -29,13 +29,13 @@
 		private void InitializeComponent()
 		{
 			this.MacroMenu = new System.Windows.Forms.MenuStrip();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.loadMacroToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveAsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.loadMacroToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
 			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NameTextbox = new System.Windows.Forms.TextBox();
 			this.ReplaceBox = new System.Windows.Forms.CheckBox();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -73,21 +73,15 @@
             this.RecentToolStripMenuItem,
             this.sepToolStripMenuItem,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// saveAsToolStripMenuItem
 			// 
-			this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-			this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.saveAsToolStripMenuItem.Text = "Save Selected As...";
 			this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.SaveAsToolStripMenuItem_Click);
 			// 
 			// loadMacroToolStripMenuItem
 			// 
-			this.loadMacroToolStripMenuItem.Name = "loadMacroToolStripMenuItem";
-			this.loadMacroToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.loadMacroToolStripMenuItem.Text = "Load Macro...";
 			this.loadMacroToolStripMenuItem.Click += new System.EventHandler(this.LoadMacroToolStripMenuItem_Click);
 			// 
@@ -95,8 +89,6 @@
 			// 
 			this.RecentToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator1});
-			this.RecentToolStripMenuItem.Name = "RecentToolStripMenuItem";
-			this.RecentToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.RecentToolStripMenuItem.Text = "Recent";
 			this.RecentToolStripMenuItem.DropDownOpened += new System.EventHandler(this.RecentToolStripMenuItem_DropDownOpened);
 			// 
@@ -112,9 +104,7 @@
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(170, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -292,8 +282,8 @@
 		#endregion
 
 		private System.Windows.Forms.MenuStrip MacroMenu;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.TextBox NameTextbox;
 		private System.Windows.Forms.CheckBox ReplaceBox;
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
@@ -305,9 +295,9 @@
 		private System.Windows.Forms.ListBox ZonesList;
 		private BizHawk.WinForms.Controls.LocLabelEx label3;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
-		private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem loadMacroToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveAsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx loadMacroToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
 		private System.Windows.Forms.Button CurrentButton;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
@@ -33,8 +33,8 @@
 			this.saveAsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.loadMacroToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.sepToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NameTextbox = new System.Windows.Forms.TextBox();
 			this.ReplaceBox = new System.Windows.Forms.CheckBox();
@@ -91,16 +91,6 @@
             this.toolStripSeparator1});
 			this.RecentToolStripMenuItem.Text = "Recent";
 			this.RecentToolStripMenuItem.DropDownOpened += new System.EventHandler(this.RecentToolStripMenuItem_DropDownOpened);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(57, 6);
-			// 
-			// sepToolStripMenuItem
-			// 
-			this.sepToolStripMenuItem.Name = "sepToolStripMenuItem";
-			this.sepToolStripMenuItem.Size = new System.Drawing.Size(167, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -298,9 +288,9 @@
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveAsToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx loadMacroToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx sepToolStripMenuItem;
 		private System.Windows.Forms.Button CurrentButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private System.Windows.Forms.CheckBox OverlayBox;
 
 	}

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
@@ -43,7 +43,7 @@ namespace BizHawk.Client.EmuHawk
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
 			this.menuStrip1 = new MenuStripEx();
 			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -155,11 +155,6 @@ namespace BizHawk.Client.EmuHawk
             this.ExitMenuItem});
 			this.FileSubMenu.Text = "&File";
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(131, 6);
-			// 
 			// ExitMenuItem
 			// 
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
@@ -199,7 +194,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx lblContents;
 		private MenuStripEx menuStrip1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.TextBox textBox1;
 		private System.Windows.Forms.TextBox txtPatternLength;

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
@@ -42,9 +42,9 @@ namespace BizHawk.Client.EmuHawk
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
 			this.menuStrip1.SuspendLayout();
@@ -153,8 +153,6 @@ namespace BizHawk.Client.EmuHawk
 			this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator2,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// toolStripSeparator2
@@ -164,9 +162,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(134, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -202,9 +198,9 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.Button btnExport;
 		private BizHawk.WinForms.Controls.LocLabelEx lblContents;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.TextBox textBox1;
 		private System.Windows.Forms.TextBox txtPatternLength;
 		private System.Windows.Forms.GroupBox groupBox1;

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
@@ -34,15 +34,15 @@ namespace BizHawk.Client.EmuHawk
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.NameTableView = new BizHawk.Client.EmuHawk.NameTableViewer();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.ScreenshotAsContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveImageClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RefreshImageContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ScreenshotAsContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveImageClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RefreshImageContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScreenshotToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScreenshotToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.txtScanline = new System.Windows.Forms.TextBox();
 			this.rbNametableNW = new System.Windows.Forms.RadioButton();
 			this.rbNametableNE = new System.Windows.Forms.RadioButton();
@@ -109,23 +109,17 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ScreenshotAsContextMenuItem
 			// 
-			this.ScreenshotAsContextMenuItem.Name = "ScreenshotAsContextMenuItem";
-			this.ScreenshotAsContextMenuItem.Size = new System.Drawing.Size(247, 22);
 			this.ScreenshotAsContextMenuItem.Text = "&Save Image...";
 			this.ScreenshotAsContextMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
 			// 
 			// SaveImageClipboardMenuItem
 			// 
-			this.SaveImageClipboardMenuItem.Name = "SaveImageClipboardMenuItem";
 			this.SaveImageClipboardMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
-			this.SaveImageClipboardMenuItem.Size = new System.Drawing.Size(247, 22);
 			this.SaveImageClipboardMenuItem.Text = "&Copy Image to clipboard";
 			this.SaveImageClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotToClipboardMenuItem_Click);
 			// 
 			// RefreshImageContextMenuItem
 			// 
-			this.RefreshImageContextMenuItem.Name = "RefreshImageContextMenuItem";
-			this.RefreshImageContextMenuItem.Size = new System.Drawing.Size(247, 22);
 			this.RefreshImageContextMenuItem.Text = "&Refresh Image";
 			this.RefreshImageContextMenuItem.Click += new System.EventHandler(this.RefreshImageContextMenuItem_Click);
 			// 
@@ -144,22 +138,16 @@ namespace BizHawk.Client.EmuHawk
             this.ScreenshotToClipboardMenuItem,
             this.toolStripSeparator2,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// ScreenshotMenuItem
 			// 
-			this.ScreenshotMenuItem.Name = "ScreenshotMenuItem";
-			this.ScreenshotMenuItem.Size = new System.Drawing.Size(243, 22);
 			this.ScreenshotMenuItem.Text = "Save Screenshot &As...";
 			this.ScreenshotMenuItem.Click += new System.EventHandler(this.ScreenshotMenuItem_Click);
 			// 
 			// ScreenshotToClipboardMenuItem
 			// 
-			this.ScreenshotToClipboardMenuItem.Name = "ScreenshotToClipboardMenuItem";
 			this.ScreenshotToClipboardMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
-			this.ScreenshotToClipboardMenuItem.Size = new System.Drawing.Size(243, 22);
 			this.ScreenshotToClipboardMenuItem.Text = "Screenshot to &Clipboard";
 			this.ScreenshotToClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotToClipboardMenuItem_Click);
 			// 
@@ -170,9 +158,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(243, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -447,15 +433,15 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label6;
 		private System.Windows.Forms.TrackBar RefreshRate;
 		private BizHawk.WinForms.Controls.LocLabelEx label7;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotAsContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RefreshImageContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveImageClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ScreenshotToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotAsContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RefreshImageContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveImageClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotToClipboardMenuItem;
 		private System.Windows.Forms.ToolTip toolTip1;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
@@ -41,7 +41,7 @@ namespace BizHawk.Client.EmuHawk
 			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScreenshotToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.txtScanline = new System.Windows.Forms.TextBox();
 			this.rbNametableNW = new System.Windows.Forms.RadioButton();
@@ -150,11 +150,6 @@ namespace BizHawk.Client.EmuHawk
 			this.ScreenshotToClipboardMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
 			this.ScreenshotToClipboardMenuItem.Text = "Screenshot to &Clipboard";
 			this.ScreenshotToClipboardMenuItem.Click += new System.EventHandler(this.ScreenshotToClipboardMenuItem_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(240, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -435,7 +430,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScreenshotAsContextMenuItem;

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
@@ -72,11 +72,11 @@ namespace BizHawk.Client.EmuHawk
 			this.SavePaletteScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SavePatternScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveSpriteScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.CopyPaletteToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyPatternToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopySpriteToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PatternSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.Table0PaletteSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -486,11 +486,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveSpriteScreenshotMenuItem.Text = "Save Sprite Screenshot...";
 			this.SaveSpriteScreenshotMenuItem.Click += new System.EventHandler(this.SaveSpriteScreenshotMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(253, 6);
-			// 
 			// CopyPaletteToClipboardMenuItem
 			// 
 			this.CopyPaletteToClipboardMenuItem.Text = "Copy Palette to Clipboard";
@@ -505,11 +500,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.CopySpriteToClipboardMenuItem.Text = "Copy Sprite to Clipboard";
 			this.CopySpriteToClipboardMenuItem.Click += new System.EventHandler(this.CopySpriteToClipboardMenuItem_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(253, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -809,7 +799,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SavePaletteScreenshotMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SavePatternScreenshotMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSpriteScreenshotMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.ContextMenuStrip PaletteContext;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PaletteSaveImageMenuItem;
@@ -826,7 +816,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyPaletteToClipboardMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyPatternToClipboardMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopySpriteToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private StatusStripEx NesPPUStatusBar;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
 		private System.Windows.Forms.Timer Messagetimer;

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
@@ -36,15 +36,15 @@ namespace BizHawk.Client.EmuHawk
 			this.Table0PaletteLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.PatternView = new BizHawk.Client.EmuHawk.PatternViewer();
 			this.PatternContext = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.PatternSaveImageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PatternImageToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PatternRefreshMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.PatternSaveImageMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PatternImageToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PatternRefreshMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PalettesGroup = new System.Windows.Forms.GroupBox();
 			this.PaletteView = new BizHawk.Client.EmuHawk.PaletteViewer();
 			this.PaletteContext = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.PaletteSaveImageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PaletteImageToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PaletteRefreshMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.PaletteSaveImageMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PaletteImageToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PaletteRefreshMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DetailsBox = new System.Windows.Forms.GroupBox();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.Value5Label = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -58,9 +58,9 @@ namespace BizHawk.Client.EmuHawk
 			this.SpriteViewerBox = new System.Windows.Forms.GroupBox();
 			this.SpriteView = new BizHawk.Client.EmuHawk.SpriteViewer();
 			this.SpriteContext = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.SpriteSaveImageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SpriteImageToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SpriteRefreshMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SpriteSaveImageMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SpriteImageToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SpriteRefreshMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.txtScanline = new System.Windows.Forms.TextBox();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -68,37 +68,37 @@ namespace BizHawk.Client.EmuHawk
 			this.label3 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.RefreshRate = new System.Windows.Forms.TrackBar();
 			this.NesPPUMenu = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SavePaletteScreenshotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SavePatternScreenshotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveSpriteScreenshotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SavePaletteScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SavePatternScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveSpriteScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.CopyPaletteToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopyPatternToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopySpriteToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.CopyPaletteToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopyPatternToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopySpriteToClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PatternSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0PaletteSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P0MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table0P7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1PaletteSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P0MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P3MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P4MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P5MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P6MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Table1P7MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.cHRROMTileViewerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PatternSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0PaletteSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table0P7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1PaletteSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P0MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P3MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P4MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P5MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P6MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Table1P7MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cHRROMTileViewerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NesPPUStatusBar = new StatusStripEx();
 			this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
 			this.Messagetimer = new System.Windows.Forms.Timer(this.components);
@@ -178,22 +178,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// PatternSaveImageMenuItem
 			// 
-			this.PatternSaveImageMenuItem.Name = "PatternSaveImageMenuItem";
-			this.PatternSaveImageMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PatternSaveImageMenuItem.Text = "&Save Image...";
 			this.PatternSaveImageMenuItem.Click += new System.EventHandler(this.SavePatternScreenshotMenuItem_Click);
 			// 
 			// PatternImageToClipboardMenuItem
 			// 
-			this.PatternImageToClipboardMenuItem.Name = "PatternImageToClipboardMenuItem";
-			this.PatternImageToClipboardMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PatternImageToClipboardMenuItem.Text = "Image to &Clipboard";
 			this.PatternImageToClipboardMenuItem.Click += new System.EventHandler(this.CopyPatternToClipboardMenuItem_Click);
 			// 
 			// PatternRefreshMenuItem
 			// 
-			this.PatternRefreshMenuItem.Name = "PatternRefreshMenuItem";
-			this.PatternRefreshMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PatternRefreshMenuItem.Text = "&Refresh";
 			this.PatternRefreshMenuItem.Click += new System.EventHandler(this.PatternRefreshMenuItem_Click);
 			// 
@@ -236,22 +230,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// PaletteSaveImageMenuItem
 			// 
-			this.PaletteSaveImageMenuItem.Name = "PaletteSaveImageMenuItem";
-			this.PaletteSaveImageMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PaletteSaveImageMenuItem.Text = "&Save Image...";
 			this.PaletteSaveImageMenuItem.Click += new System.EventHandler(this.SavePaletteScreenshotMenuItem_Click);
 			// 
 			// PaletteImageToClipboardMenuItem
 			// 
-			this.PaletteImageToClipboardMenuItem.Name = "PaletteImageToClipboardMenuItem";
-			this.PaletteImageToClipboardMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PaletteImageToClipboardMenuItem.Text = "Image to &Clipboard";
 			this.PaletteImageToClipboardMenuItem.Click += new System.EventHandler(this.CopyPaletteToClipboardMenuItem_Click);
 			// 
 			// PaletteRefreshMenuItem
 			// 
-			this.PaletteRefreshMenuItem.Name = "PaletteRefreshMenuItem";
-			this.PaletteRefreshMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.PaletteRefreshMenuItem.Text = "&Refresh";
 			this.PaletteRefreshMenuItem.Click += new System.EventHandler(this.PaletteRefreshMenuItem_Click);
 			// 
@@ -380,22 +368,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// SpriteSaveImageMenuItem
 			// 
-			this.SpriteSaveImageMenuItem.Name = "SpriteSaveImageMenuItem";
-			this.SpriteSaveImageMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.SpriteSaveImageMenuItem.Text = "&Save Image...";
 			this.SpriteSaveImageMenuItem.Click += new System.EventHandler(this.SaveSpriteScreenshotMenuItem_Click);
 			// 
 			// SpriteImageToClipboardMenuItem
 			// 
-			this.SpriteImageToClipboardMenuItem.Name = "SpriteImageToClipboardMenuItem";
-			this.SpriteImageToClipboardMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.SpriteImageToClipboardMenuItem.Text = "Image to &Clipboard";
 			this.SpriteImageToClipboardMenuItem.Click += new System.EventHandler(this.CopySpriteToClipboardMenuItem_Click);
 			// 
 			// SpriteRefreshMenuItem
 			// 
-			this.SpriteRefreshMenuItem.Name = "SpriteRefreshMenuItem";
-			this.SpriteRefreshMenuItem.Size = new System.Drawing.Size(214, 26);
 			this.SpriteRefreshMenuItem.Text = "&Refresh";
 			this.SpriteRefreshMenuItem.Click += new System.EventHandler(this.SpriteRefreshMenuItem_Click);
 			// 
@@ -487,28 +469,20 @@ namespace BizHawk.Client.EmuHawk
             this.CopySpriteToClipboardMenuItem,
             this.toolStripSeparator2,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(44, 24);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// SavePaletteScreenshotMenuItem
 			// 
-			this.SavePaletteScreenshotMenuItem.Name = "SavePaletteScreenshotMenuItem";
-			this.SavePaletteScreenshotMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.SavePaletteScreenshotMenuItem.Text = "Save Palette Screenshot...";
 			this.SavePaletteScreenshotMenuItem.Click += new System.EventHandler(this.SavePaletteScreenshotMenuItem_Click);
 			// 
 			// SavePatternScreenshotMenuItem
 			// 
-			this.SavePatternScreenshotMenuItem.Name = "SavePatternScreenshotMenuItem";
-			this.SavePatternScreenshotMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.SavePatternScreenshotMenuItem.Text = "Save Pattern Screenshot...";
 			this.SavePatternScreenshotMenuItem.Click += new System.EventHandler(this.SavePatternScreenshotMenuItem_Click);
 			// 
 			// SaveSpriteScreenshotMenuItem
 			// 
-			this.SaveSpriteScreenshotMenuItem.Name = "SaveSpriteScreenshotMenuItem";
-			this.SaveSpriteScreenshotMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.SaveSpriteScreenshotMenuItem.Text = "Save Sprite Screenshot...";
 			this.SaveSpriteScreenshotMenuItem.Click += new System.EventHandler(this.SaveSpriteScreenshotMenuItem_Click);
 			// 
@@ -519,22 +493,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CopyPaletteToClipboardMenuItem
 			// 
-			this.CopyPaletteToClipboardMenuItem.Name = "CopyPaletteToClipboardMenuItem";
-			this.CopyPaletteToClipboardMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.CopyPaletteToClipboardMenuItem.Text = "Copy Palette to Clipboard";
 			this.CopyPaletteToClipboardMenuItem.Click += new System.EventHandler(this.CopyPaletteToClipboardMenuItem_Click);
 			// 
 			// CopyPatternToClipboardMenuItem
 			// 
-			this.CopyPatternToClipboardMenuItem.Name = "CopyPatternToClipboardMenuItem";
-			this.CopyPatternToClipboardMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.CopyPatternToClipboardMenuItem.Text = "Copy Pattern to Clipboard";
 			this.CopyPatternToClipboardMenuItem.Click += new System.EventHandler(this.CopyPatternToClipboardMenuItem_Click);
 			// 
 			// CopySpriteToClipboardMenuItem
 			// 
-			this.CopySpriteToClipboardMenuItem.Name = "CopySpriteToClipboardMenuItem";
-			this.CopySpriteToClipboardMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.CopySpriteToClipboardMenuItem.Text = "Copy Sprite to Clipboard";
 			this.CopySpriteToClipboardMenuItem.Click += new System.EventHandler(this.CopySpriteToClipboardMenuItem_Click);
 			// 
@@ -545,8 +513,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
-			this.ExitMenuItem.Size = new System.Drawing.Size(256, 26);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -555,8 +521,6 @@ namespace BizHawk.Client.EmuHawk
 			this.PatternSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Table0PaletteSubMenu,
             this.Table1PaletteSubMenu});
-			this.PatternSubMenu.Name = "PatternSubMenu";
-			this.PatternSubMenu.Size = new System.Drawing.Size(67, 24);
 			this.PatternSubMenu.Text = "&Pattern";
 			// 
 			// Table0PaletteSubMenu
@@ -570,64 +534,46 @@ namespace BizHawk.Client.EmuHawk
             this.Table0P5MenuItem,
             this.Table0P6MenuItem,
             this.Table0P7MenuItem});
-			this.Table0PaletteSubMenu.Name = "Table0PaletteSubMenu";
-			this.Table0PaletteSubMenu.Size = new System.Drawing.Size(180, 26);
 			this.Table0PaletteSubMenu.Text = "Table 0 Palette";
 			this.Table0PaletteSubMenu.DropDownOpened += new System.EventHandler(this.Table0PaletteSubMenu_DropDownOpened);
 			// 
 			// Table0P0MenuItem
 			// 
-			this.Table0P0MenuItem.Name = "Table0P0MenuItem";
-			this.Table0P0MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P0MenuItem.Text = "0";
 			this.Table0P0MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P1MenuItem
 			// 
-			this.Table0P1MenuItem.Name = "Table0P1MenuItem";
-			this.Table0P1MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P1MenuItem.Text = "1";
 			this.Table0P1MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P2MenuItem
 			// 
-			this.Table0P2MenuItem.Name = "Table0P2MenuItem";
-			this.Table0P2MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P2MenuItem.Text = "2";
 			this.Table0P2MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P3MenuItem
 			// 
-			this.Table0P3MenuItem.Name = "Table0P3MenuItem";
-			this.Table0P3MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P3MenuItem.Text = "3";
 			this.Table0P3MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P4MenuItem
 			// 
-			this.Table0P4MenuItem.Name = "Table0P4MenuItem";
-			this.Table0P4MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P4MenuItem.Text = "4";
 			this.Table0P4MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P5MenuItem
 			// 
-			this.Table0P5MenuItem.Name = "Table0P5MenuItem";
-			this.Table0P5MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P5MenuItem.Text = "5";
 			this.Table0P5MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P6MenuItem
 			// 
-			this.Table0P6MenuItem.Name = "Table0P6MenuItem";
-			this.Table0P6MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P6MenuItem.Text = "6";
 			this.Table0P6MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table0P7MenuItem
 			// 
-			this.Table0P7MenuItem.Name = "Table0P7MenuItem";
-			this.Table0P7MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table0P7MenuItem.Text = "7";
 			this.Table0P7MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
@@ -642,64 +588,46 @@ namespace BizHawk.Client.EmuHawk
             this.Table1P5MenuItem,
             this.Table1P6MenuItem,
             this.Table1P7MenuItem});
-			this.Table1PaletteSubMenu.Name = "Table1PaletteSubMenu";
-			this.Table1PaletteSubMenu.Size = new System.Drawing.Size(180, 26);
 			this.Table1PaletteSubMenu.Text = "Table 1 Palette";
 			this.Table1PaletteSubMenu.DropDownOpened += new System.EventHandler(this.Table1PaletteSubMenu_DropDownOpened);
 			// 
 			// Table1P0MenuItem
 			// 
-			this.Table1P0MenuItem.Name = "Table1P0MenuItem";
-			this.Table1P0MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P0MenuItem.Text = "0";
 			this.Table1P0MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P1MenuItem
 			// 
-			this.Table1P1MenuItem.Name = "Table1P1MenuItem";
-			this.Table1P1MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P1MenuItem.Text = "1";
 			this.Table1P1MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P2MenuItem
 			// 
-			this.Table1P2MenuItem.Name = "Table1P2MenuItem";
-			this.Table1P2MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P2MenuItem.Text = "2";
 			this.Table1P2MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P3MenuItem
 			// 
-			this.Table1P3MenuItem.Name = "Table1P3MenuItem";
-			this.Table1P3MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P3MenuItem.Text = "3";
 			this.Table1P3MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P4MenuItem
 			// 
-			this.Table1P4MenuItem.Name = "Table1P4MenuItem";
-			this.Table1P4MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P4MenuItem.Text = "4";
 			this.Table1P4MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P5MenuItem
 			// 
-			this.Table1P5MenuItem.Name = "Table1P5MenuItem";
-			this.Table1P5MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P5MenuItem.Text = "5";
 			this.Table1P5MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P6MenuItem
 			// 
-			this.Table1P6MenuItem.Name = "Table1P6MenuItem";
-			this.Table1P6MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P6MenuItem.Text = "6";
 			this.Table1P6MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
 			// Table1P7MenuItem
 			// 
-			this.Table1P7MenuItem.Name = "Table1P7MenuItem";
-			this.Table1P7MenuItem.Size = new System.Drawing.Size(92, 26);
 			this.Table1P7MenuItem.Text = "7";
 			this.Table1P7MenuItem.Click += new System.EventHandler(this.Palette_Click);
 			// 
@@ -707,15 +635,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SettingsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.cHRROMTileViewerToolStripMenuItem});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(74, 24);
 			this.SettingsSubMenu.Text = "&Settings";
 			this.SettingsSubMenu.DropDownOpened += new System.EventHandler(this.SettingsSubMenu_DropDownOpened);
 			// 
 			// cHRROMTileViewerToolStripMenuItem
 			// 
-			this.cHRROMTileViewerToolStripMenuItem.Name = "cHRROMTileViewerToolStripMenuItem";
-			this.cHRROMTileViewerToolStripMenuItem.Size = new System.Drawing.Size(227, 26);
 			this.cHRROMTileViewerToolStripMenuItem.Text = "CHR ROM Tile Viewer";
 			this.cHRROMTileViewerToolStripMenuItem.Click += new System.EventHandler(this.ChrROMTileViewerToolStripMenuItem_Click);
 			// 
@@ -861,47 +785,47 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label4;
 		private BizHawk.WinForms.Controls.LocLabelEx label3;
 		private MenuStripEx NesPPUMenu;
-		private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PatternSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem Table0PaletteSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem Table0P0MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table0P7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1PaletteSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem Table1P0MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P3MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P4MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P5MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P6MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Table1P7MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SavePaletteScreenshotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SavePatternScreenshotMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveSpriteScreenshotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PatternSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0PaletteSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P0MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table0P7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1PaletteSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P0MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P3MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P4MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P5MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P6MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Table1P7MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SavePaletteScreenshotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SavePatternScreenshotMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveSpriteScreenshotMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.ContextMenuStrip PaletteContext;
-		private System.Windows.Forms.ToolStripMenuItem PaletteSaveImageMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PaletteRefreshMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PaletteSaveImageMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PaletteRefreshMenuItem;
 		private System.Windows.Forms.ContextMenuStrip PatternContext;
-		private System.Windows.Forms.ToolStripMenuItem PatternSaveImageMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PatternRefreshMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PatternSaveImageMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PatternRefreshMenuItem;
 		private System.Windows.Forms.ContextMenuStrip SpriteContext;
-		private System.Windows.Forms.ToolStripMenuItem SpriteSaveImageMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SpriteRefreshMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SpriteImageToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PatternImageToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PaletteImageToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyPaletteToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyPatternToClipboardMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopySpriteToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SpriteSaveImageMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SpriteRefreshMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SpriteImageToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PatternImageToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PaletteImageToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyPaletteToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyPatternToClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopySpriteToClipboardMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
 		private StatusStripEx NesPPUStatusBar;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
@@ -910,6 +834,6 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label5;
 		private System.Windows.Forms.NumericUpDown numericUpDownCHRROMBank;
 		private PatternViewer CHRROMView;
-		private System.Windows.Forms.ToolStripMenuItem cHRROMTileViewerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx cHRROMTileViewerToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
@@ -34,7 +34,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ViewerSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.VDC1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.VDC2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.canvas = new BizHawk.Client.EmuHawk.PceBgCanvas();
@@ -84,11 +84,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.VDC2MenuItem.Text = "VCD&2";
 			this.VDC2MenuItem.Click += new System.EventHandler(this.VDC2MenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(149, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -243,7 +238,7 @@ namespace BizHawk.Client.EmuHawk
         private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VDC1MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VDC2MenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private System.Windows.Forms.GroupBox groupBox1;
 		private System.Windows.Forms.GroupBox groupBox5;
 		private BizHawk.WinForms.Controls.LocLabelEx label7;

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
@@ -31,11 +31,11 @@ namespace BizHawk.Client.EmuHawk
 		private void InitializeComponent()
 		{
 			this.PceBgViewerMenu = new MenuStripEx();
-			this.ViewerSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.VDC1MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.VDC2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ViewerSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VDC1MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.VDC2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1 = new System.Windows.Forms.GroupBox();
 			this.canvas = new BizHawk.Client.EmuHawk.PceBgCanvas();
 			this.groupBox5 = new System.Windows.Forms.GroupBox();
@@ -72,22 +72,16 @@ namespace BizHawk.Client.EmuHawk
             this.VDC2MenuItem,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.ViewerSubMenu.Name = "ViewerSubMenu";
-			this.ViewerSubMenu.Size = new System.Drawing.Size(51, 20);
 			this.ViewerSubMenu.Text = "&Viewer";
 			this.ViewerSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// VDC1MenuItem
 			// 
-			this.VDC1MenuItem.Name = "VDC1MenuItem";
-			this.VDC1MenuItem.Size = new System.Drawing.Size(152, 22);
 			this.VDC1MenuItem.Text = "VDC&1";
 			this.VDC1MenuItem.Click += new System.EventHandler(this.VDC1MenuItem_Click);
 			// 
 			// VDC2MenuItem
 			// 
-			this.VDC2MenuItem.Name = "VDC2MenuItem";
-			this.VDC2MenuItem.Size = new System.Drawing.Size(152, 22);
 			this.VDC2MenuItem.Text = "VCD&2";
 			this.VDC2MenuItem.Click += new System.EventHandler(this.VDC2MenuItem_Click);
 			// 
@@ -98,9 +92,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(152, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -247,10 +239,10 @@ namespace BizHawk.Client.EmuHawk
 
 		private PceBgCanvas canvas;
         private MenuStripEx PceBgViewerMenu;
-		private System.Windows.Forms.ToolStripMenuItem ViewerSubMenu;
-        private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VDC1MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem VDC2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewerSubMenu;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VDC1MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx VDC2MenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 		private System.Windows.Forms.GroupBox groupBox1;
 		private System.Windows.Forms.GroupBox groupBox5;

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
@@ -39,11 +39,11 @@ namespace BizHawk.Client.EmuHawk
 			this.checkBoxVDC2 = new System.Windows.Forms.CheckBox();
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveBackgroundScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveSpriteScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveBackgroundScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveSpriteScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.closeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
 			this.menuStrip1.SuspendLayout();
@@ -137,21 +137,15 @@ namespace BizHawk.Client.EmuHawk
             this.saveSpriteScreenshotToolStripMenuItem,
             this.toolStripSeparator1,
             this.closeToolStripMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// saveBackgroundScreenshotToolStripMenuItem
 			// 
-			this.saveBackgroundScreenshotToolStripMenuItem.Name = "saveBackgroundScreenshotToolStripMenuItem";
-			this.saveBackgroundScreenshotToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
 			this.saveBackgroundScreenshotToolStripMenuItem.Text = "Save BG Screenshot...";
 			this.saveBackgroundScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveBackgroundScreenshotMenuItem_Click);
 			// 
 			// saveSpriteScreenshotToolStripMenuItem
 			// 
-			this.saveSpriteScreenshotToolStripMenuItem.Name = "saveSpriteScreenshotToolStripMenuItem";
-			this.saveSpriteScreenshotToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
 			this.saveSpriteScreenshotToolStripMenuItem.Text = "Save Sprite Screenshot...";
 			this.saveSpriteScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveSpriteScreenshotMenuItem_Click);
 			// 
@@ -162,9 +156,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// closeToolStripMenuItem
 			// 
-			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
 			this.closeToolStripMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.closeToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
 			this.closeToolStripMenuItem.Text = "&Close";
 			this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseMenuItem_Click);
 			// 
@@ -204,10 +196,10 @@ namespace BizHawk.Client.EmuHawk
 		private BmpView bmpViewSP;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem closeToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveBackgroundScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveSpriteScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx closeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBackgroundScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveSpriteScreenshotToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.EmuHawk
 			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveBackgroundScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveSpriteScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.closeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -149,11 +149,6 @@ namespace BizHawk.Client.EmuHawk
 			this.saveSpriteScreenshotToolStripMenuItem.Text = "Save Sprite Screenshot...";
 			this.saveSpriteScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveSpriteScreenshotMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(195, 6);
-			// 
 			// closeToolStripMenuItem
 			// 
 			this.closeToolStripMenuItem.ShortcutKeyDisplayString = "Alt+F4";
@@ -200,6 +195,6 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx closeToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBackgroundScreenshotToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveSpriteScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
@@ -38,12 +38,12 @@ namespace BizHawk.Client.EmuHawk
 			this.bmpViewBG = new BizHawk.Client.EmuHawk.BmpView();
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveTilesScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.savePalettesScrenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveBGScreenshotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveTilesScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.savePalettesScrenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveBGScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.CloseMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.CloseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
 			this.groupBox3.SuspendLayout();
@@ -127,28 +127,20 @@ namespace BizHawk.Client.EmuHawk
             this.saveBGScreenshotToolStripMenuItem,
             this.toolStripSeparator1,
             this.CloseMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// saveTilesScreenshotToolStripMenuItem
 			// 
-			this.saveTilesScreenshotToolStripMenuItem.Name = "saveTilesScreenshotToolStripMenuItem";
-			this.saveTilesScreenshotToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
 			this.saveTilesScreenshotToolStripMenuItem.Text = "Save Tiles Screenshot...";
 			this.saveTilesScreenshotToolStripMenuItem.Click += new System.EventHandler(this.saveTilesScreenshotToolStripMenuItem_Click);
 			// 
 			// savePalettesScrenshotToolStripMenuItem
 			// 
-			this.savePalettesScrenshotToolStripMenuItem.Name = "savePalettesScrenshotToolStripMenuItem";
-			this.savePalettesScrenshotToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
 			this.savePalettesScrenshotToolStripMenuItem.Text = "Save Palettes Screnshot...";
 			this.savePalettesScrenshotToolStripMenuItem.Click += new System.EventHandler(this.SavePalettesScreenshotMenuItem_Click);
 			// 
 			// saveBGScreenshotToolStripMenuItem
 			// 
-			this.saveBGScreenshotToolStripMenuItem.Name = "saveBGScreenshotToolStripMenuItem";
-			this.saveBGScreenshotToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
 			this.saveBGScreenshotToolStripMenuItem.Text = "Save BG Screenshot...";
 			this.saveBGScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveBgScreenshotMenuItem_Click);
 			// 
@@ -159,9 +151,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CloseMenuItem
 			// 
-			this.CloseMenuItem.Name = "CloseMenuItem";
 			this.CloseMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.CloseMenuItem.Size = new System.Drawing.Size(203, 22);
 			this.CloseMenuItem.Text = "&Close";
 			this.CloseMenuItem.Click += new System.EventHandler(this.CloseMenuItem_Click);
 			// 
@@ -201,11 +191,11 @@ namespace BizHawk.Client.EmuHawk
 		private BmpView bmpViewBG;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem CloseMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveTilesScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveTilesScreenshotToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem savePalettesScrenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveBGScreenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx savePalettesScrenshotToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBGScreenshotToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.EmuHawk
 			this.saveTilesScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.savePalettesScrenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveBGScreenshotToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.CloseMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox1.SuspendLayout();
 			this.groupBox2.SuspendLayout();
@@ -144,11 +144,6 @@ namespace BizHawk.Client.EmuHawk
 			this.saveBGScreenshotToolStripMenuItem.Text = "Save BG Screenshot...";
 			this.saveBGScreenshotToolStripMenuItem.Click += new System.EventHandler(this.SaveBgScreenshotMenuItem_Click);
 			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(200, 6);
-			// 
 			// CloseMenuItem
 			// 
 			this.CloseMenuItem.ShortcutKeyDisplayString = "Alt+F4";
@@ -194,7 +189,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloseMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveTilesScreenshotToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx savePalettesScrenshotToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveBGScreenshotToolStripMenuItem;
 	}

--- a/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
@@ -36,7 +36,7 @@ namespace BizHawk.Client.EmuHawk
 			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveScreenshotAsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.saveScreenshotToClipboardToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.exitToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.panel1 = new System.Windows.Forms.Panel();
@@ -298,11 +298,6 @@ namespace BizHawk.Client.EmuHawk
 			this.saveScreenshotToClipboardToolStripMenuItem.Enabled = false;
 			this.saveScreenshotToClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
 			this.saveScreenshotToClipboardToolStripMenuItem.Text = "Save Screenshot to Clipboard";
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(252, 6);
 			// 
 			// exitToolStripMenuItem
 			// 
@@ -2519,7 +2514,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveScreenshotAsToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveScreenshotToClipboardToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx exitToolStripMenuItem;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 		private System.Windows.Forms.Panel panel1;

--- a/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
@@ -33,11 +33,11 @@ namespace BizHawk.Client.EmuHawk
 			this.components = new System.ComponentModel.Container();
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SNESGraphicsDebugger));
 			this.menuStrip1 = new MenuStripEx();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveScreenshotAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.saveScreenshotToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveScreenshotAsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.saveScreenshotToClipboardToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.exitToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.panel1 = new System.Windows.Forms.Panel();
 			this.groupFreeze = new System.Windows.Forms.GroupBox();
@@ -286,23 +286,17 @@ namespace BizHawk.Client.EmuHawk
             this.saveScreenshotToClipboardToolStripMenuItem,
             this.toolStripSeparator1,
             this.exitToolStripMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
 			this.fileToolStripMenuItem.Text = "&File";
 			// 
 			// saveScreenshotAsToolStripMenuItem
 			// 
 			this.saveScreenshotAsToolStripMenuItem.Enabled = false;
-			this.saveScreenshotAsToolStripMenuItem.Name = "saveScreenshotAsToolStripMenuItem";
-			this.saveScreenshotAsToolStripMenuItem.Size = new System.Drawing.Size(255, 22);
 			this.saveScreenshotAsToolStripMenuItem.Text = "Save Screenshot &As...";
 			// 
 			// saveScreenshotToClipboardToolStripMenuItem
 			// 
 			this.saveScreenshotToClipboardToolStripMenuItem.Enabled = false;
-			this.saveScreenshotToClipboardToolStripMenuItem.Name = "saveScreenshotToClipboardToolStripMenuItem";
 			this.saveScreenshotToClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.saveScreenshotToClipboardToolStripMenuItem.Size = new System.Drawing.Size(255, 22);
 			this.saveScreenshotToClipboardToolStripMenuItem.Text = "Save Screenshot to Clipboard";
 			// 
 			// toolStripSeparator1
@@ -312,9 +306,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// exitToolStripMenuItem
 			// 
-			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
 			this.exitToolStripMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.exitToolStripMenuItem.Size = new System.Drawing.Size(255, 22);
 			this.exitToolStripMenuItem.Text = "E&xit";
 			this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
 			// 
@@ -2524,11 +2516,11 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveScreenshotAsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveScreenshotToClipboardToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveScreenshotAsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveScreenshotToClipboardToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx exitToolStripMenuItem;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 		private System.Windows.Forms.Panel panel1;
 		private System.Windows.Forms.GroupBox groupBox2;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.Designer.cs
@@ -45,7 +45,7 @@
 			this.EditBranchTextContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.JumpToBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UndoBranchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RemoveBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.BookmarksBranchesGroupBox.SuspendLayout();
@@ -224,11 +224,6 @@
 			this.UndoBranchToolStripMenuItem.Text = "Undo";
 			this.UndoBranchToolStripMenuItem.Click += new System.EventHandler(this.UndoBranchToolStripMenuItem_Click);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(143, 6);
-			// 
 			// RemoveBranchContextMenuItem
 			// 
 			this.RemoveBranchContextMenuItem.Text = "Remove";
@@ -262,7 +257,7 @@
 		private System.Windows.Forms.Button AddBranchButton;
 		private System.Windows.Forms.Button LoadBranchButton;
 		private System.Windows.Forms.ToolTip toolTip1;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private System.Windows.Forms.Button JumpToBranchButton;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx JumpToBranchContextMenuItem;
 		private System.Windows.Forms.Button UndoBranchButton;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.Designer.cs
@@ -38,15 +38,15 @@
 			this.LoadBranchButton = new System.Windows.Forms.Button();
 			this.BranchView = new BizHawk.Client.EmuHawk.InputRoll();
 			this.BranchesContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.AddBranchContextMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddBranchWithTextContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadBranchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UpdateBranchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditBranchTextContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.JumpToBranchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UndoBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AddBranchContextMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddBranchWithTextContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UpdateBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditBranchTextContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.JumpToBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UndoBranchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.RemoveBranchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RemoveBranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.BookmarksBranchesGroupBox.SuspendLayout();
 			this.BranchesContextMenu.SuspendLayout();
@@ -190,51 +190,37 @@
 			// 
 			// AddBranchContextMenu
 			// 
-			this.AddBranchContextMenu.Name = "AddBranchContextMenu";
-			this.AddBranchContextMenu.Size = new System.Drawing.Size(146, 22);
 			this.AddBranchContextMenu.Text = "Add";
 			this.AddBranchContextMenu.Click += new System.EventHandler(this.AddBranchToolStripMenuItem_Click);
 			// 
 			// AddBranchWithTextContextMenuItem
 			// 
-			this.AddBranchWithTextContextMenuItem.Name = "AddBranchWithTextContextMenuItem";
-			this.AddBranchWithTextContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.AddBranchWithTextContextMenuItem.Text = "Add with Text";
 			this.AddBranchWithTextContextMenuItem.Click += new System.EventHandler(this.AddBranchWithTexToolStripMenuItem_Click);
 			// 
 			// LoadBranchContextMenuItem
 			// 
-			this.LoadBranchContextMenuItem.Name = "LoadBranchContextMenuItem";
-			this.LoadBranchContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.LoadBranchContextMenuItem.Text = "Load";
 			this.LoadBranchContextMenuItem.Click += new System.EventHandler(this.LoadBranchToolStripMenuItem_Click);
 			// 
 			// UpdateBranchContextMenuItem
 			// 
-			this.UpdateBranchContextMenuItem.Name = "UpdateBranchContextMenuItem";
-			this.UpdateBranchContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.UpdateBranchContextMenuItem.Text = "&Update";
 			this.UpdateBranchContextMenuItem.Click += new System.EventHandler(this.UpdateBranchToolStripMenuItem_Click);
 			// 
 			// EditBranchTextContextMenuItem
 			// 
-			this.EditBranchTextContextMenuItem.Name = "EditBranchTextContextMenuItem";
-			this.EditBranchTextContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.EditBranchTextContextMenuItem.Text = "Edit Text";
 			this.EditBranchTextContextMenuItem.Click += new System.EventHandler(this.EditBranchTextToolStripMenuItem_Click);
 			// 
 			// JumpToBranchContextMenuItem
 			// 
-			this.JumpToBranchContextMenuItem.Name = "JumpToBranchContextMenuItem";
-			this.JumpToBranchContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.JumpToBranchContextMenuItem.Text = "Jump To";
 			this.JumpToBranchContextMenuItem.Click += new System.EventHandler(this.JumpToBranchToolStripMenuItem_Click);
 			// 
 			// UndoBranchToolStripMenuItem
 			// 
 			this.UndoBranchToolStripMenuItem.Enabled = false;
-			this.UndoBranchToolStripMenuItem.Name = "UndoBranchToolStripMenuItem";
-			this.UndoBranchToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.UndoBranchToolStripMenuItem.Text = "Undo";
 			this.UndoBranchToolStripMenuItem.Click += new System.EventHandler(this.UndoBranchToolStripMenuItem_Click);
 			// 
@@ -245,8 +231,6 @@
 			// 
 			// RemoveBranchContextMenuItem
 			// 
-			this.RemoveBranchContextMenuItem.Name = "RemoveBranchContextMenuItem";
-			this.RemoveBranchContextMenuItem.Size = new System.Drawing.Size(146, 22);
 			this.RemoveBranchContextMenuItem.Text = "Remove";
 			this.RemoveBranchContextMenuItem.Click += new System.EventHandler(this.RemoveBranchToolStripMenuItem_Click);
 			// 
@@ -267,12 +251,12 @@
 		private System.Windows.Forms.GroupBox BookmarksBranchesGroupBox;
 		private InputRoll BranchView;
 		private System.Windows.Forms.ContextMenuStrip BranchesContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem AddBranchContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem RemoveBranchContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadBranchContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UpdateBranchContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EditBranchTextContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AddBranchWithTextContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddBranchContextMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveBranchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadBranchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UpdateBranchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditBranchTextContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddBranchWithTextContextMenuItem;
 		private System.Windows.Forms.Button UpdateBranchButton;
 		private System.Windows.Forms.Button AddWithTextBranchButton;
 		private System.Windows.Forms.Button AddBranchButton;
@@ -280,8 +264,8 @@
 		private System.Windows.Forms.ToolTip toolTip1;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
 		private System.Windows.Forms.Button JumpToBranchButton;
-		private System.Windows.Forms.ToolStripMenuItem JumpToBranchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx JumpToBranchContextMenuItem;
 		private System.Windows.Forms.Button UndoBranchButton;
-		private System.Windows.Forms.ToolStripMenuItem UndoBranchToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UndoBranchToolStripMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.Designer.cs
@@ -30,12 +30,12 @@
 		{
 			this.components = new System.ComponentModel.Container();
 			this.MarkerContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.JumpToMarkerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ScrollToMarkerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditMarkerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddMarkerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.JumpToMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ScrollToMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.RemoveMarkerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RemoveMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.JumpToMarkerButton = new System.Windows.Forms.Button();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this.EditMarkerButton = new System.Windows.Forms.Button();
@@ -64,29 +64,21 @@
 			// 
 			// JumpToMarkerToolStripMenuItem
 			// 
-			this.JumpToMarkerToolStripMenuItem.Name = "JumpToMarkerToolStripMenuItem";
-			this.JumpToMarkerToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
 			this.JumpToMarkerToolStripMenuItem.Text = "Jump To";
 			this.JumpToMarkerToolStripMenuItem.Click += new System.EventHandler(this.JumpToMarkerToolStripMenuItem_Click);
 			// 
 			// ScrollToMarkerToolStripMenuItem
 			// 
-			this.ScrollToMarkerToolStripMenuItem.Name = "ScrollToMarkerToolStripMenuItem";
-			this.ScrollToMarkerToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
 			this.ScrollToMarkerToolStripMenuItem.Text = "Scroll To";
 			this.ScrollToMarkerToolStripMenuItem.Click += new System.EventHandler(this.ScrollToMarkerToolStripMenuItem_Click);
 			// 
 			// EditMarkerToolStripMenuItem
 			// 
-			this.EditMarkerToolStripMenuItem.Name = "EditMarkerToolStripMenuItem";
-			this.EditMarkerToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
 			this.EditMarkerToolStripMenuItem.Text = "Edit";
 			this.EditMarkerToolStripMenuItem.Click += new System.EventHandler(this.EditMarkerToolStripMenuItem_Click);
 			// 
 			// AddMarkerToolStripMenuItem
 			// 
-			this.AddMarkerToolStripMenuItem.Name = "AddMarkerToolStripMenuItem";
-			this.AddMarkerToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
 			this.AddMarkerToolStripMenuItem.Text = "Add";
 			this.AddMarkerToolStripMenuItem.Click += new System.EventHandler(this.AddMarkerToolStripMenuItem_Click);
 			// 
@@ -97,8 +89,6 @@
 			// 
 			// RemoveMarkerToolStripMenuItem
 			// 
-			this.RemoveMarkerToolStripMenuItem.Name = "RemoveMarkerToolStripMenuItem";
-			this.RemoveMarkerToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
 			this.RemoveMarkerToolStripMenuItem.Text = "Remove";
 			this.RemoveMarkerToolStripMenuItem.Click += new System.EventHandler(this.RemoveMarkerToolStripMenuItem_Click);
 			// 
@@ -242,11 +232,11 @@
 		private System.Windows.Forms.Button ScrollToMarkerButton;
 		private System.Windows.Forms.ToolTip toolTip1;
 		private System.Windows.Forms.ContextMenuStrip MarkerContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem ScrollToMarkerToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EditMarkerToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AddMarkerToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveMarkerToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem JumpToMarkerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ScrollToMarkerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditMarkerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddMarkerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMarkerToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx JumpToMarkerToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
 		private System.Windows.Forms.Button AddMarkerWithTextButton;
 		private System.Windows.Forms.GroupBox MarkersGroupBox;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.Designer.cs
@@ -34,7 +34,7 @@
 			this.ScrollToMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.EditMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AddMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RemoveMarkerToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.JumpToMarkerButton = new System.Windows.Forms.Button();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -81,11 +81,6 @@
 			// 
 			this.AddMarkerToolStripMenuItem.Text = "Add";
 			this.AddMarkerToolStripMenuItem.Click += new System.EventHandler(this.AddMarkerToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(115, 6);
 			// 
 			// RemoveMarkerToolStripMenuItem
 			// 
@@ -237,7 +232,7 @@
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddMarkerToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMarkerToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx JumpToMarkerToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private System.Windows.Forms.Button AddMarkerWithTextButton;
 		private System.Windows.Forms.GroupBox MarkersGroupBox;
 	}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -43,15 +43,15 @@ namespace BizHawk.Client.EmuHawk
 			this.SaveBackupMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveBk2BackupMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.saveSelectionToMacroToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.placeMacroAtSelectionToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.recentMacrosToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator22 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator20 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ToBk2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.EditSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -59,66 +59,66 @@ namespace BizHawk.Client.EmuHawk
 			this.showUndoHistoryToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectionUndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectionRedoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DeselectMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectBetweenMarkersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ReselectClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PasteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PasteInsertMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ClearFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertFrameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DeleteFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CloneFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertNumFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.TruncateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearGreenzoneMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.GreenzoneICheckSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.GreenzoneICheckSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.StateHistoryIntegrityCheckMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetMaxUndoLevelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetBranchCellHoverIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetSeekingCutoffIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator26 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.autosaveToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetAutosaveIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutosaveAsBk2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutosaveAsBackupFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BackupPerFileSaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.AutoadjustInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.applyPatternToPaintedInputToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.onlyOnAutoFireColumnsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SingleClickAxisEditMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UseInputKeysItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.BindMarkersToInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.EmptyNewMarkerNotesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OldControlSchemeForBranchesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.LoadBranchOnDoubleclickMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.OsdInBranchScreenshotsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator14 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.AutopauseAtEndOfMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+			this.sepToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.autoHoldFireToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.keepSetPatternsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.sepToolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+			this.sepToolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.autoHoldToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.autoFireToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.customPatternToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.setpToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+			this.setpToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.setCustomsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MetaSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.HeaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StateHistorySettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CommentsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator21 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator21 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DefaultStateSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RotateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -127,30 +127,30 @@ namespace BizHawk.Client.EmuHawk
 			this.HideLagFrames1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.HideLagFrames2 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.HideLagFrames3 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.hideWasLagFramesToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.iconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DenoteStatesWithIconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DenoteStatesWithBGColorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DenoteMarkersWithIconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DenoteMarkersWithBGColorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator23 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.followCursorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.alwaysScrollToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator24 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator24 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.scrollToViewToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.scrollToTopToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.scrollToBottomToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.scrollToCenterToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator25 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator25 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.wheelScrollSpeedToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ColumnsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TASEditorManualOnlineMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ForumThreadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.aboutToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.EnableTooltipsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TasView = new BizHawk.Client.EmuHawk.InputRoll();
 			this.TasStatusStrip = new StatusStripEx();
@@ -164,27 +164,27 @@ namespace BizHawk.Client.EmuHawk
 			this.SetMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SetMarkerWithTextContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DeselectContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SelectBetweenMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.UngreenzoneContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CancelSeekContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator17 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.copyToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.pasteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.pasteInsertToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.cutToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.separateToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+			this.separateToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ClearContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertFrameContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DeleteFramesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CloneContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.InsertNumFramesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator18 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.TruncateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.StartFromNowSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.StartFromNowSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.StartNewProjectFromNowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StartANewProjectFromSaveRamMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BookMarkControl = new BizHawk.Client.EmuHawk.BookmarksBranchesBox();
@@ -303,16 +303,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(187, 6);
-			// 
 			// saveSelectionToMacroToolStripMenuItem
 			// 
 			this.saveSelectionToMacroToolStripMenuItem.Text = "Save Selection to Macro";
@@ -330,25 +320,10 @@ namespace BizHawk.Client.EmuHawk
 			this.recentMacrosToolStripMenuItem.Text = "Recent Macros";
 			this.recentMacrosToolStripMenuItem.DropDownOpened += new System.EventHandler(this.RecentMacrosMenuItem_DropDownOpened);
 			// 
-			// toolStripSeparator22
-			// 
-			this.toolStripSeparator22.Name = "toolStripSeparator22";
-			this.toolStripSeparator22.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator20
-			// 
-			this.toolStripSeparator20.Name = "toolStripSeparator20";
-			this.toolStripSeparator20.Size = new System.Drawing.Size(187, 6);
-			// 
 			// ToBk2MenuItem
 			// 
 			this.ToBk2MenuItem.Text = "&Export to Bk2";
 			this.ToBk2MenuItem.Click += new System.EventHandler(this.ToBk2MenuItem_Click);
-			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(187, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -414,11 +389,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SelectionRedoMenuItem.Enabled = false;
 			this.SelectionRedoMenuItem.Text = "Selection Redo";
 			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(277, 6);
-			// 
 			// DeselectMenuItem
 			// 
 			this.DeselectMenuItem.Text = "Deselect";
@@ -439,11 +409,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ReselectClipboardMenuItem.Text = "Reselect Clipboard";
 			this.ReselectClipboardMenuItem.Click += new System.EventHandler(this.ReselectClipboardMenuItem_Click);
-			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(277, 6);
 			// 
 			// CopyMenuItem
 			// 
@@ -469,11 +434,6 @@ namespace BizHawk.Client.EmuHawk
 			this.CutMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
 			this.CutMenuItem.Text = "&Cut";
 			this.CutMenuItem.Click += new System.EventHandler(this.CutMenuItem_Click);
-			// 
-			// toolStripSeparator8
-			// 
-			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(277, 6);
 			// 
 			// ClearFramesMenuItem
 			// 
@@ -502,11 +462,6 @@ namespace BizHawk.Client.EmuHawk
 			this.InsertNumFramesMenuItem.Text = "Insert # of Frames";
 			this.InsertNumFramesMenuItem.Click += new System.EventHandler(this.InsertNumFramesMenuItem_Click);
 			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(277, 6);
-			// 
 			// TruncateMenuItem
 			// 
 			this.TruncateMenuItem.Text = "&Truncate Movie";
@@ -516,11 +471,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ClearGreenzoneMenuItem.Text = "&Clear Savestate History";
 			this.ClearGreenzoneMenuItem.Click += new System.EventHandler(this.ClearGreenzoneMenuItem_Click);
-			// 
-			// GreenzoneICheckSeparator
-			// 
-			this.GreenzoneICheckSeparator.Name = "GreenzoneICheckSeparator";
-			this.GreenzoneICheckSeparator.Size = new System.Drawing.Size(277, 6);
 			// 
 			// StateHistoryIntegrityCheckMenuItem
 			// 
@@ -574,11 +524,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SetSeekingCutoffIntervalMenuItem.Visible = false;
 			this.SetSeekingCutoffIntervalMenuItem.Click += new System.EventHandler(this.SetSeekingCutoffIntervalMenuItem_Click);
 			// 
-			// toolStripSeparator26
-			// 
-			this.toolStripSeparator26.Name = "toolStripSeparator26";
-			this.toolStripSeparator26.Size = new System.Drawing.Size(241, 6);
-			// 
 			// autosaveToolStripMenuItem
 			// 
 			this.autosaveToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -606,11 +551,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.BackupPerFileSaveMenuItem.Text = "Backup Per File Save";
 			this.BackupPerFileSaveMenuItem.Click += new System.EventHandler(this.BackupPerFileSaveMenuItem_Click);
-			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			this.toolStripSeparator9.Size = new System.Drawing.Size(241, 6);
 			// 
 			// AutoadjustInputMenuItem
 			// 
@@ -644,11 +584,6 @@ namespace BizHawk.Client.EmuHawk
 			this.UseInputKeysItem.Text = "Use Input keys for Column Set";
 			this.UseInputKeysItem.Visible = false;
 			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(241, 6);
-			// 
 			// BindMarkersToInputMenuItem
 			// 
 			this.BindMarkersToInputMenuItem.Checked = true;
@@ -678,20 +613,10 @@ namespace BizHawk.Client.EmuHawk
 			this.OsdInBranchScreenshotsMenuItem.Text = "OSD in Branch screenshots";
 			this.OsdInBranchScreenshotsMenuItem.Visible = false;
 			// 
-			// toolStripSeparator14
-			// 
-			this.toolStripSeparator14.Name = "toolStripSeparator14";
-			this.toolStripSeparator14.Size = new System.Drawing.Size(241, 6);
-			// 
 			// AutopauseAtEndOfMovieMenuItem
 			// 
 			this.AutopauseAtEndOfMovieMenuItem.Text = "Autopause at end of Movie";
 			this.AutopauseAtEndOfMovieMenuItem.Click += new System.EventHandler(this.AutoPauseAtEndMenuItem_Click);
-			// 
-			// sepToolStripMenuItem
-			// 
-			this.sepToolStripMenuItem.Name = "sepToolStripMenuItem";
-			this.sepToolStripMenuItem.Size = new System.Drawing.Size(241, 6);
 			// 
 			// autoHoldFireToolStripMenuItem
 			// 
@@ -709,11 +634,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.keepSetPatternsToolStripMenuItem.CheckOnClick = true;
 			this.keepSetPatternsToolStripMenuItem.Text = "Keep set patterns";
-			// 
-			// sepToolStripMenuItem1
-			// 
-			this.sepToolStripMenuItem1.Name = "sepToolStripMenuItem1";
-			this.sepToolStripMenuItem1.Size = new System.Drawing.Size(157, 6);
 			// 
 			// autoHoldToolStripMenuItem
 			// 
@@ -734,11 +654,6 @@ namespace BizHawk.Client.EmuHawk
 			this.customPatternToolStripMenuItem.CheckOnClick = true;
 			this.customPatternToolStripMenuItem.Text = "Custom Pattern";
 			this.customPatternToolStripMenuItem.CheckedChanged += new System.EventHandler(this.CustomPatternMenuItem_CheckedChanged);
-			// 
-			// setpToolStripMenuItem
-			// 
-			this.setpToolStripMenuItem.Name = "setpToolStripMenuItem";
-			this.setpToolStripMenuItem.Size = new System.Drawing.Size(157, 6);
 			// 
 			// setCustomsToolStripMenuItem
 			// 
@@ -775,11 +690,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SubtitlesMenuItem.Text = "&Subtitles...";
 			this.SubtitlesMenuItem.Click += new System.EventHandler(this.SubtitlesMenuItem_Click);
-			// 
-			// toolStripSeparator21
-			// 
-			this.toolStripSeparator21.Name = "toolStripSeparator21";
-			this.toolStripSeparator21.Size = new System.Drawing.Size(226, 6);
 			// 
 			// DefaultStateSettingsMenuItem
 			// 
@@ -845,11 +755,6 @@ namespace BizHawk.Client.EmuHawk
 			this.HideLagFrames3.Text = "3 (15fps)";
 			this.HideLagFrames3.Click += new System.EventHandler(this.HideLagFramesX_Click);
 			// 
-			// toolStripSeparator12
-			// 
-			this.toolStripSeparator12.Name = "toolStripSeparator12";
-			this.toolStripSeparator12.Size = new System.Drawing.Size(171, 6);
-			// 
 			// hideWasLagFramesToolStripMenuItem
 			// 
 			this.hideWasLagFramesToolStripMenuItem.CheckOnClick = true;
@@ -890,11 +795,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DenoteMarkersWithBGColorToolStripMenuItem.Text = "Denote Markers With BG Color";
 			this.DenoteMarkersWithBGColorToolStripMenuItem.Click += new System.EventHandler(this.DenoteMarkersWithBGColorToolStripMenuItem_Click);
 			// 
-			// toolStripSeparator23
-			// 
-			this.toolStripSeparator23.Name = "toolStripSeparator23";
-			this.toolStripSeparator23.Size = new System.Drawing.Size(177, 6);
-			// 
 			// followCursorToolStripMenuItem
 			// 
 			this.followCursorToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -912,11 +812,6 @@ namespace BizHawk.Client.EmuHawk
 			this.alwaysScrollToolStripMenuItem.CheckOnClick = true;
 			this.alwaysScrollToolStripMenuItem.Text = "Always Scroll";
 			this.alwaysScrollToolStripMenuItem.Click += new System.EventHandler(this.AlwaysScrollMenuItem_Click);
-			// 
-			// toolStripSeparator24
-			// 
-			this.toolStripSeparator24.Name = "toolStripSeparator24";
-			this.toolStripSeparator24.Size = new System.Drawing.Size(146, 6);
 			// 
 			// scrollToViewToolStripMenuItem
 			// 
@@ -944,11 +839,6 @@ namespace BizHawk.Client.EmuHawk
 			this.scrollToCenterToolStripMenuItem.Text = "Scroll to Center";
 			this.scrollToCenterToolStripMenuItem.Click += new System.EventHandler(this.ScrollToCenterMenuItem_Click);
 			// 
-			// toolStripSeparator25
-			// 
-			this.toolStripSeparator25.Name = "toolStripSeparator25";
-			this.toolStripSeparator25.Size = new System.Drawing.Size(177, 6);
-			// 
 			// wheelScrollSpeedToolStripMenuItem
 			// 
 			this.wheelScrollSpeedToolStripMenuItem.Text = "Wheel Scroll Speed...";
@@ -959,11 +849,6 @@ namespace BizHawk.Client.EmuHawk
 			this.ColumnsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator19});
 			this.ColumnsSubMenu.Text = "&Columns";
-			// 
-			// toolStripSeparator19
-			// 
-			this.toolStripSeparator19.Name = "toolStripSeparator19";
-			this.toolStripSeparator19.Size = new System.Drawing.Size(177, 6);
 			// 
 			// HelpSubMenu
 			// 
@@ -989,11 +874,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.aboutToolStripMenuItem.Enabled = false;
 			this.aboutToolStripMenuItem.Text = "&About";
-			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			this.toolStripSeparator10.Size = new System.Drawing.Size(203, 6);
 			// 
 			// EnableTooltipsMenuItem
 			// 
@@ -1143,11 +1023,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RemoveMarkersContextMenuItem.Text = "Remove Markers";
 			this.RemoveMarkersContextMenuItem.Click += new System.EventHandler(this.RemoveMarkersMenuItem_Click);
 			// 
-			// toolStripSeparator15
-			// 
-			this.toolStripSeparator15.Name = "toolStripSeparator15";
-			this.toolStripSeparator15.Size = new System.Drawing.Size(239, 6);
-			// 
 			// DeselectContextMenuItem
 			// 
 			this.DeselectContextMenuItem.Text = "Deselect";
@@ -1158,11 +1033,6 @@ namespace BizHawk.Client.EmuHawk
 			this.SelectBetweenMarkersContextMenuItem.Text = "Select between Markers";
 			this.SelectBetweenMarkersContextMenuItem.Click += new System.EventHandler(this.SelectBetweenMarkersMenuItem_Click);
 			// 
-			// toolStripSeparator16
-			// 
-			this.toolStripSeparator16.Name = "toolStripSeparator16";
-			this.toolStripSeparator16.Size = new System.Drawing.Size(239, 6);
-			// 
 			// UngreenzoneContextMenuItem
 			// 
 			this.UngreenzoneContextMenuItem.Text = "Clear Greenzone";
@@ -1172,11 +1042,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.CancelSeekContextMenuItem.Text = "Cancel Seek";
 			this.CancelSeekContextMenuItem.Click += new System.EventHandler(this.CancelSeekContextMenuItem_Click);
-			// 
-			// toolStripSeparator17
-			// 
-			this.toolStripSeparator17.Name = "toolStripSeparator17";
-			this.toolStripSeparator17.Size = new System.Drawing.Size(239, 6);
 			// 
 			// copyToolStripMenuItem
 			// 
@@ -1201,11 +1066,6 @@ namespace BizHawk.Client.EmuHawk
 			this.cutToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+X";
 			this.cutToolStripMenuItem.Text = "Cut";
 			this.cutToolStripMenuItem.Click += new System.EventHandler(this.CutMenuItem_Click);
-			// 
-			// separateToolStripMenuItem
-			// 
-			this.separateToolStripMenuItem.Name = "separateToolStripMenuItem";
-			this.separateToolStripMenuItem.Size = new System.Drawing.Size(239, 6);
 			// 
 			// ClearContextMenuItem
 			// 
@@ -1232,11 +1092,6 @@ namespace BizHawk.Client.EmuHawk
 			this.InsertNumFramesContextMenuItem.Text = "Insert # of Frames";
 			this.InsertNumFramesContextMenuItem.Click += new System.EventHandler(this.InsertNumFramesMenuItem_Click);
 			// 
-			// toolStripSeparator18
-			// 
-			this.toolStripSeparator18.Name = "toolStripSeparator18";
-			this.toolStripSeparator18.Size = new System.Drawing.Size(239, 6);
-			// 
 			// TruncateContextMenuItem
 			// 
 			this.TruncateContextMenuItem.Text = "Truncate Movie";
@@ -1246,11 +1101,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.BranchContextMenuItem.Text = "&Branch";
 			this.BranchContextMenuItem.Click += new System.EventHandler(this.BranchContextMenuItem_Click);
-			// 
-			// StartFromNowSeparator
-			// 
-			this.StartFromNowSeparator.Name = "StartFromNowSeparator";
-			this.StartFromNowSeparator.Size = new System.Drawing.Size(239, 6);
 			// 
 			// StartNewProjectFromNowMenuItem
 			// 
@@ -1369,23 +1219,23 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenTASMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveTASMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsTASMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ConfigSubMenu;
 		private InputRoll TasView;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertFrameMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloneFramesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeleteFramesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearFramesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertNumFramesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteMenuItem;
@@ -1395,15 +1245,15 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RedoMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectionUndoMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectionRedoMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeselectMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectBetweenMarkersMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReselectClipboardMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator9;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HelpSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EnableTooltipsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator10;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx aboutToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMaxUndoLevelsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoadjustInputMenuItem;
@@ -1412,7 +1262,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EmptyNewMarkerNotesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OldControlSchemeForBranchesMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OsdInBranchScreenshotsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator14;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutopauseAtEndOfMovieMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
 		private StatusStripEx TasStatusStrip;
@@ -1428,28 +1278,28 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ContextMenuStrip RightClickMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMarkersContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMarkersContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator15;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator15;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeselectContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectBetweenMarkersContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator16;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator16;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UngreenzoneContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator17;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeleteFramesContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertFrameContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertNumFramesContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloneContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator18;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator18;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearGreenzoneMenuItem;
-		private System.Windows.Forms.ToolStripSeparator GreenzoneICheckSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx GreenzoneICheckSeparator;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StateHistoryIntegrityCheckMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColumnsSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator19;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator21;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator19;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator21;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DefaultStateSettingsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CancelSeekContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator StartFromNowSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx StartFromNowSeparator;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StartNewProjectFromNowMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RotateMenuItem;
 		private System.Windows.Forms.ToolStripProgressBar SavingProgressBar;
@@ -1461,31 +1311,31 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFrames2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx copyToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx pasteToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator separateToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx separateToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx pasteInsertToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx cutToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx showUndoHistoryToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx sepToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoHoldFireToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx keepSetPatternsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx sepToolStripMenuItem1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoHoldToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoFireToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx customPatternToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator setpToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx setpToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setCustomsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator12;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx hideWasLagFramesToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveSelectionToMacroToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx placeMacroAtSelectionToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator20;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator20;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToBk2MenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx recentMacrosToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator22;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator23;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator22;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator23;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx followCursorToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx alwaysScrollToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator24;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator24;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToViewToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToTopToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToBottomToolStripMenuItem;
@@ -1494,7 +1344,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx onlyOnAutoFireColumnsToolStripMenuItem;
 		private BookmarksBranchesBox BookMarkControl;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BranchContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator25;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator25;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx wheelScrollSpeedToolStripMenuItem;
 		private System.Windows.Forms.SplitContainer BranchesMarkersSplit;
 		private System.Windows.Forms.SplitContainer MainVertialSplit;
@@ -1510,7 +1360,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetBranchCellHoverIntervalMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMarkerWithTextContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetSeekingCutoffIntervalMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator26;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator26;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TASEditorManualOnlineMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ForumThreadMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autosaveToolStripMenuItem;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -32,126 +32,126 @@ namespace BizHawk.Client.EmuHawk
 		{
 			this.components = new System.ComponentModel.Container();
 			this.TASMenu = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewTASMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewFromSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewFromNowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewFromCurrentSaveRamMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenTASMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveTASMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsTASMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveBackupMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveBk2BackupMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewTASMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewFromSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewFromNowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewFromCurrentSaveRamMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenTASMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveTASMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsTASMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveBackupMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveBk2BackupMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.saveSelectionToMacroToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.placeMacroAtSelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.recentMacrosToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.saveSelectionToMacroToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.placeMacroAtSelectionToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.recentMacrosToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
-			this.ToBk2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ToBk2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.UndoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RedoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.showUndoHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectionUndoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectionRedoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RedoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.showUndoHistoryToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectionUndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectionRedoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.DeselectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectBetweenMarkersMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ReselectClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DeselectMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectBetweenMarkersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ReselectClipboardMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.CopyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PasteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PasteInsertMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PasteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PasteInsertMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CutMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-			this.ClearFramesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertFrameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DeleteFramesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CloneFramesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertNumFramesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertFrameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DeleteFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloneFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertNumFramesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.TruncateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearGreenzoneMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.TruncateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearGreenzoneMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.GreenzoneICheckSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.StateHistoryIntegrityCheckMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ConfigSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetMaxUndoLevelsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetBranchCellHoverIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetSeekingCutoffIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.StateHistoryIntegrityCheckMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetMaxUndoLevelsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetBranchCellHoverIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetSeekingCutoffIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
-			this.autosaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetAutosaveIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutosaveAsBk2MenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutosaveAsBackupFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BackupPerFileSaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.autosaveToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetAutosaveIntervalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutosaveAsBk2MenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutosaveAsBackupFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BackupPerFileSaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoadjustInputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.applyPatternToPaintedInputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.onlyOnAutoFireColumnsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SingleClickAxisEditMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UseInputKeysItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoadjustInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.applyPatternToPaintedInputToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.onlyOnAutoFireColumnsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SingleClickAxisEditMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UseInputKeysItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.BindMarkersToInputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EmptyNewMarkerNotesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OldControlSchemeForBranchesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LoadBranchOnDoubleclickMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OsdInBranchScreenshotsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.BindMarkersToInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EmptyNewMarkerNotesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OldControlSchemeForBranchesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.LoadBranchOnDoubleclickMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OsdInBranchScreenshotsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutopauseAtEndOfMovieMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutopauseAtEndOfMovieMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-			this.autoHoldFireToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.keepSetPatternsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.autoHoldFireToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.keepSetPatternsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.sepToolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-			this.autoHoldToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.autoFireToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.customPatternToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.autoHoldToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.autoFireToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.customPatternToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.setpToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-			this.setCustomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MetaSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.HeaderMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StateHistorySettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CommentsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SubtitlesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.setCustomsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MetaSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HeaderMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StateHistorySettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CommentsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SubtitlesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator21 = new System.Windows.Forms.ToolStripSeparator();
-			this.DefaultStateSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.RotateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.HideLagFramesSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.HideLagFrames0 = new System.Windows.Forms.ToolStripMenuItem();
-			this.HideLagFrames1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.HideLagFrames2 = new System.Windows.Forms.ToolStripMenuItem();
-			this.HideLagFrames3 = new System.Windows.Forms.ToolStripMenuItem();
+			this.DefaultStateSettingsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RotateMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HideLagFramesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HideLagFrames0 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HideLagFrames1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HideLagFrames2 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.HideLagFrames3 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-			this.hideWasLagFramesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.iconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DenoteStatesWithIconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DenoteStatesWithBGColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DenoteMarkersWithIconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DenoteMarkersWithBGColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.hideWasLagFramesToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.iconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DenoteStatesWithIconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DenoteStatesWithBGColorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DenoteMarkersWithIconsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DenoteMarkersWithBGColorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
-			this.followCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.alwaysScrollToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.followCursorToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.alwaysScrollToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator24 = new System.Windows.Forms.ToolStripSeparator();
-			this.scrollToViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scrollToTopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scrollToBottomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scrollToCenterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.scrollToViewToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.scrollToTopToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.scrollToBottomToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.scrollToCenterToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator25 = new System.Windows.Forms.ToolStripSeparator();
-			this.wheelScrollSpeedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ColumnsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.wheelScrollSpeedToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ColumnsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
-			this.HelpSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.TASEditorManualOnlineMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ForumThreadMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.HelpSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TASEditorManualOnlineMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ForumThreadMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.aboutToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-			this.EnableTooltipsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.EnableTooltipsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TasView = new BizHawk.Client.EmuHawk.InputRoll();
 			this.TasStatusStrip = new StatusStripEx();
 			this.MessageStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -161,36 +161,36 @@ namespace BizHawk.Client.EmuHawk
 			this.TasPlaybackBox = new BizHawk.Client.EmuHawk.PlaybackBox();
 			this.MarkerControl = new BizHawk.Client.EmuHawk.MarkerControl();
 			this.RightClickMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.SetMarkersContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SetMarkerWithTextContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveMarkersContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SetMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SetMarkerWithTextContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-			this.DeselectContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectBetweenMarkersContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DeselectContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectBetweenMarkersContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-			this.UngreenzoneContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CancelSeekContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.UngreenzoneContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CancelSeekContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
-			this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.pasteInsertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.copyToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.pasteToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.pasteInsertToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.cutToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.separateToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-			this.ClearContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertFrameContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DeleteFramesContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CloneContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.InsertNumFramesContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertFrameContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DeleteFramesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CloneContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.InsertNumFramesContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
-			this.TruncateContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.BranchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.TruncateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.BranchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StartFromNowSeparator = new System.Windows.Forms.ToolStripSeparator();
-			this.StartNewProjectFromNowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StartANewProjectFromSaveRamMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.StartNewProjectFromNowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StartANewProjectFromSaveRamMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.BookMarkControl = new BizHawk.Client.EmuHawk.BookmarksBranchesBox();
 			this.BranchesMarkersSplit = new System.Windows.Forms.SplitContainer();
 			this.MainVertialSplit = new System.Windows.Forms.SplitContainer();
-			this.SetFontMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SetFontMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TASMenu.SuspendLayout();
 			this.TasStatusStrip.SuspendLayout();
 			this.RightClickMenu.SuspendLayout();
@@ -239,16 +239,12 @@ namespace BizHawk.Client.EmuHawk
             this.ToBk2MenuItem,
             this.toolStripSeparator2,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// NewTASMenuItem
 			// 
-			this.NewTASMenuItem.Name = "NewTASMenuItem";
 			this.NewTASMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-			this.NewTASMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.NewTASMenuItem.Text = "&New";
 			this.NewTASMenuItem.Click += new System.EventHandler(this.NewTasMenuItem_Click);
 			// 
@@ -257,61 +253,45 @@ namespace BizHawk.Client.EmuHawk
 			this.NewFromSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.NewFromNowMenuItem,
             this.NewFromCurrentSaveRamMenuItem});
-			this.NewFromSubMenu.Name = "NewFromSubMenu";
-			this.NewFromSubMenu.Size = new System.Drawing.Size(190, 22);
 			this.NewFromSubMenu.Text = "New From";
 			this.NewFromSubMenu.DropDownOpened += new System.EventHandler(this.NewFromSubMenu_DropDownOpened);
 			// 
 			// NewFromNowMenuItem
 			// 
-			this.NewFromNowMenuItem.Name = "NewFromNowMenuItem";
-			this.NewFromNowMenuItem.Size = new System.Drawing.Size(159, 22);
 			this.NewFromNowMenuItem.Text = "&Now";
 			this.NewFromNowMenuItem.Click += new System.EventHandler(this.StartNewProjectFromNowMenuItem_Click);
 			// 
 			// NewFromCurrentSaveRamMenuItem
 			// 
-			this.NewFromCurrentSaveRamMenuItem.Name = "NewFromCurrentSaveRamMenuItem";
-			this.NewFromCurrentSaveRamMenuItem.Size = new System.Drawing.Size(159, 22);
 			this.NewFromCurrentSaveRamMenuItem.Text = "&Current SaveRam";
 			this.NewFromCurrentSaveRamMenuItem.Click += new System.EventHandler(this.StartANewProjectFromSaveRamMenuItem_Click);
 			// 
 			// OpenTASMenuItem
 			// 
-			this.OpenTASMenuItem.Name = "OpenTASMenuItem";
 			this.OpenTASMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenTASMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.OpenTASMenuItem.Text = "&Open";
 			this.OpenTASMenuItem.Click += new System.EventHandler(this.OpenTasMenuItem_Click);
 			// 
 			// SaveTASMenuItem
 			// 
-			this.SaveTASMenuItem.Name = "SaveTASMenuItem";
 			this.SaveTASMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveTASMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.SaveTASMenuItem.Text = "&Save";
 			this.SaveTASMenuItem.Click += new System.EventHandler(this.SaveTasMenuItem_Click);
 			// 
 			// SaveAsTASMenuItem
 			// 
-			this.SaveAsTASMenuItem.Name = "SaveAsTASMenuItem";
 			this.SaveAsTASMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveAsTASMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.SaveAsTASMenuItem.Text = "Save As";
 			this.SaveAsTASMenuItem.Click += new System.EventHandler(this.SaveAsTasMenuItem_Click);
 			// 
 			// SaveBackupMenuItem
 			// 
-			this.SaveBackupMenuItem.Name = "SaveBackupMenuItem";
-			this.SaveBackupMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.SaveBackupMenuItem.Text = "Save Backup";
 			this.SaveBackupMenuItem.Click += new System.EventHandler(this.SaveBackupMenuItem_Click);
 			// 
 			// SaveBk2BackupMenuItem
 			// 
-			this.SaveBk2BackupMenuItem.Name = "SaveBk2BackupMenuItem";
-			this.SaveBk2BackupMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.SaveBk2BackupMenuItem.Text = "Save Bk2 Backup";
 			this.SaveBk2BackupMenuItem.Visible = false;
 			this.SaveBk2BackupMenuItem.Click += new System.EventHandler(this.SaveBk2BackupMenuItem_Click);
@@ -320,8 +300,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator3});
-			this.RecentSubMenu.Name = "RecentSubMenu";
-			this.RecentSubMenu.Size = new System.Drawing.Size(190, 22);
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
@@ -337,15 +315,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// saveSelectionToMacroToolStripMenuItem
 			// 
-			this.saveSelectionToMacroToolStripMenuItem.Name = "saveSelectionToMacroToolStripMenuItem";
-			this.saveSelectionToMacroToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.saveSelectionToMacroToolStripMenuItem.Text = "Save Selection to Macro";
 			this.saveSelectionToMacroToolStripMenuItem.Click += new System.EventHandler(this.SaveSelectionToMacroMenuItem_Click);
 			// 
 			// placeMacroAtSelectionToolStripMenuItem
 			// 
-			this.placeMacroAtSelectionToolStripMenuItem.Name = "placeMacroAtSelectionToolStripMenuItem";
-			this.placeMacroAtSelectionToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.placeMacroAtSelectionToolStripMenuItem.Text = "Place Macro at Selection";
 			this.placeMacroAtSelectionToolStripMenuItem.Click += new System.EventHandler(this.PlaceMacroAtSelectionMenuItem_Click);
 			// 
@@ -353,8 +327,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.recentMacrosToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator22});
-			this.recentMacrosToolStripMenuItem.Name = "recentMacrosToolStripMenuItem";
-			this.recentMacrosToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.recentMacrosToolStripMenuItem.Text = "Recent Macros";
 			this.recentMacrosToolStripMenuItem.DropDownOpened += new System.EventHandler(this.RecentMacrosMenuItem_DropDownOpened);
 			// 
@@ -370,8 +342,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ToBk2MenuItem
 			// 
-			this.ToBk2MenuItem.Name = "ToBk2MenuItem";
-			this.ToBk2MenuItem.Size = new System.Drawing.Size(190, 22);
 			this.ToBk2MenuItem.Text = "&Export to Bk2";
 			this.ToBk2MenuItem.Click += new System.EventHandler(this.ToBk2MenuItem_Click);
 			// 
@@ -382,9 +352,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(190, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -417,45 +385,33 @@ namespace BizHawk.Client.EmuHawk
             this.ClearGreenzoneMenuItem,
             this.GreenzoneICheckSeparator,
             this.StateHistoryIntegrityCheckMenuItem});
-			this.EditSubMenu.Name = "EditSubMenu";
-			this.EditSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.EditSubMenu.Text = "&Edit";
 			this.EditSubMenu.DropDownOpened += new System.EventHandler(this.EditSubMenu_DropDownOpened);
 			// 
 			// UndoMenuItem
 			// 
-			this.UndoMenuItem.Name = "UndoMenuItem";
-			this.UndoMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.UndoMenuItem.Text = "&Undo";
 			this.UndoMenuItem.Click += new System.EventHandler(this.UndoMenuItem_Click);
 			// 
 			// RedoMenuItem
 			// 
 			this.RedoMenuItem.Enabled = false;
-			this.RedoMenuItem.Name = "RedoMenuItem";
-			this.RedoMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.RedoMenuItem.Text = "&Redo";
 			this.RedoMenuItem.Click += new System.EventHandler(this.RedoMenuItem_Click);
 			// 
 			// showUndoHistoryToolStripMenuItem
 			// 
-			this.showUndoHistoryToolStripMenuItem.Name = "showUndoHistoryToolStripMenuItem";
-			this.showUndoHistoryToolStripMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.showUndoHistoryToolStripMenuItem.Text = "Show Undo History";
 			this.showUndoHistoryToolStripMenuItem.Click += new System.EventHandler(this.ShowUndoHistoryMenuItem_Click);
 			// 
 			// SelectionUndoMenuItem
 			// 
 			this.SelectionUndoMenuItem.Enabled = false;
-			this.SelectionUndoMenuItem.Name = "SelectionUndoMenuItem";
-			this.SelectionUndoMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.SelectionUndoMenuItem.Text = "Selection Undo";
 			// 
 			// SelectionRedoMenuItem
 			// 
 			this.SelectionRedoMenuItem.Enabled = false;
-			this.SelectionRedoMenuItem.Name = "SelectionRedoMenuItem";
-			this.SelectionRedoMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.SelectionRedoMenuItem.Text = "Selection Redo";
 			// 
 			// toolStripSeparator5
@@ -465,30 +421,22 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// DeselectMenuItem
 			// 
-			this.DeselectMenuItem.Name = "DeselectMenuItem";
-			this.DeselectMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.DeselectMenuItem.Text = "Deselect";
 			this.DeselectMenuItem.Click += new System.EventHandler(this.DeselectMenuItem_Click);
 			// 
 			// SelectBetweenMarkersMenuItem
 			// 
-			this.SelectBetweenMarkersMenuItem.Name = "SelectBetweenMarkersMenuItem";
-			this.SelectBetweenMarkersMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.SelectBetweenMarkersMenuItem.Text = "Select between Markers";
 			this.SelectBetweenMarkersMenuItem.Click += new System.EventHandler(this.SelectBetweenMarkersMenuItem_Click);
 			// 
 			// SelectAllMenuItem
 			// 
-			this.SelectAllMenuItem.Name = "SelectAllMenuItem";
 			this.SelectAllMenuItem.ShortcutKeyDisplayString = "";
-			this.SelectAllMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
 			// ReselectClipboardMenuItem
 			// 
-			this.ReselectClipboardMenuItem.Name = "ReselectClipboardMenuItem";
-			this.ReselectClipboardMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.ReselectClipboardMenuItem.Text = "Reselect Clipboard";
 			this.ReselectClipboardMenuItem.Click += new System.EventHandler(this.ReselectClipboardMenuItem_Click);
 			// 
@@ -499,34 +447,26 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CopyMenuItem
 			// 
-			this.CopyMenuItem.Name = "CopyMenuItem";
 			this.CopyMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.CopyMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.CopyMenuItem.Text = "Copy";
 			this.CopyMenuItem.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// PasteMenuItem
 			// 
-			this.PasteMenuItem.Name = "PasteMenuItem";
 			this.PasteMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-			this.PasteMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.PasteMenuItem.Text = "&Paste";
 			this.PasteMenuItem.Click += new System.EventHandler(this.PasteMenuItem_Click);
 			// 
 			// PasteInsertMenuItem
 			// 
-			this.PasteInsertMenuItem.Name = "PasteInsertMenuItem";
 			this.PasteInsertMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.V)));
-			this.PasteInsertMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.PasteInsertMenuItem.Text = "&Paste Insert";
 			this.PasteInsertMenuItem.Click += new System.EventHandler(this.PasteInsertMenuItem_Click);
 			// 
 			// CutMenuItem
 			// 
-			this.CutMenuItem.Name = "CutMenuItem";
 			this.CutMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-			this.CutMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.CutMenuItem.Text = "&Cut";
 			this.CutMenuItem.Click += new System.EventHandler(this.CutMenuItem_Click);
 			// 
@@ -537,38 +477,28 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearFramesMenuItem
 			// 
-			this.ClearFramesMenuItem.Name = "ClearFramesMenuItem";
 			this.ClearFramesMenuItem.ShortcutKeyDisplayString = "";
-			this.ClearFramesMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.ClearFramesMenuItem.Text = "Clear";
 			this.ClearFramesMenuItem.Click += new System.EventHandler(this.ClearFramesMenuItem_Click);
 			// 
 			// InsertFrameMenuItem
 			// 
-			this.InsertFrameMenuItem.Name = "InsertFrameMenuItem";
-			this.InsertFrameMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.InsertFrameMenuItem.Text = "&Insert";
 			this.InsertFrameMenuItem.Click += new System.EventHandler(this.InsertFrameMenuItem_Click);
 			// 
 			// DeleteFramesMenuItem
 			// 
-			this.DeleteFramesMenuItem.Name = "DeleteFramesMenuItem";
-			this.DeleteFramesMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.DeleteFramesMenuItem.Text = "&Delete";
 			this.DeleteFramesMenuItem.Click += new System.EventHandler(this.DeleteFramesMenuItem_Click);
 			// 
 			// CloneFramesMenuItem
 			// 
-			this.CloneFramesMenuItem.Name = "CloneFramesMenuItem";
-			this.CloneFramesMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.CloneFramesMenuItem.Text = "&Clone";
 			this.CloneFramesMenuItem.Click += new System.EventHandler(this.CloneFramesMenuItem_Click);
 			// 
 			// InsertNumFramesMenuItem
 			// 
-			this.InsertNumFramesMenuItem.Name = "InsertNumFramesMenuItem";
 			this.InsertNumFramesMenuItem.ShortcutKeyDisplayString = "";
-			this.InsertNumFramesMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.InsertNumFramesMenuItem.Text = "Insert # of Frames";
 			this.InsertNumFramesMenuItem.Click += new System.EventHandler(this.InsertNumFramesMenuItem_Click);
 			// 
@@ -579,15 +509,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// TruncateMenuItem
 			// 
-			this.TruncateMenuItem.Name = "TruncateMenuItem";
-			this.TruncateMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.TruncateMenuItem.Text = "&Truncate Movie";
 			this.TruncateMenuItem.Click += new System.EventHandler(this.TruncateMenuItem_Click);
 			// 
 			// ClearGreenzoneMenuItem
 			// 
-			this.ClearGreenzoneMenuItem.Name = "ClearGreenzoneMenuItem";
-			this.ClearGreenzoneMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.ClearGreenzoneMenuItem.Text = "&Clear Savestate History";
 			this.ClearGreenzoneMenuItem.Click += new System.EventHandler(this.ClearGreenzoneMenuItem_Click);
 			// 
@@ -598,10 +524,8 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// StateHistoryIntegrityCheckMenuItem
 			// 
-			this.StateHistoryIntegrityCheckMenuItem.Name = "StateHistoryIntegrityCheckMenuItem";
 			this.StateHistoryIntegrityCheckMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.I)));
-			this.StateHistoryIntegrityCheckMenuItem.Size = new System.Drawing.Size(280, 22);
 			this.StateHistoryIntegrityCheckMenuItem.Text = "State History Integrity Check";
 			this.StateHistoryIntegrityCheckMenuItem.Click += new System.EventHandler(this.StateHistoryIntegrityCheckMenuItem_Click);
 			// 
@@ -631,29 +555,21 @@ namespace BizHawk.Client.EmuHawk
             this.sepToolStripMenuItem,
             this.autoHoldFireToolStripMenuItem,
 			this.SetFontMenuItem});
-			this.ConfigSubMenu.Name = "ConfigSubMenu";
-			this.ConfigSubMenu.Size = new System.Drawing.Size(50, 20);
 			this.ConfigSubMenu.Text = "&Config";
 			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
 			// 
 			// SetMaxUndoLevelsMenuItem
 			// 
-			this.SetMaxUndoLevelsMenuItem.Name = "SetMaxUndoLevelsMenuItem";
-			this.SetMaxUndoLevelsMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.SetMaxUndoLevelsMenuItem.Text = "Set max Undo Levels";
 			this.SetMaxUndoLevelsMenuItem.Click += new System.EventHandler(this.SetMaxUndoLevelsMenuItem_Click);
 			// 
 			// SetBranchCellHoverIntervalMenuItem
 			// 
-			this.SetBranchCellHoverIntervalMenuItem.Name = "SetBranchCellHoverIntervalMenuItem";
-			this.SetBranchCellHoverIntervalMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.SetBranchCellHoverIntervalMenuItem.Text = "Set Branch Cell Hover Interval";
 			this.SetBranchCellHoverIntervalMenuItem.Click += new System.EventHandler(this.SetBranchCellHoverIntervalMenuItem_Click);
 			// 
 			// SetSeekingCutoffIntervalMenuItem
 			// 
-			this.SetSeekingCutoffIntervalMenuItem.Name = "SetSeekingCutoffIntervalMenuItem";
-			this.SetSeekingCutoffIntervalMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.SetSeekingCutoffIntervalMenuItem.Text = "Set Seeking Cutoff Interval";
 			this.SetSeekingCutoffIntervalMenuItem.Visible = false;
 			this.SetSeekingCutoffIntervalMenuItem.Click += new System.EventHandler(this.SetSeekingCutoffIntervalMenuItem_Click);
@@ -669,35 +585,25 @@ namespace BizHawk.Client.EmuHawk
             this.SetAutosaveIntervalMenuItem,
             this.AutosaveAsBk2MenuItem,
             this.AutosaveAsBackupFileMenuItem});
-			this.autosaveToolStripMenuItem.Name = "autosaveToolStripMenuItem";
-			this.autosaveToolStripMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.autosaveToolStripMenuItem.Text = "Autosave";
 			// 
 			// SetAutosaveIntervalMenuItem
 			// 
-			this.SetAutosaveIntervalMenuItem.Name = "SetAutosaveIntervalMenuItem";
-			this.SetAutosaveIntervalMenuItem.Size = new System.Drawing.Size(191, 22);
 			this.SetAutosaveIntervalMenuItem.Text = "Set Autosave Interval";
 			this.SetAutosaveIntervalMenuItem.Click += new System.EventHandler(this.SetAutosaveIntervalMenuItem_Click);
 			// 
 			// AutosaveAsBk2MenuItem
 			// 
-			this.AutosaveAsBk2MenuItem.Name = "AutosaveAsBk2MenuItem";
-			this.AutosaveAsBk2MenuItem.Size = new System.Drawing.Size(191, 22);
 			this.AutosaveAsBk2MenuItem.Text = "Autosave As Bk2";
 			this.AutosaveAsBk2MenuItem.Click += new System.EventHandler(this.AutosaveAsBk2MenuItem_Click);
 			// 
 			// AutosaveAsBackupFileMenuItem
 			// 
-			this.AutosaveAsBackupFileMenuItem.Name = "AutosaveAsBackupFileMenuItem";
-			this.AutosaveAsBackupFileMenuItem.Size = new System.Drawing.Size(191, 22);
 			this.AutosaveAsBackupFileMenuItem.Text = "Autosave As Backup File";
 			this.AutosaveAsBackupFileMenuItem.Click += new System.EventHandler(this.AutosaveAsBackupFileMenuItem_Click);
 			// 
 			// BackupPerFileSaveMenuItem
 			// 
-			this.BackupPerFileSaveMenuItem.Name = "BackupPerFileSaveMenuItem";
-			this.BackupPerFileSaveMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.BackupPerFileSaveMenuItem.Text = "Backup Per File Save";
 			this.BackupPerFileSaveMenuItem.Click += new System.EventHandler(this.BackupPerFileSaveMenuItem_Click);
 			// 
@@ -709,15 +615,11 @@ namespace BizHawk.Client.EmuHawk
 			// AutoadjustInputMenuItem
 			// 
 			this.AutoadjustInputMenuItem.CheckOnClick = true;
-			this.AutoadjustInputMenuItem.Name = "AutoadjustInputMenuItem";
-			this.AutoadjustInputMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.AutoadjustInputMenuItem.Text = "Auto-adjust Input according to Lag";
 			// 
 			// applyPatternToPaintedInputToolStripMenuItem
 			// 
 			this.applyPatternToPaintedInputToolStripMenuItem.CheckOnClick = true;
-			this.applyPatternToPaintedInputToolStripMenuItem.Name = "applyPatternToPaintedInputToolStripMenuItem";
-			this.applyPatternToPaintedInputToolStripMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.applyPatternToPaintedInputToolStripMenuItem.Text = "Apply Pattern to painted input";
 			this.applyPatternToPaintedInputToolStripMenuItem.CheckedChanged += new System.EventHandler(this.ApplyPatternToPaintedInputMenuItem_CheckedChanged);
 			// 
@@ -727,15 +629,11 @@ namespace BizHawk.Client.EmuHawk
 			this.onlyOnAutoFireColumnsToolStripMenuItem.CheckOnClick = true;
 			this.onlyOnAutoFireColumnsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.onlyOnAutoFireColumnsToolStripMenuItem.Enabled = false;
-			this.onlyOnAutoFireColumnsToolStripMenuItem.Name = "onlyOnAutoFireColumnsToolStripMenuItem";
-			this.onlyOnAutoFireColumnsToolStripMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.onlyOnAutoFireColumnsToolStripMenuItem.Text = "Only on Auto-Fire columns";
 			// 
 			// SingleClickAxisEditMenuItem
 			// 
 			this.SingleClickAxisEditMenuItem.Enabled = false;
-			this.SingleClickAxisEditMenuItem.Name = "SingleClickAxisEditMenuItem";
-			this.SingleClickAxisEditMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.SingleClickAxisEditMenuItem.Text = "Enter Axis Edit mode by single click";
 			this.SingleClickAxisEditMenuItem.Visible = false;
 			this.SingleClickAxisEditMenuItem.Click += new System.EventHandler(this.SingleClickAxisEditMenuItem_Click);
@@ -743,8 +641,6 @@ namespace BizHawk.Client.EmuHawk
 			// UseInputKeysItem
 			// 
 			this.UseInputKeysItem.Enabled = false;
-			this.UseInputKeysItem.Name = "UseInputKeysItem";
-			this.UseInputKeysItem.Size = new System.Drawing.Size(244, 22);
 			this.UseInputKeysItem.Text = "Use Input keys for Column Set";
 			this.UseInputKeysItem.Visible = false;
 			// 
@@ -758,37 +654,27 @@ namespace BizHawk.Client.EmuHawk
 			this.BindMarkersToInputMenuItem.Checked = true;
 			this.BindMarkersToInputMenuItem.CheckOnClick = true;
 			this.BindMarkersToInputMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.BindMarkersToInputMenuItem.Name = "BindMarkersToInputMenuItem";
-			this.BindMarkersToInputMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.BindMarkersToInputMenuItem.Text = "Bind Markers to Input";
 			this.BindMarkersToInputMenuItem.Click += new System.EventHandler(this.BindMarkersToInputMenuItem_Click);
 			// 
 			// EmptyNewMarkerNotesMenuItem
 			// 
-			this.EmptyNewMarkerNotesMenuItem.Name = "EmptyNewMarkerNotesMenuItem";
-			this.EmptyNewMarkerNotesMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.EmptyNewMarkerNotesMenuItem.Text = "Empty new Marker Notes";
 			this.EmptyNewMarkerNotesMenuItem.Click += new System.EventHandler(this.EmptyNewMarkerNotesMenuItem_Click);
 			// 
 			// OldControlSchemeForBranchesMenuItem
 			// 
-			this.OldControlSchemeForBranchesMenuItem.Name = "OldControlSchemeForBranchesMenuItem";
-			this.OldControlSchemeForBranchesMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.OldControlSchemeForBranchesMenuItem.Text = "Old control scheme for Branches";
 			this.OldControlSchemeForBranchesMenuItem.Click += new System.EventHandler(this.OldControlSchemeForBranchesMenuItem_Click);
 			// 
 			// LoadBranchOnDoubleclickMenuItem
 			// 
-			this.LoadBranchOnDoubleclickMenuItem.Name = "LoadBranchOnDoubleclickMenuItem";
-			this.LoadBranchOnDoubleclickMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.LoadBranchOnDoubleclickMenuItem.Text = "Load Branch on double-click";
 			this.LoadBranchOnDoubleclickMenuItem.Click += new System.EventHandler(this.LoadBranchOnDoubleClickMenuItem_Click);
 			// 
 			// OsdInBranchScreenshotsMenuItem
 			// 
 			this.OsdInBranchScreenshotsMenuItem.Enabled = false;
-			this.OsdInBranchScreenshotsMenuItem.Name = "OsdInBranchScreenshotsMenuItem";
-			this.OsdInBranchScreenshotsMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.OsdInBranchScreenshotsMenuItem.Text = "OSD in Branch screenshots";
 			this.OsdInBranchScreenshotsMenuItem.Visible = false;
 			// 
@@ -799,8 +685,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// AutopauseAtEndOfMovieMenuItem
 			// 
-			this.AutopauseAtEndOfMovieMenuItem.Name = "AutopauseAtEndOfMovieMenuItem";
-			this.AutopauseAtEndOfMovieMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.AutopauseAtEndOfMovieMenuItem.Text = "Autopause at end of Movie";
 			this.AutopauseAtEndOfMovieMenuItem.Click += new System.EventHandler(this.AutoPauseAtEndMenuItem_Click);
 			// 
@@ -819,15 +703,11 @@ namespace BizHawk.Client.EmuHawk
             this.customPatternToolStripMenuItem,
             this.setpToolStripMenuItem,
             this.setCustomsToolStripMenuItem});
-			this.autoHoldFireToolStripMenuItem.Name = "autoHoldFireToolStripMenuItem";
-			this.autoHoldFireToolStripMenuItem.Size = new System.Drawing.Size(244, 22);
 			this.autoHoldFireToolStripMenuItem.Text = "Auto Hold/Fire";
 			// 
 			// keepSetPatternsToolStripMenuItem
 			// 
 			this.keepSetPatternsToolStripMenuItem.CheckOnClick = true;
-			this.keepSetPatternsToolStripMenuItem.Name = "keepSetPatternsToolStripMenuItem";
-			this.keepSetPatternsToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.keepSetPatternsToolStripMenuItem.Text = "Keep set patterns";
 			// 
 			// sepToolStripMenuItem1
@@ -840,24 +720,18 @@ namespace BizHawk.Client.EmuHawk
 			this.autoHoldToolStripMenuItem.Checked = true;
 			this.autoHoldToolStripMenuItem.CheckOnClick = true;
 			this.autoHoldToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.autoHoldToolStripMenuItem.Name = "autoHoldToolStripMenuItem";
-			this.autoHoldToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.autoHoldToolStripMenuItem.Text = "Auto-Hold";
 			this.autoHoldToolStripMenuItem.CheckedChanged += new System.EventHandler(this.AutoHoldMenuItem_CheckedChanged);
 			// 
 			// autoFireToolStripMenuItem
 			// 
 			this.autoFireToolStripMenuItem.CheckOnClick = true;
-			this.autoFireToolStripMenuItem.Name = "autoFireToolStripMenuItem";
-			this.autoFireToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.autoFireToolStripMenuItem.Text = "Auto-Fire";
 			this.autoFireToolStripMenuItem.CheckedChanged += new System.EventHandler(this.AutoFireMenuItem_CheckedChanged);
 			// 
 			// customPatternToolStripMenuItem
 			// 
 			this.customPatternToolStripMenuItem.CheckOnClick = true;
-			this.customPatternToolStripMenuItem.Name = "customPatternToolStripMenuItem";
-			this.customPatternToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.customPatternToolStripMenuItem.Text = "Custom Pattern";
 			this.customPatternToolStripMenuItem.CheckedChanged += new System.EventHandler(this.CustomPatternMenuItem_CheckedChanged);
 			// 
@@ -868,8 +742,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// setCustomsToolStripMenuItem
 			// 
-			this.setCustomsToolStripMenuItem.Name = "setCustomsToolStripMenuItem";
-			this.setCustomsToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
 			this.setCustomsToolStripMenuItem.Text = "Set Customs...";
 			this.setCustomsToolStripMenuItem.Click += new System.EventHandler(this.SetCustomsMenuItem_Click);
 			// 
@@ -882,35 +754,25 @@ namespace BizHawk.Client.EmuHawk
             this.SubtitlesMenuItem,
             this.toolStripSeparator21,
             this.DefaultStateSettingsMenuItem});
-			this.MetaSubMenu.Name = "MetaSubMenu";
-			this.MetaSubMenu.Size = new System.Drawing.Size(65, 20);
 			this.MetaSubMenu.Text = "&Metadata";
 			// 
 			// HeaderMenuItem
 			// 
-			this.HeaderMenuItem.Name = "HeaderMenuItem";
-			this.HeaderMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.HeaderMenuItem.Text = "&Header...";
 			this.HeaderMenuItem.Click += new System.EventHandler(this.HeaderMenuItem_Click);
 			// 
 			// StateHistorySettingsMenuItem
 			// 
-			this.StateHistorySettingsMenuItem.Name = "StateHistorySettingsMenuItem";
-			this.StateHistorySettingsMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.StateHistorySettingsMenuItem.Text = "&Savestate History Settings...";
 			this.StateHistorySettingsMenuItem.Click += new System.EventHandler(this.StateHistorySettingsMenuItem_Click);
 			// 
 			// CommentsMenuItem
 			// 
-			this.CommentsMenuItem.Name = "CommentsMenuItem";
-			this.CommentsMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.CommentsMenuItem.Text = "&Comments...";
 			this.CommentsMenuItem.Click += new System.EventHandler(this.CommentsMenuItem_Click);
 			// 
 			// SubtitlesMenuItem
 			// 
-			this.SubtitlesMenuItem.Name = "SubtitlesMenuItem";
-			this.SubtitlesMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.SubtitlesMenuItem.Text = "&Subtitles...";
 			this.SubtitlesMenuItem.Click += new System.EventHandler(this.SubtitlesMenuItem_Click);
 			// 
@@ -921,8 +783,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// DefaultStateSettingsMenuItem
 			// 
-			this.DefaultStateSettingsMenuItem.Name = "DefaultStateSettingsMenuItem";
-			this.DefaultStateSettingsMenuItem.Size = new System.Drawing.Size(229, 22);
 			this.DefaultStateSettingsMenuItem.Text = "&Default State History Settings...";
 			this.DefaultStateSettingsMenuItem.Click += new System.EventHandler(this.DefaultStateSettingsMenuItem_Click);
 			// 
@@ -936,15 +796,11 @@ namespace BizHawk.Client.EmuHawk
             this.followCursorToolStripMenuItem,
             this.toolStripSeparator25,
             this.wheelScrollSpeedToolStripMenuItem});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(58, 20);
 			this.SettingsSubMenu.Text = "&Settings";
 			this.SettingsSubMenu.DropDownOpened += new System.EventHandler(this.SettingsSubMenu_DropDownOpened);
 			// 
 			// RotateMenuItem
 			// 
-			this.RotateMenuItem.Name = "RotateMenuItem";
-			this.RotateMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.RotateMenuItem.Text = "Rotate";
 			this.RotateMenuItem.Click += new System.EventHandler(this.RotateMenuItem_Click);
 			// 
@@ -957,8 +813,6 @@ namespace BizHawk.Client.EmuHawk
             this.HideLagFrames3,
             this.toolStripSeparator12,
             this.hideWasLagFramesToolStripMenuItem});
-			this.HideLagFramesSubMenu.Name = "HideLagFramesSubMenu";
-			this.HideLagFramesSubMenu.Size = new System.Drawing.Size(180, 22);
 			this.HideLagFramesSubMenu.Text = "Hide Lag Frames";
 			this.HideLagFramesSubMenu.DropDownOpened += new System.EventHandler(this.HideLagFramesSubMenu_DropDownOpened);
 			// 
@@ -967,8 +821,6 @@ namespace BizHawk.Client.EmuHawk
 			this.HideLagFrames0.Checked = true;
 			this.HideLagFrames0.CheckOnClick = true;
 			this.HideLagFrames0.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.HideLagFrames0.Name = "HideLagFrames0";
-			this.HideLagFrames0.Size = new System.Drawing.Size(174, 22);
 			this.HideLagFrames0.Tag = 0;
 			this.HideLagFrames0.Text = "Don\'t Hide";
 			this.HideLagFrames0.Click += new System.EventHandler(this.HideLagFramesX_Click);
@@ -976,16 +828,12 @@ namespace BizHawk.Client.EmuHawk
 			// HideLagFrames1
 			// 
 			this.HideLagFrames1.CheckOnClick = true;
-			this.HideLagFrames1.Name = "HideLagFrames1";
-			this.HideLagFrames1.Size = new System.Drawing.Size(174, 22);
 			this.HideLagFrames1.Tag = 1;
 			this.HideLagFrames1.Text = "1 (30 fps)";
 			this.HideLagFrames1.Click += new System.EventHandler(this.HideLagFramesX_Click);
 			// 
 			// HideLagFrames2
 			// 
-			this.HideLagFrames2.Name = "HideLagFrames2";
-			this.HideLagFrames2.Size = new System.Drawing.Size(174, 22);
 			this.HideLagFrames2.Tag = 2;
 			this.HideLagFrames2.Text = "2 (20 fps)";
 			this.HideLagFrames2.Click += new System.EventHandler(this.HideLagFramesX_Click);
@@ -993,8 +841,6 @@ namespace BizHawk.Client.EmuHawk
 			// HideLagFrames3
 			// 
 			this.HideLagFrames3.CheckOnClick = true;
-			this.HideLagFrames3.Name = "HideLagFrames3";
-			this.HideLagFrames3.Size = new System.Drawing.Size(174, 22);
 			this.HideLagFrames3.Tag = 3;
 			this.HideLagFrames3.Text = "3 (15fps)";
 			this.HideLagFrames3.Click += new System.EventHandler(this.HideLagFramesX_Click);
@@ -1007,8 +853,6 @@ namespace BizHawk.Client.EmuHawk
 			// hideWasLagFramesToolStripMenuItem
 			// 
 			this.hideWasLagFramesToolStripMenuItem.CheckOnClick = true;
-			this.hideWasLagFramesToolStripMenuItem.Name = "hideWasLagFramesToolStripMenuItem";
-			this.hideWasLagFramesToolStripMenuItem.Size = new System.Drawing.Size(174, 22);
 			this.hideWasLagFramesToolStripMenuItem.Text = "Hide WasLag Frames";
 			this.hideWasLagFramesToolStripMenuItem.Click += new System.EventHandler(this.HideWasLagFramesMenuItem_Click);
 			// 
@@ -1019,40 +863,30 @@ namespace BizHawk.Client.EmuHawk
             this.DenoteStatesWithBGColorToolStripMenuItem,
             this.DenoteMarkersWithIconsToolStripMenuItem,
             this.DenoteMarkersWithBGColorToolStripMenuItem});
-			this.iconsToolStripMenuItem.Name = "iconsToolStripMenuItem";
-			this.iconsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.iconsToolStripMenuItem.Text = "Icons";
 			this.iconsToolStripMenuItem.DropDownOpened += new System.EventHandler(this.IconsMenuItem_DropDownOpened);
 			// 
 			// DenoteStatesWithIconsToolStripMenuItem
 			// 
 			this.DenoteStatesWithIconsToolStripMenuItem.CheckOnClick = true;
-			this.DenoteStatesWithIconsToolStripMenuItem.Name = "DenoteStatesWithIconsToolStripMenuItem";
-			this.DenoteStatesWithIconsToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
 			this.DenoteStatesWithIconsToolStripMenuItem.Text = "Denote States With Icons";
 			this.DenoteStatesWithIconsToolStripMenuItem.Click += new System.EventHandler(this.DenoteStatesWithIconsToolStripMenuItem_Click);
 			// 
 			// DenoteStatesWithBGColorToolStripMenuItem
 			// 
 			this.DenoteStatesWithBGColorToolStripMenuItem.CheckOnClick = true;
-			this.DenoteStatesWithBGColorToolStripMenuItem.Name = "DenoteStatesWithBGColorToolStripMenuItem";
-			this.DenoteStatesWithBGColorToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
 			this.DenoteStatesWithBGColorToolStripMenuItem.Text = "Denote States With BG Color";
 			this.DenoteStatesWithBGColorToolStripMenuItem.Click += new System.EventHandler(this.DenoteStatesWithBGColorToolStripMenuItem_Click);
 			// 
 			// DenoteMarkersWithIconsToolStripMenuItem
 			// 
 			this.DenoteMarkersWithIconsToolStripMenuItem.CheckOnClick = true;
-			this.DenoteMarkersWithIconsToolStripMenuItem.Name = "DenoteMarkersWithIconsToolStripMenuItem";
-			this.DenoteMarkersWithIconsToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
 			this.DenoteMarkersWithIconsToolStripMenuItem.Text = "Denote Markers With Icons";
 			this.DenoteMarkersWithIconsToolStripMenuItem.Click += new System.EventHandler(this.DenoteMarkersWithIconsToolStripMenuItem_Click);
 			// 
 			// DenoteMarkersWithBGColorToolStripMenuItem
 			// 
 			this.DenoteMarkersWithBGColorToolStripMenuItem.CheckOnClick = true;
-			this.DenoteMarkersWithBGColorToolStripMenuItem.Name = "DenoteMarkersWithBGColorToolStripMenuItem";
-			this.DenoteMarkersWithBGColorToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
 			this.DenoteMarkersWithBGColorToolStripMenuItem.Text = "Denote Markers With BG Color";
 			this.DenoteMarkersWithBGColorToolStripMenuItem.Click += new System.EventHandler(this.DenoteMarkersWithBGColorToolStripMenuItem_Click);
 			// 
@@ -1070,16 +904,12 @@ namespace BizHawk.Client.EmuHawk
             this.scrollToTopToolStripMenuItem,
             this.scrollToBottomToolStripMenuItem,
             this.scrollToCenterToolStripMenuItem});
-			this.followCursorToolStripMenuItem.Name = "followCursorToolStripMenuItem";
-			this.followCursorToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.followCursorToolStripMenuItem.Text = "Follow Cursor";
 			this.followCursorToolStripMenuItem.DropDownOpened += new System.EventHandler(this.FollowCursorMenuItem_DropDownOpened);
 			// 
 			// alwaysScrollToolStripMenuItem
 			// 
 			this.alwaysScrollToolStripMenuItem.CheckOnClick = true;
-			this.alwaysScrollToolStripMenuItem.Name = "alwaysScrollToolStripMenuItem";
-			this.alwaysScrollToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
 			this.alwaysScrollToolStripMenuItem.Text = "Always Scroll";
 			this.alwaysScrollToolStripMenuItem.Click += new System.EventHandler(this.AlwaysScrollMenuItem_Click);
 			// 
@@ -1093,32 +923,24 @@ namespace BizHawk.Client.EmuHawk
 			this.scrollToViewToolStripMenuItem.Checked = true;
 			this.scrollToViewToolStripMenuItem.CheckOnClick = true;
 			this.scrollToViewToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.scrollToViewToolStripMenuItem.Name = "scrollToViewToolStripMenuItem";
-			this.scrollToViewToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
 			this.scrollToViewToolStripMenuItem.Text = "Scroll to View";
 			this.scrollToViewToolStripMenuItem.Click += new System.EventHandler(this.ScrollToViewMenuItem_Click);
 			// 
 			// scrollToTopToolStripMenuItem
 			// 
 			this.scrollToTopToolStripMenuItem.CheckOnClick = true;
-			this.scrollToTopToolStripMenuItem.Name = "scrollToTopToolStripMenuItem";
-			this.scrollToTopToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
 			this.scrollToTopToolStripMenuItem.Text = "Scroll to Top";
 			this.scrollToTopToolStripMenuItem.Click += new System.EventHandler(this.ScrollToTopMenuItem_Click);
 			// 
 			// scrollToBottomToolStripMenuItem
 			// 
 			this.scrollToBottomToolStripMenuItem.CheckOnClick = true;
-			this.scrollToBottomToolStripMenuItem.Name = "scrollToBottomToolStripMenuItem";
-			this.scrollToBottomToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
 			this.scrollToBottomToolStripMenuItem.Text = "Scroll to Bottom";
 			this.scrollToBottomToolStripMenuItem.Click += new System.EventHandler(this.ScrollToBottomMenuItem_Click);
 			// 
 			// scrollToCenterToolStripMenuItem
 			// 
 			this.scrollToCenterToolStripMenuItem.CheckOnClick = true;
-			this.scrollToCenterToolStripMenuItem.Name = "scrollToCenterToolStripMenuItem";
-			this.scrollToCenterToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
 			this.scrollToCenterToolStripMenuItem.Text = "Scroll to Center";
 			this.scrollToCenterToolStripMenuItem.Click += new System.EventHandler(this.ScrollToCenterMenuItem_Click);
 			// 
@@ -1129,8 +951,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// wheelScrollSpeedToolStripMenuItem
 			// 
-			this.wheelScrollSpeedToolStripMenuItem.Name = "wheelScrollSpeedToolStripMenuItem";
-			this.wheelScrollSpeedToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.wheelScrollSpeedToolStripMenuItem.Text = "Wheel Scroll Speed...";
 			this.wheelScrollSpeedToolStripMenuItem.Click += new System.EventHandler(this.WheelScrollSpeedMenuItem_Click);
 			// 
@@ -1138,8 +958,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ColumnsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator19});
-			this.ColumnsSubMenu.Name = "ColumnsSubMenu";
-			this.ColumnsSubMenu.Size = new System.Drawing.Size(59, 20);
 			this.ColumnsSubMenu.Text = "&Columns";
 			// 
 			// toolStripSeparator19
@@ -1155,29 +973,21 @@ namespace BizHawk.Client.EmuHawk
             this.aboutToolStripMenuItem,
             this.toolStripSeparator10,
             this.EnableTooltipsMenuItem});
-			this.HelpSubMenu.Name = "HelpSubMenu";
-			this.HelpSubMenu.Size = new System.Drawing.Size(40, 20);
 			this.HelpSubMenu.Text = "&Help";
 			// 
 			// TASEditorManualOnlineMenuItem
 			// 
-			this.TASEditorManualOnlineMenuItem.Name = "TASEditorManualOnlineMenuItem";
-			this.TASEditorManualOnlineMenuItem.Size = new System.Drawing.Size(206, 22);
 			this.TASEditorManualOnlineMenuItem.Text = "TAS Editor Manual Online...";
 			this.TASEditorManualOnlineMenuItem.Click += new System.EventHandler(this.TASEditorManualOnlineMenuItem_Click);
 			// 
 			// ForumThreadMenuItem
 			// 
-			this.ForumThreadMenuItem.Name = "ForumThreadMenuItem";
-			this.ForumThreadMenuItem.Size = new System.Drawing.Size(206, 22);
 			this.ForumThreadMenuItem.Text = "Forum Thread...";
 			this.ForumThreadMenuItem.Click += new System.EventHandler(this.ForumThreadMenuItem_Click);
 			// 
 			// aboutToolStripMenuItem
 			// 
 			this.aboutToolStripMenuItem.Enabled = false;
-			this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-			this.aboutToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
 			this.aboutToolStripMenuItem.Text = "&About";
 			// 
 			// toolStripSeparator10
@@ -1188,8 +998,6 @@ namespace BizHawk.Client.EmuHawk
 			// EnableTooltipsMenuItem
 			// 
 			this.EnableTooltipsMenuItem.Enabled = false;
-			this.EnableTooltipsMenuItem.Name = "EnableTooltipsMenuItem";
-			this.EnableTooltipsMenuItem.Size = new System.Drawing.Size(206, 22);
 			this.EnableTooltipsMenuItem.Text = "&Enable Tooltips";
 			// 
 			// TasView
@@ -1322,22 +1130,16 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// SetMarkersContextMenuItem
 			// 
-			this.SetMarkersContextMenuItem.Name = "SetMarkersContextMenuItem";
-			this.SetMarkersContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.SetMarkersContextMenuItem.Text = "Set Markers";
 			this.SetMarkersContextMenuItem.Click += new System.EventHandler(this.SetMarkersMenuItem_Click);
 			// 
 			// SetMarkerWithTextContextMenuItem
 			// 
-			this.SetMarkerWithTextContextMenuItem.Name = "SetMarkerWithTextContextMenuItem";
-			this.SetMarkerWithTextContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.SetMarkerWithTextContextMenuItem.Text = "Set Marker with Text";
 			this.SetMarkerWithTextContextMenuItem.Click += new System.EventHandler(this.SetMarkerWithTextMenuItem_Click);
 			// 
 			// RemoveMarkersContextMenuItem
 			// 
-			this.RemoveMarkersContextMenuItem.Name = "RemoveMarkersContextMenuItem";
-			this.RemoveMarkersContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.RemoveMarkersContextMenuItem.Text = "Remove Markers";
 			this.RemoveMarkersContextMenuItem.Click += new System.EventHandler(this.RemoveMarkersMenuItem_Click);
 			// 
@@ -1348,15 +1150,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// DeselectContextMenuItem
 			// 
-			this.DeselectContextMenuItem.Name = "DeselectContextMenuItem";
-			this.DeselectContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.DeselectContextMenuItem.Text = "Deselect";
 			this.DeselectContextMenuItem.Click += new System.EventHandler(this.DeselectMenuItem_Click);
 			// 
 			// SelectBetweenMarkersContextMenuItem
 			// 
-			this.SelectBetweenMarkersContextMenuItem.Name = "SelectBetweenMarkersContextMenuItem";
-			this.SelectBetweenMarkersContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.SelectBetweenMarkersContextMenuItem.Text = "Select between Markers";
 			this.SelectBetweenMarkersContextMenuItem.Click += new System.EventHandler(this.SelectBetweenMarkersMenuItem_Click);
 			// 
@@ -1367,15 +1165,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// UngreenzoneContextMenuItem
 			// 
-			this.UngreenzoneContextMenuItem.Name = "UngreenzoneContextMenuItem";
-			this.UngreenzoneContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.UngreenzoneContextMenuItem.Text = "Clear Greenzone";
 			this.UngreenzoneContextMenuItem.Click += new System.EventHandler(this.ClearGreenzoneMenuItem_Click);
 			// 
 			// CancelSeekContextMenuItem
 			// 
-			this.CancelSeekContextMenuItem.Name = "CancelSeekContextMenuItem";
-			this.CancelSeekContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.CancelSeekContextMenuItem.Text = "Cancel Seek";
 			this.CancelSeekContextMenuItem.Click += new System.EventHandler(this.CancelSeekContextMenuItem_Click);
 			// 
@@ -1386,33 +1180,25 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// copyToolStripMenuItem
 			// 
-			this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
 			this.copyToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
-			this.copyToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.copyToolStripMenuItem.Text = "Copy";
 			this.copyToolStripMenuItem.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// pasteToolStripMenuItem
 			// 
-			this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
 			this.pasteToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+V";
-			this.pasteToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.pasteToolStripMenuItem.Text = "Paste";
 			this.pasteToolStripMenuItem.Click += new System.EventHandler(this.PasteMenuItem_Click);
 			// 
 			// pasteInsertToolStripMenuItem
 			// 
-			this.pasteInsertToolStripMenuItem.Name = "pasteInsertToolStripMenuItem";
 			this.pasteInsertToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+Shift+V";
-			this.pasteInsertToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.pasteInsertToolStripMenuItem.Text = "Paste Insert";
 			this.pasteInsertToolStripMenuItem.Click += new System.EventHandler(this.PasteInsertMenuItem_Click);
 			// 
 			// cutToolStripMenuItem
 			// 
-			this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
 			this.cutToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+X";
-			this.cutToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.cutToolStripMenuItem.Text = "Cut";
 			this.cutToolStripMenuItem.Click += new System.EventHandler(this.CutMenuItem_Click);
 			// 
@@ -1423,36 +1209,26 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearContextMenuItem
 			// 
-			this.ClearContextMenuItem.Name = "ClearContextMenuItem";
-			this.ClearContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.ClearContextMenuItem.Text = "Clear";
 			this.ClearContextMenuItem.Click += new System.EventHandler(this.ClearFramesMenuItem_Click);
 			// 
 			// InsertFrameContextMenuItem
 			// 
-			this.InsertFrameContextMenuItem.Name = "InsertFrameContextMenuItem";
-			this.InsertFrameContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.InsertFrameContextMenuItem.Text = "Insert";
 			this.InsertFrameContextMenuItem.Click += new System.EventHandler(this.InsertFrameMenuItem_Click);
 			// 
 			// DeleteFramesContextMenuItem
 			// 
-			this.DeleteFramesContextMenuItem.Name = "DeleteFramesContextMenuItem";
-			this.DeleteFramesContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.DeleteFramesContextMenuItem.Text = "Delete";
 			this.DeleteFramesContextMenuItem.Click += new System.EventHandler(this.DeleteFramesMenuItem_Click);
 			// 
 			// CloneContextMenuItem
 			// 
-			this.CloneContextMenuItem.Name = "CloneContextMenuItem";
-			this.CloneContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.CloneContextMenuItem.Text = "Clone";
 			this.CloneContextMenuItem.Click += new System.EventHandler(this.CloneFramesMenuItem_Click);
 			// 
 			// InsertNumFramesContextMenuItem
 			// 
-			this.InsertNumFramesContextMenuItem.Name = "InsertNumFramesContextMenuItem";
-			this.InsertNumFramesContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.InsertNumFramesContextMenuItem.Text = "Insert # of Frames";
 			this.InsertNumFramesContextMenuItem.Click += new System.EventHandler(this.InsertNumFramesMenuItem_Click);
 			// 
@@ -1463,15 +1239,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// TruncateContextMenuItem
 			// 
-			this.TruncateContextMenuItem.Name = "TruncateContextMenuItem";
-			this.TruncateContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.TruncateContextMenuItem.Text = "Truncate Movie";
 			this.TruncateContextMenuItem.Click += new System.EventHandler(this.TruncateMenuItem_Click);
 			// 
 			// BranchContextMenuItem
 			// 
-			this.BranchContextMenuItem.Name = "BranchContextMenuItem";
-			this.BranchContextMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.BranchContextMenuItem.Text = "&Branch";
 			this.BranchContextMenuItem.Click += new System.EventHandler(this.BranchContextMenuItem_Click);
 			// 
@@ -1482,15 +1254,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// StartNewProjectFromNowMenuItem
 			// 
-			this.StartNewProjectFromNowMenuItem.Name = "StartNewProjectFromNowMenuItem";
-			this.StartNewProjectFromNowMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.StartNewProjectFromNowMenuItem.Text = "Start a new project from Now";
 			this.StartNewProjectFromNowMenuItem.Click += new System.EventHandler(this.StartNewProjectFromNowMenuItem_Click);
 			// 
 			// StartANewProjectFromSaveRamMenuItem
 			// 
-			this.StartANewProjectFromSaveRamMenuItem.Name = "StartANewProjectFromSaveRamMenuItem";
-			this.StartANewProjectFromSaveRamMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.StartANewProjectFromSaveRamMenuItem.Text = "Start a new project from SaveRam";
 			this.StartANewProjectFromSaveRamMenuItem.Click += new System.EventHandler(this.StartANewProjectFromSaveRamMenuItem_Click);
 			// 
@@ -1552,8 +1320,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// SetFontMenuItem
 			// 
-			this.SetFontMenuItem.Name = "SetFontMenuItem";
-			this.SetFontMenuItem.Size = new System.Drawing.Size(264, 22);
 			this.SetFontMenuItem.Text = "Set Font";
 			this.SetFontMenuItem.Click += new System.EventHandler(this.SetFontMenuItem_Click);
 			// 
@@ -1598,164 +1364,164 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx TASMenu;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NewTASMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenTASMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveTASMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsTASMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewTASMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenTASMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveTASMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsTASMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EditSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ConfigSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ConfigSubMenu;
 		private InputRoll TasView;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem InsertFrameMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertFrameMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem CloneFramesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DeleteFramesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearFramesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertNumFramesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloneFramesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeleteFramesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearFramesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertNumFramesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-		private System.Windows.Forms.ToolStripMenuItem TruncateMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PasteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PasteInsertMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CutMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UndoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RedoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectionUndoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectionRedoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PasteInsertMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CutMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UndoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RedoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectionUndoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectionRedoMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-		private System.Windows.Forms.ToolStripMenuItem DeselectMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectBetweenMarkersMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ReselectClipboardMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeselectMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectBetweenMarkersMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReselectClipboardMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
-		private System.Windows.Forms.ToolStripMenuItem HelpSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem EnableTooltipsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HelpSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EnableTooltipsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
-		private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetMaxUndoLevelsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoadjustInputMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UseInputKeysItem;
-		private System.Windows.Forms.ToolStripMenuItem BindMarkersToInputMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EmptyNewMarkerNotesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OldControlSchemeForBranchesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OsdInBranchScreenshotsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx aboutToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMaxUndoLevelsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoadjustInputMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UseInputKeysItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BindMarkersToInputMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EmptyNewMarkerNotesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OldControlSchemeForBranchesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OsdInBranchScreenshotsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
-		private System.Windows.Forms.ToolStripMenuItem AutopauseAtEndOfMovieMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutopauseAtEndOfMovieMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
 		private StatusStripEx TasStatusStrip;
 		private System.Windows.Forms.ToolStripStatusLabel MessageStatusLabel;
 		public PlaybackBox TasPlaybackBox;
 		private System.Windows.Forms.ToolStripStatusLabel SplicerStatusLabel;
-		private System.Windows.Forms.ToolStripMenuItem MetaSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem HeaderMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CommentsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SubtitlesMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StateHistorySettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MetaSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HeaderMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CommentsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SubtitlesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StateHistorySettingsMenuItem;
 		private MarkerControl MarkerControl;
 		private System.Windows.Forms.ContextMenuStrip RightClickMenu;
-		private System.Windows.Forms.ToolStripMenuItem SetMarkersContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveMarkersContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMarkersContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMarkersContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator15;
-		private System.Windows.Forms.ToolStripMenuItem DeselectContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectBetweenMarkersContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeselectContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectBetweenMarkersContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator16;
-		private System.Windows.Forms.ToolStripMenuItem UngreenzoneContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UngreenzoneContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
-		private System.Windows.Forms.ToolStripMenuItem ClearContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DeleteFramesContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertFrameContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertNumFramesContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CloneContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DeleteFramesContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertFrameContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertNumFramesContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CloneContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator18;
-		private System.Windows.Forms.ToolStripMenuItem TruncateContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearGreenzoneMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearGreenzoneMenuItem;
 		private System.Windows.Forms.ToolStripSeparator GreenzoneICheckSeparator;
-		private System.Windows.Forms.ToolStripMenuItem StateHistoryIntegrityCheckMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ColumnsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StateHistoryIntegrityCheckMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ColumnsSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator19;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator21;
-		private System.Windows.Forms.ToolStripMenuItem DefaultStateSettingsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CancelSeekContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DefaultStateSettingsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CancelSeekContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator StartFromNowSeparator;
-		private System.Windows.Forms.ToolStripMenuItem StartNewProjectFromNowMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RotateMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StartNewProjectFromNowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RotateMenuItem;
 		private System.Windows.Forms.ToolStripProgressBar SavingProgressBar;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel2;
-		private System.Windows.Forms.ToolStripMenuItem HideLagFramesSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem HideLagFrames3;
-		private System.Windows.Forms.ToolStripMenuItem HideLagFrames0;
-		private System.Windows.Forms.ToolStripMenuItem HideLagFrames1;
-		private System.Windows.Forms.ToolStripMenuItem HideLagFrames2;
-		private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFramesSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFrames3;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFrames0;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFrames1;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx HideLagFrames2;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx copyToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx pasteToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator separateToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem pasteInsertToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem showUndoHistoryToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx pasteInsertToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx cutToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx showUndoHistoryToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem autoHoldFireToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem keepSetPatternsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoHoldFireToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx keepSetPatternsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem1;
-		private System.Windows.Forms.ToolStripMenuItem autoHoldToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem autoFireToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem customPatternToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoHoldToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autoFireToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx customPatternToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator setpToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem setCustomsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx setCustomsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
-		private System.Windows.Forms.ToolStripMenuItem hideWasLagFramesToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem saveSelectionToMacroToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem placeMacroAtSelectionToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx hideWasLagFramesToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx saveSelectionToMacroToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx placeMacroAtSelectionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator20;
-		private System.Windows.Forms.ToolStripMenuItem ToBk2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem recentMacrosToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ToBk2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx recentMacrosToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator22;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator23;
-		private System.Windows.Forms.ToolStripMenuItem followCursorToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem alwaysScrollToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx followCursorToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx alwaysScrollToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator24;
-		private System.Windows.Forms.ToolStripMenuItem scrollToViewToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem scrollToTopToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem scrollToBottomToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem scrollToCenterToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem applyPatternToPaintedInputToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem onlyOnAutoFireColumnsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToViewToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToTopToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToBottomToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx scrollToCenterToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx applyPatternToPaintedInputToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx onlyOnAutoFireColumnsToolStripMenuItem;
 		private BookmarksBranchesBox BookMarkControl;
-		private System.Windows.Forms.ToolStripMenuItem BranchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BranchContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator25;
-		private System.Windows.Forms.ToolStripMenuItem wheelScrollSpeedToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx wheelScrollSpeedToolStripMenuItem;
 		private System.Windows.Forms.SplitContainer BranchesMarkersSplit;
 		private System.Windows.Forms.SplitContainer MainVertialSplit;
-		private System.Windows.Forms.ToolStripMenuItem StartANewProjectFromSaveRamMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem iconsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DenoteStatesWithIconsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DenoteStatesWithBGColorToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DenoteMarkersWithIconsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DenoteMarkersWithBGColorToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NewFromSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NewFromNowMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem NewFromCurrentSaveRamMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetBranchCellHoverIntervalMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetMarkerWithTextContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetSeekingCutoffIntervalMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StartANewProjectFromSaveRamMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx iconsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DenoteStatesWithIconsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DenoteStatesWithBGColorToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DenoteMarkersWithIconsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DenoteMarkersWithBGColorToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewFromSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewFromNowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewFromCurrentSaveRamMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetBranchCellHoverIntervalMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetMarkerWithTextContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetSeekingCutoffIntervalMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator26;
-		private System.Windows.Forms.ToolStripMenuItem TASEditorManualOnlineMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ForumThreadMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem autosaveToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetAutosaveIntervalMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutosaveAsBk2MenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutosaveAsBackupFileMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem BackupPerFileSaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveBackupMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveBk2BackupMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SingleClickAxisEditMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LoadBranchOnDoubleclickMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SetFontMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TASEditorManualOnlineMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ForumThreadMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx autosaveToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetAutosaveIntervalMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutosaveAsBk2MenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutosaveAsBackupFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BackupPerFileSaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveBackupMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveBk2BackupMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SingleClickAxisEditMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LoadBranchOnDoubleclickMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SetFontMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.Designer.cs
@@ -35,7 +35,7 @@
 			this.RightClickMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.undoHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.redoHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+			this.sepToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.clearHistoryToHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutoScrollCheck = new System.Windows.Forms.CheckBox();
 			this.MaxStepsNum = new System.Windows.Forms.NumericUpDown();
@@ -97,11 +97,6 @@
 			// 
 			this.redoHereToolStripMenuItem.Text = "Redo To Selection";
 			this.redoHereToolStripMenuItem.Click += new System.EventHandler(this.RedoHereMenuItem_Click);
-			// 
-			// sepToolStripMenuItem
-			// 
-			this.sepToolStripMenuItem.Name = "sepToolStripMenuItem";
-			this.sepToolStripMenuItem.Size = new System.Drawing.Size(205, 6);
 			// 
 			// clearHistoryToHereToolStripMenuItem
 			// 
@@ -202,7 +197,7 @@
 		private System.Windows.Forms.ContextMenuStrip RightClickMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx undoHereToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx redoHereToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx sepToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearHistoryToHereToolStripMenuItem;
 		private System.Windows.Forms.CheckBox AutoScrollCheck;
 		private System.Windows.Forms.NumericUpDown MaxStepsNum;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/UndoHistoryForm.Designer.cs
@@ -33,10 +33,10 @@
 			this.UndoButton = new System.Windows.Forms.Button();
 			this.RedoButton = new System.Windows.Forms.Button();
 			this.RightClickMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.undoHereToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.redoHereToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.undoHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.redoHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.sepToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-			this.clearHistoryToHereToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.clearHistoryToHereToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutoScrollCheck = new System.Windows.Forms.CheckBox();
 			this.MaxStepsNum = new System.Windows.Forms.NumericUpDown();
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -90,15 +90,11 @@
 			// 
 			// undoHereToolStripMenuItem
 			// 
-			this.undoHereToolStripMenuItem.Name = "undoHereToolStripMenuItem";
-			this.undoHereToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.undoHereToolStripMenuItem.Text = "Undo To Selection";
 			this.undoHereToolStripMenuItem.Click += new System.EventHandler(this.UndoHereMenuItem_Click);
 			// 
 			// redoHereToolStripMenuItem
 			// 
-			this.redoHereToolStripMenuItem.Name = "redoHereToolStripMenuItem";
-			this.redoHereToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.redoHereToolStripMenuItem.Text = "Redo To Selection";
 			this.redoHereToolStripMenuItem.Click += new System.EventHandler(this.RedoHereMenuItem_Click);
 			// 
@@ -109,8 +105,6 @@
 			// 
 			// clearHistoryToHereToolStripMenuItem
 			// 
-			this.clearHistoryToHereToolStripMenuItem.Name = "clearHistoryToHereToolStripMenuItem";
-			this.clearHistoryToHereToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
 			this.clearHistoryToHereToolStripMenuItem.Text = "Clear History To Selection";
 			this.clearHistoryToHereToolStripMenuItem.Click += new System.EventHandler(this.ClearHistoryToHereMenuItem_Click);
 			// 
@@ -206,10 +200,10 @@
 		private InputRoll HistoryView;
 		private System.Windows.Forms.Button RedoButton;
 		private System.Windows.Forms.ContextMenuStrip RightClickMenu;
-		private System.Windows.Forms.ToolStripMenuItem undoHereToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem redoHereToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx undoHereToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx redoHereToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator sepToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem clearHistoryToHereToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearHistoryToHereToolStripMenuItem;
 		private System.Windows.Forms.CheckBox AutoScrollCheck;
 		private System.Windows.Forms.NumericUpDown MaxStepsNum;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;

--- a/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.Designer.cs
@@ -32,11 +32,11 @@ namespace BizHawk.Client.EmuHawk
         {
 			this.components = new System.ComponentModel.Container();
 			this.menuStrip1 = new MenuStripEx();
-			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this.KeyPadSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ShowHotkeysMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripMenuItem1 = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.KeyPadSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ShowHotkeysMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.YButton = new System.Windows.Forms.Button();
 			this.SecondButton = new System.Windows.Forms.Button();
 			this.WindowButton = new System.Windows.Forms.Button();
@@ -182,24 +182,15 @@ namespace BizHawk.Client.EmuHawk
 			this.menuStrip1.TabIndex = 0;
 			this.menuStrip1.Text = "menuStrip1";
 			// 
-			// toolStripMenuItem1
-			// 
-			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-			this.toolStripMenuItem1.Size = new System.Drawing.Size(12, 20);
-			// 
 			// KeyPadSubMenu
 			// 
 			this.KeyPadSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ExitMenuItem});
-			this.KeyPadSubMenu.Name = "KeyPadSubMenu";
-			this.KeyPadSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.KeyPadSubMenu.Text = "Key Pad";
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.ExitMenuItem.Size = new System.Drawing.Size(134, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -207,8 +198,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SettingsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ShowHotkeysMenuItem});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.SettingsSubMenu.Text = "&Settings";
 			this.SettingsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
@@ -216,8 +205,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.ShowHotkeysMenuItem.Checked = true;
 			this.ShowHotkeysMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.ShowHotkeysMenuItem.Name = "ShowHotkeysMenuItem";
-			this.ShowHotkeysMenuItem.Size = new System.Drawing.Size(191, 22);
 			this.ShowHotkeysMenuItem.Text = "Show Hotkeys";
 			this.ShowHotkeysMenuItem.Click += new System.EventHandler(this.ShowHotkeysMenuItem_Click);
 			// 
@@ -1674,10 +1661,10 @@ namespace BizHawk.Client.EmuHawk
         #endregion
 
         private MenuStripEx menuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
-        private System.Windows.Forms.ToolStripMenuItem KeyPadSubMenu;
-        private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx toolStripMenuItem1;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx KeyPadSubMenu;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
         private System.Windows.Forms.Button YButton;
         private System.Windows.Forms.Button SecondButton;
         private System.Windows.Forms.Button WindowButton;
@@ -1805,7 +1792,7 @@ namespace BizHawk.Client.EmuHawk
         private System.Windows.Forms.Button DownButton;
         private System.Windows.Forms.Button UpButton;
         private System.Windows.Forms.ToolTip KeyPadToolTips;
-        private System.Windows.Forms.ToolStripMenuItem ShowHotkeysMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx ShowHotkeysMenuItem;
         private BizHawk.WinForms.Controls.LocLabelEx label77;
         private BizHawk.WinForms.Controls.LocLabelEx label78;
         private BizHawk.WinForms.Controls.LocLabelEx label79;

--- a/src/BizHawk.Client.EmuHawk/tools/ToolBox.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolBox.Designer.cs
@@ -30,38 +30,35 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.ToolBoxStrip = new ToolStripEx();
-			this.SuspendLayout();
-			// 
-			// ToolBoxStrip
-			// 
-			this.ToolBoxStrip.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.ToolBoxStrip.AutoSize = false;
-			this.ToolBoxStrip.BackColor = System.Drawing.SystemColors.Control;
-			this.ToolBoxStrip.Dock = System.Windows.Forms.DockStyle.None;
-			this.ToolBoxStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-			this.ToolBoxStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
-			this.ToolBoxStrip.Location = new System.Drawing.Point(2, 2);
-			this.ToolBoxStrip.Name = "ToolBoxStrip";
-			this.ToolBoxStrip.Padding = new System.Windows.Forms.Padding(0);
-			this.ToolBoxStrip.Stretch = true;
-			this.ToolBoxStrip.TabIndex = 0;
-			this.ToolBoxStrip.TabStop = true;
-			// 
-			// ToolBox
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(140, 183);
-			this.Controls.Add(this.ToolBoxStrip);
-			this.MaximumSize = new System.Drawing.Size(270, 600);
-			this.MinimumSize = new System.Drawing.Size(135, 38);
-			this.Name = "ToolBox";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Load += new System.EventHandler(this.ToolBox_Load);
-			this.ResumeLayout(false);
+            this.ToolBoxStrip = new BizHawk.WinForms.Controls.ToolStripEx();
+            this.SuspendLayout();
+            // 
+            // ToolBoxStrip
+            // 
+            this.ToolBoxStrip.AutoSize = false;
+            this.ToolBoxStrip.BackColor = System.Drawing.SystemColors.Control;
+            this.ToolBoxStrip.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToolBoxStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.ToolBoxStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+            this.ToolBoxStrip.Location = new System.Drawing.Point(0, 0);
+            this.ToolBoxStrip.Name = "ToolBoxStrip";
+            this.ToolBoxStrip.Padding = new System.Windows.Forms.Padding(0);
+            this.ToolBoxStrip.Stretch = true;
+            this.ToolBoxStrip.TabIndex = 0;
+            this.ToolBoxStrip.TabStop = true;
+            // 
+            // ToolBox
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(140, 183);
+            this.Controls.Add(this.ToolBoxStrip);
+            this.MaximumSize = new System.Drawing.Size(270, 600);
+            this.MinimumSize = new System.Drawing.Size(135, 39);
+            this.Name = "ToolBox";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Load += new System.EventHandler(this.ToolBox_Load);
+            this.ResumeLayout(false);
 
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
@@ -34,20 +34,20 @@ namespace BizHawk.Client.EmuHawk
 			this.TracerBox = new System.Windows.Forms.GroupBox();
 			this.TraceView = new InputRoll();
 			this.TraceContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.CopyContextMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllContextMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearContextMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.CopyContextMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllContextMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearContextMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.menuStrip1 = new MenuStripEx();
-			this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveLogMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveLogMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.EditSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SelectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OptionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.MaxLinesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.EditSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MaxLinesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.groupBox2 = new System.Windows.Forms.GroupBox();
 			this.OpenLogFile = new System.Windows.Forms.Button();
 			this.BrowseBox = new System.Windows.Forms.Button();
@@ -55,7 +55,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ToFileRadio = new System.Windows.Forms.RadioButton();
 			this.ToWindowRadio = new System.Windows.Forms.RadioButton();
 			this.LoggingEnabled = new System.Windows.Forms.CheckBox();
-			this.SegmentSizeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SegmentSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TracerBox.SuspendLayout();
 			this.TraceContextMenu.SuspendLayout();
 			this.menuStrip1.SuspendLayout();
@@ -104,24 +104,18 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CopyContextMenu
 			// 
-			this.CopyContextMenu.Name = "CopyContextMenu";
 			this.CopyContextMenu.ShortcutKeyDisplayString = "Ctrl+C";
-			this.CopyContextMenu.Size = new System.Drawing.Size(164, 22);
 			this.CopyContextMenu.Text = "&Copy";
 			this.CopyContextMenu.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// SelectAllContextMenu
 			// 
-			this.SelectAllContextMenu.Name = "SelectAllContextMenu";
 			this.SelectAllContextMenu.ShortcutKeyDisplayString = "Ctrl+A";
-			this.SelectAllContextMenu.Size = new System.Drawing.Size(164, 22);
 			this.SelectAllContextMenu.Text = "Select &All";
 			this.SelectAllContextMenu.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
 			// ClearContextMenu
 			// 
-			this.ClearContextMenu.Name = "ClearContextMenu";
-			this.ClearContextMenu.Size = new System.Drawing.Size(164, 22);
 			this.ClearContextMenu.Text = "Clear";
 			this.ClearContextMenu.Click += new System.EventHandler(this.ClearMenuItem_Click);
 			// 
@@ -141,14 +135,10 @@ namespace BizHawk.Client.EmuHawk
             this.SaveLogMenuItem,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-			this.FileSubMenu.Name = "FileSubMenu";
-			this.FileSubMenu.Size = new System.Drawing.Size(35, 20);
 			this.FileSubMenu.Text = "&File";
 			// 
 			// SaveLogMenuItem
 			// 
-			this.SaveLogMenuItem.Name = "SaveLogMenuItem";
-			this.SaveLogMenuItem.Size = new System.Drawing.Size(143, 22);
 			this.SaveLogMenuItem.Text = "&Save Log";
 			this.SaveLogMenuItem.Click += new System.EventHandler(this.SaveLogMenuItem_Click);
 			// 
@@ -159,9 +149,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(143, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -171,32 +159,24 @@ namespace BizHawk.Client.EmuHawk
             this.CopyMenuItem,
             this.SelectAllMenuItem,
             this.ClearMenuItem});
-			this.EditSubMenu.Name = "EditSubMenu";
-			this.EditSubMenu.Size = new System.Drawing.Size(37, 20);
 			this.EditSubMenu.Text = "Edit";
 			// 
 			// CopyMenuItem
 			// 
-			this.CopyMenuItem.Name = "CopyMenuItem";
 			this.CopyMenuItem.ShortcutKeyDisplayString = "";
 			this.CopyMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.CopyMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.CopyMenuItem.Text = "&Copy";
 			this.CopyMenuItem.Click += new System.EventHandler(this.CopyMenuItem_Click);
 			// 
 			// SelectAllMenuItem
 			// 
-			this.SelectAllMenuItem.Name = "SelectAllMenuItem";
 			this.SelectAllMenuItem.ShortcutKeyDisplayString = "";
 			this.SelectAllMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-			this.SelectAllMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.SelectAllMenuItem.Text = "Select &All";
 			this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
 			// ClearMenuItem
 			// 
-			this.ClearMenuItem.Name = "ClearMenuItem";
-			this.ClearMenuItem.Size = new System.Drawing.Size(167, 22);
 			this.ClearMenuItem.Text = "Clear";
 			this.ClearMenuItem.Click += new System.EventHandler(this.ClearMenuItem_Click);
 			// 
@@ -205,14 +185,10 @@ namespace BizHawk.Client.EmuHawk
 			this.OptionsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.MaxLinesMenuItem,
             this.SegmentSizeMenuItem});
-			this.OptionsSubMenu.Name = "OptionsSubMenu";
-			this.OptionsSubMenu.Size = new System.Drawing.Size(58, 20);
 			this.OptionsSubMenu.Text = "&Settings";
 			// 
 			// MaxLinesMenuItem
 			// 
-			this.MaxLinesMenuItem.Name = "MaxLinesMenuItem";
-			this.MaxLinesMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.MaxLinesMenuItem.Text = "&Set Max Lines...";
 			this.MaxLinesMenuItem.Click += new System.EventHandler(this.MaxLinesMenuItem_Click);
 			// 
@@ -305,8 +281,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// SegmentSizeMenuItem
 			// 
-			this.SegmentSizeMenuItem.Name = "SegmentSizeMenuItem";
-			this.SegmentSizeMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.SegmentSizeMenuItem.Text = "Set Segment Size...";
 			this.SegmentSizeMenuItem.Click += new System.EventHandler(this.SegmentSizeMenuItem_Click);
 			// 
@@ -340,28 +314,28 @@ namespace BizHawk.Client.EmuHawk
 
 		private System.Windows.Forms.GroupBox TracerBox;
 		private MenuStripEx menuStrip1;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem SaveLogMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveLogMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.GroupBox groupBox2;
 		private System.Windows.Forms.CheckBox LoggingEnabled;
-		private System.Windows.Forms.ToolStripMenuItem OptionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
 		private InputRoll TraceView;
-		private System.Windows.Forms.ToolStripMenuItem MaxLinesMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MaxLinesMenuItem;
 		private System.Windows.Forms.RadioButton ToFileRadio;
 		private System.Windows.Forms.RadioButton ToWindowRadio;
 		private System.Windows.Forms.TextBox FileBox;
 		private System.Windows.Forms.Button BrowseBox;
-		private System.Windows.Forms.ToolStripMenuItem EditSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem CopyMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearMenuItem;
 		private System.Windows.Forms.ContextMenuStrip TraceContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem CopyContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem ClearContextMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyContextMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllContextMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearContextMenu;
 		private System.Windows.Forms.Button OpenLogFile;
-		private System.Windows.Forms.ToolStripMenuItem SegmentSizeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SegmentSizeMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Client.EmuHawk
 			this.menuStrip1 = new MenuStripEx();
 			this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveLogMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.EditSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -141,11 +141,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SaveLogMenuItem.Text = "&Save Log";
 			this.SaveLogMenuItem.Click += new System.EventHandler(this.SaveLogMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(140, 6);
 			// 
 			// ExitMenuItem
 			// 
@@ -316,7 +311,7 @@ namespace BizHawk.Client.EmuHawk
 		private MenuStripEx menuStrip1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveLogMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private System.Windows.Forms.GroupBox groupBox2;
 		private System.Windows.Forms.CheckBox LoggingEnabled;

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
@@ -40,7 +40,7 @@ namespace BizHawk.Client.EmuHawk
 			this.PadsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.StickyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearClearsAnalogInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -122,11 +122,6 @@ namespace BizHawk.Client.EmuHawk
 			this.StickyMenuItem.Text = "Sticky";
 			this.StickyMenuItem.Click += new System.EventHandler(this.StickyMenuItem_Click);
 			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(139, 6);
-			// 
 			// ExitMenuItem
 			// 
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
@@ -177,7 +172,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StickyContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearClearsAnalogInputMenuItem;
 		private System.Windows.Forms.Panel ControllerPanel;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
@@ -33,17 +33,17 @@ namespace BizHawk.Client.EmuHawk
 			this.components = new System.ComponentModel.Container();
 			this.ControllerBox = new System.Windows.Forms.GroupBox();
 			this.PadBoxContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.clearAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StickyContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.clearAllToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StickyContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ControllerPanel = new System.Windows.Forms.Panel();
 			this.PadMenu = new MenuStripEx();
-			this.PadsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.StickyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.PadsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.StickyMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SettingsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearClearsAnalogInputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SettingsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearClearsAnalogInputMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ControllerBox.SuspendLayout();
 			this.PadBoxContextMenu.SuspendLayout();
 			this.PadMenu.SuspendLayout();
@@ -74,16 +74,12 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// clearAllToolStripMenuItem
 			// 
-			this.clearAllToolStripMenuItem.Name = "clearAllToolStripMenuItem";
 			this.clearAllToolStripMenuItem.ShortcutKeyDisplayString = "Del";
-			this.clearAllToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
 			this.clearAllToolStripMenuItem.Text = "Clear All";
 			this.clearAllToolStripMenuItem.Click += new System.EventHandler(this.ClearAllMenuItem_Click);
 			// 
 			// StickyContextMenuItem
 			// 
-			this.StickyContextMenuItem.Name = "StickyContextMenuItem";
-			this.StickyContextMenuItem.Size = new System.Drawing.Size(142, 22);
 			this.StickyContextMenuItem.Text = "Sticky";
 			this.StickyContextMenuItem.Click += new System.EventHandler(this.StickyMenuItem_Click);
 			// 
@@ -112,23 +108,17 @@ namespace BizHawk.Client.EmuHawk
             this.StickyMenuItem,
             this.toolStripSeparator4,
             this.ExitMenuItem});
-			this.PadsSubMenu.Name = "PadsSubMenu";
-			this.PadsSubMenu.Size = new System.Drawing.Size(44, 20);
 			this.PadsSubMenu.Text = "&Pads";
 			this.PadsSubMenu.DropDownOpened += new System.EventHandler(this.PadsSubMenu_DropDownOpened);
 			// 
 			// ClearAllMenuItem
 			// 
-			this.ClearAllMenuItem.Name = "ClearAllMenuItem";
 			this.ClearAllMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.ClearAllMenuItem.Size = new System.Drawing.Size(142, 22);
 			this.ClearAllMenuItem.Text = "&Clear All";
 			this.ClearAllMenuItem.Click += new System.EventHandler(this.ClearAllMenuItem_Click);
 			// 
 			// StickyMenuItem
 			// 
-			this.StickyMenuItem.Name = "StickyMenuItem";
-			this.StickyMenuItem.Size = new System.Drawing.Size(142, 22);
 			this.StickyMenuItem.Text = "Sticky";
 			this.StickyMenuItem.Click += new System.EventHandler(this.StickyMenuItem_Click);
 			// 
@@ -139,9 +129,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExitMenuItem
 			// 
-			this.ExitMenuItem.Name = "ExitMenuItem";
 			this.ExitMenuItem.ShortcutKeyDisplayString = "Alt+F4";
-			this.ExitMenuItem.Size = new System.Drawing.Size(142, 22);
 			this.ExitMenuItem.Text = "E&xit";
 			this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
 			// 
@@ -149,15 +137,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.SettingsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ClearClearsAnalogInputMenuItem});
-			this.SettingsSubMenu.Name = "SettingsSubMenu";
-			this.SettingsSubMenu.Size = new System.Drawing.Size(61, 20);
 			this.SettingsSubMenu.Text = "&Settings";
 			this.SettingsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
 			// ClearClearsAnalogInputMenuItem
 			// 
-			this.ClearClearsAnalogInputMenuItem.Name = "ClearClearsAnalogInputMenuItem";
-			this.ClearClearsAnalogInputMenuItem.Size = new System.Drawing.Size(230, 22);
 			this.ClearClearsAnalogInputMenuItem.Text = "&Clear also clears Analog Input";
 			this.ClearClearsAnalogInputMenuItem.Click += new System.EventHandler(this.ClearClearsAnalogInputMenuItem_Click);
 			// 
@@ -183,17 +167,17 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private MenuStripEx PadMenu;
-		private System.Windows.Forms.ToolStripMenuItem SettingsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PadsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem ClearAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SettingsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PadsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearAllMenuItem;
 		private System.Windows.Forms.GroupBox ControllerBox;
-		private System.Windows.Forms.ToolStripMenuItem StickyMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StickyMenuItem;
 		private System.Windows.Forms.ContextMenuStrip PadBoxContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem clearAllToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem StickyContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearClearsAnalogInputMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx clearAllToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx StickyContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearClearsAnalogInputMenuItem;
 		private System.Windows.Forms.Panel ControllerPanel;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
@@ -36,15 +36,15 @@ namespace BizHawk.Client.EmuHawk
 			this.ListViewContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.DoSearchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.NewSearchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextMenuSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.ContextMenuSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RemoveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AddToRamWatchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PokeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FreezeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UnfreezeAllContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextMenuSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.ContextMenuSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ViewInHexEditorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.ContextMenuSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.ContextMenuSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ClearPreviewContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RamSearchMenu = new MenuStripEx();
 			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -54,24 +54,24 @@ namespace BizHawk.Client.EmuHawk
 			this.AppendFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.TruncateFromFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+			this.toolStripSeparator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.exitToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.settingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.modeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DetailedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FastMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemoryDomainsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.sizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.WordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CheckMisalignedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisplayTypeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DefinePreviousValueSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.Previous_LastSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PreviousFrameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -79,32 +79,32 @@ namespace BizHawk.Client.EmuHawk
 			this.Previous_LastChangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.searchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.newSearchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.UndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RedoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.CopyValueToPrevMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ClearChangeCountsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RemoveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.GoToAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AddToRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PokeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator13 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ClearUndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.optionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.PreviewModeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutoSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AutoSearchAccountForLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator9 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ExcludeRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.UseUndoHistoryMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator11 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.AutoloadDialogMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.SaveWinPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RestoreDefaultsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemDomainLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.MessageLabel = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -122,20 +122,20 @@ namespace BizHawk.Client.EmuHawk
 			this.PreviousValueRadio = new System.Windows.Forms.RadioButton();
 			this.toolStrip1 = new ToolStripEx();
 			this.DoSearchToolButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator10 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.NewSearchToolButton = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator15 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.CopyValueToPrevToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.ClearChangeCountsToolBarItem = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator16 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RemoveToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.AddToRamWatchToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.PokeAddressToolBarItem = new System.Windows.Forms.ToolStripButton();
 			this.FreezeAddressToolBarItem = new System.Windows.Forms.ToolStripButton();
-			this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+			this.toolStripSeparator12 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.UndoToolBarButton = new System.Windows.Forms.ToolStripButton();
 			this.RedoToolBarItem = new System.Windows.Forms.ToolStripButton();
-			this.RebootToolBarSeparator = new System.Windows.Forms.ToolStripSeparator();
+			this.RebootToolBarSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.RebootToolbarButton = new System.Windows.Forms.ToolStripButton();
 			this.ErrorIconButton = new System.Windows.Forms.ToolStripButton();
 			this.ComparisonBox = new System.Windows.Forms.GroupBox();
@@ -225,11 +225,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.NewSearchContextMenuItem.Text = "&Start New Search";
 			this.NewSearchContextMenuItem.Click += new System.EventHandler(this.NewSearchMenuMenuItem_Click);
-			//
-			// ContextMenuSeparator1
-			// 
-			this.ContextMenuSeparator1.Name = "ContextMenuSeparator1";
-			this.ContextMenuSeparator1.Size = new System.Drawing.Size(214, 6);
 			// 
 			// RemoveContextMenuItem
 			// 
@@ -260,20 +255,10 @@ namespace BizHawk.Client.EmuHawk
 			this.UnfreezeAllContextMenuItem.Text = "Unfreeze &All";
 			this.UnfreezeAllContextMenuItem.Click += new System.EventHandler(this.UnfreezeAllContextMenuItem_Click);
 			// 
-			// ContextMenuSeparator2
-			// 
-			this.ContextMenuSeparator2.Name = "ContextMenuSeparator2";
-			this.ContextMenuSeparator2.Size = new System.Drawing.Size(214, 6);
-			// 
 			// ViewInHexEditorContextMenuItem
 			// 
 			this.ViewInHexEditorContextMenuItem.Text = "View in Hex Editor";
 			this.ViewInHexEditorContextMenuItem.Click += new System.EventHandler(this.ViewInHexEditorContextMenuItem_Click);
-			// 
-			// ContextMenuSeparator3
-			// 
-			this.ContextMenuSeparator3.Name = "ContextMenuSeparator3";
-			this.ContextMenuSeparator3.Size = new System.Drawing.Size(214, 6);
 			// 
 			// ClearPreviewContextMenuItem
 			// 
@@ -341,16 +326,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator2
-			// 
-			this.toolStripSeparator2.Name = "toolStripSeparator2";
-			this.toolStripSeparator2.Size = new System.Drawing.Size(57, 6);
-			// 
-			// toolStripSeparator4
-			// 
-			this.toolStripSeparator4.Name = "toolStripSeparator4";
-			this.toolStripSeparator4.Size = new System.Drawing.Size(192, 6);
-			// 
 			// exitToolStripMenuItem
 			// 
 			this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
@@ -396,11 +371,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MemoryDomainsSubMenu.Text = "&Memory Domains";
 			this.MemoryDomainsSubMenu.DropDownOpened += new System.EventHandler(this.MemoryDomainsSubMenu_DropDownOpened);
 			// 
-			// toolStripSeparator6
-			// 
-			this.toolStripSeparator6.Name = "toolStripSeparator6";
-			this.toolStripSeparator6.Size = new System.Drawing.Size(57, 6);
-			// 
 			// sizeToolStripMenuItem
 			// 
 			this.sizeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -430,11 +400,6 @@ namespace BizHawk.Client.EmuHawk
 			this.CheckMisalignedMenuItem.Text = "Check Mis-aligned";
 			this.CheckMisalignedMenuItem.Click += new System.EventHandler(this.CheckMisalignedMenuItem_Click);
 			// 
-			// toolStripSeparator8
-			// 
-			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(184, 6);
-			// 
 			// BigEndianMenuItem
 			// 
 			this.BigEndianMenuItem.Text = "&Big Endian";
@@ -446,11 +411,6 @@ namespace BizHawk.Client.EmuHawk
             this.toolStripSeparator1});
 			this.DisplayTypeSubMenu.Text = "&Display Type";
 			this.DisplayTypeSubMenu.DropDownOpened += new System.EventHandler(this.DisplayTypeSubMenu_DropDownOpened);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(57, 6);
 			// 
 			// DefinePreviousValueSubMenu
 			// 
@@ -508,11 +468,6 @@ namespace BizHawk.Client.EmuHawk
 			this.newSearchToolStripMenuItem.Text = "&New Search";
 			this.newSearchToolStripMenuItem.Click += new System.EventHandler(this.NewSearchMenuMenuItem_Click);
 			// 
-			// toolStripSeparator7
-			// 
-			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(218, 6);
-			// 
 			// UndoMenuItem
 			// 
 			this.UndoMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
@@ -542,11 +497,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RemoveMenuItem.Text = "&Remove selected";
 			this.RemoveMenuItem.Click += new System.EventHandler(this.RemoveMenuItem_Click);
 			// 
-			// toolStripSeparator5
-			// 
-			this.toolStripSeparator5.Name = "toolStripSeparator5";
-			this.toolStripSeparator5.Size = new System.Drawing.Size(218, 6);
-			// 
 			// GoToAddressMenuItem
 			// 
 			this.GoToAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
@@ -570,11 +520,6 @@ namespace BizHawk.Client.EmuHawk
 			this.FreezeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
 			this.FreezeAddressMenuItem.Text = "Freeze Address";
 			this.FreezeAddressMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
-			// 
-			// toolStripSeparator13
-			// 
-			this.toolStripSeparator13.Name = "toolStripSeparator13";
-			this.toolStripSeparator13.Size = new System.Drawing.Size(218, 6);
 			// 
 			// ClearUndoMenuItem
 			// 
@@ -615,11 +560,6 @@ namespace BizHawk.Client.EmuHawk
 			this.AutoSearchAccountForLagMenuItem.Text = "&Auto-Search Account for Lag";
 			this.AutoSearchAccountForLagMenuItem.Click += new System.EventHandler(this.AutoSearchAccountForLagMenuItem_Click);
 			// 
-			// toolStripSeparator9
-			// 
-			this.toolStripSeparator9.Name = "toolStripSeparator9";
-			this.toolStripSeparator9.Size = new System.Drawing.Size(239, 6);
-			// 
 			// ExcludeRamWatchMenuItem
 			// 
 			this.ExcludeRamWatchMenuItem.Text = "Always E&xclude RAM Search List";
@@ -629,11 +569,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.UseUndoHistoryMenuItem.Text = "&Use Undo History";
 			this.UseUndoHistoryMenuItem.Click += new System.EventHandler(this.UseUndoHistoryMenuItem_Click);
-			// 
-			// toolStripSeparator11
-			// 
-			this.toolStripSeparator11.Name = "toolStripSeparator11";
-			this.toolStripSeparator11.Size = new System.Drawing.Size(239, 6);
 			// 
 			// AutoloadDialogMenuItem
 			// 
@@ -654,11 +589,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.FloatingWindowMenuItem.Text = "&Floating Window";
 			this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
-			// 
-			// toolStripSeparator3
-			// 
-			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(239, 6);
 			// 
 			// RestoreDefaultsMenuItem
 			// 
@@ -862,11 +792,6 @@ namespace BizHawk.Client.EmuHawk
 			this.DoSearchToolButton.Text = "Search ";
 			this.DoSearchToolButton.Click += new System.EventHandler(this.SearchMenuItem_Click);
 			// 
-			// toolStripSeparator10
-			// 
-			this.toolStripSeparator10.Name = "toolStripSeparator10";
-			this.toolStripSeparator10.Size = new System.Drawing.Size(6, 25);
-			// 
 			// NewSearchToolButton
 			// 
 			this.NewSearchToolButton.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -874,11 +799,6 @@ namespace BizHawk.Client.EmuHawk
 			this.NewSearchToolButton.Size = new System.Drawing.Size(51, 22);
 			this.NewSearchToolButton.Text = "New";
 			this.NewSearchToolButton.Click += new System.EventHandler(this.NewSearchMenuMenuItem_Click);
-			// 
-			// toolStripSeparator15
-			// 
-			this.toolStripSeparator15.Name = "toolStripSeparator15";
-			this.toolStripSeparator15.Size = new System.Drawing.Size(6, 25);
 			// 
 			// CopyValueToPrevToolBarItem
 			// 
@@ -899,11 +819,6 @@ namespace BizHawk.Client.EmuHawk
 			this.ClearChangeCountsToolBarItem.Text = "C";
 			this.ClearChangeCountsToolBarItem.ToolTipText = "Clear Change Counts";
 			this.ClearChangeCountsToolBarItem.Click += new System.EventHandler(this.ClearChangeCountsMenuItem_Click);
-			// 
-			// toolStripSeparator16
-			// 
-			this.toolStripSeparator16.Name = "toolStripSeparator16";
-			this.toolStripSeparator16.Size = new System.Drawing.Size(6, 25);
 			// 
 			// RemoveToolBarItem
 			// 
@@ -946,11 +861,6 @@ namespace BizHawk.Client.EmuHawk
 			this.FreezeAddressToolBarItem.Text = "Freeze";
 			this.FreezeAddressToolBarItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
 			// 
-			// toolStripSeparator12
-			// 
-			this.toolStripSeparator12.Name = "toolStripSeparator12";
-			this.toolStripSeparator12.Size = new System.Drawing.Size(6, 25);
-			// 
 			// UndoToolBarButton
 			// 
 			this.UndoToolBarButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -970,11 +880,6 @@ namespace BizHawk.Client.EmuHawk
 			this.RedoToolBarItem.Size = new System.Drawing.Size(23, 22);
 			this.RedoToolBarItem.Text = "Redo";
 			this.RedoToolBarItem.Click += new System.EventHandler(this.RedoMenuItem_Click);
-			// 
-			// RebootToolBarSeparator
-			// 
-			this.RebootToolBarSeparator.Name = "RebootToolBarSeparator";
-			this.RebootToolBarSeparator.Size = new System.Drawing.Size(6, 25);
 			// 
 			// RebootToolbarButton
 			// 
@@ -1222,14 +1127,14 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx MemDomainLabel;
 		private BizHawk.WinForms.Controls.LocLabelEx MessageLabel;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendFileMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx searchToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearChangeCountsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UndoMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeAddressMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateFromFileMenuItem;
@@ -1237,7 +1142,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyValueToPrevMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ListViewContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewSearchContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextMenuSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DoSearchContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveContextMenuItem;
@@ -1249,33 +1154,33 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RedoMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadDialogMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator11;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextMenuSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysOnTopMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator13;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearUndoMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UseUndoHistoryMenuItem;
-		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx ContextMenuSeparator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearPreviewContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx newSearchToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx settingsToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx modeToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DetailedMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FastMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx sizeToolStripMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ByteMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WordMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DWordMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayTypeSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BigEndianMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CheckMisalignedMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DefinePreviousValueSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviousFrameMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Previous_LastSearchMenuItem;
@@ -1291,9 +1196,9 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.RadioButton PreviousValueRadio;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton DoSearchToolButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator10;
 		private System.Windows.Forms.ToolStripButton NewSearchToolButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator15;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator15;
 		private System.Windows.Forms.GroupBox ComparisonBox;
 		private WatchValueBox DifferentByBox;
 		private System.Windows.Forms.RadioButton DifferentByRadio;
@@ -1307,19 +1212,19 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton ClearChangeCountsToolBarItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviewModeMenuItem;
 		private System.Windows.Forms.ToolStripButton RemoveToolBarItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator16;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator16;
 		private System.Windows.Forms.ToolStripButton AddToRamWatchToolBarItem;
 		private System.Windows.Forms.ToolStripButton PokeAddressToolBarItem;
 		private System.Windows.Forms.ToolStripButton FreezeAddressToolBarItem;
 		private WatchValueBox DifferenceBox;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoSearchMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator9;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator12;
 		private System.Windows.Forms.ToolStripButton UndoToolBarButton;
 		private System.Windows.Forms.ToolStripButton RedoToolBarItem;
 		private System.Windows.Forms.CheckBox AutoSearchCheckBox;
 		private System.Windows.Forms.Button SearchButton;
-		private System.Windows.Forms.ToolStripSeparator RebootToolBarSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx RebootToolBarSeparator;
 		private System.Windows.Forms.ToolStripButton RebootToolbarButton;
 		private System.Windows.Forms.ComboBox SizeDropdown;
 		private BizHawk.WinForms.Controls.LocLabelEx label1;

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
@@ -34,78 +34,78 @@ namespace BizHawk.Client.EmuHawk
 			this.TotalSearchLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.WatchListView = new InputRoll();
 			this.ListViewContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.DoSearchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewSearchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DoSearchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.NewSearchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ContextMenuSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.RemoveContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddToRamWatchContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PokeContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FreezeContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UnfreezeAllContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RemoveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddToRamWatchContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PokeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FreezeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UnfreezeAllContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ContextMenuSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.ViewInHexEditorContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ViewInHexEditorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ContextMenuSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.ClearPreviewContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearPreviewContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.RamSearchMenu = new MenuStripEx();
-			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OpenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AppendFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.TruncateFromFileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OpenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AppendFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.TruncateFromFileMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.modeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DetailedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FastMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.MemoryDomainsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.exitToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.settingsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.modeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DetailedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FastMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.MemoryDomainsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-			this.sizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ByteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.WordMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DWordMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CheckMisalignedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.sizeToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ByteMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.WordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DWordMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CheckMisalignedMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-			this.BigEndianMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DisplayTypeSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+			this.BigEndianMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.DisplayTypeSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.DefinePreviousValueSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-			this.Previous_LastSearchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PreviousFrameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Previous_OriginalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.Previous_LastChangeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.searchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.newSearchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.DefinePreviousValueSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Previous_LastSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PreviousFrameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Previous_OriginalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.Previous_LastChangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.searchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.newSearchToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-			this.UndoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RedoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.CopyValueToPrevMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.ClearChangeCountsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.RemoveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.UndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RedoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CopyValueToPrevMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.ClearChangeCountsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.RemoveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-			this.GoToAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AddToRamWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PokeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FreezeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.GoToAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AddToRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PokeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-			this.ClearUndoMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.PreviewModeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoSearchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AutoSearchAccountForLagMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ClearUndoMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.optionsToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.PreviewModeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutoSearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AutoSearchAccountForLagMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-			this.ExcludeRamWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.UseUndoHistoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ExcludeRamWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.UseUndoHistoryMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-			this.AutoloadDialogMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.SaveWinPositionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.AlwaysOnTopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.FloatingWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.AutoloadDialogMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.SaveWinPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-			this.RestoreDefaultsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.RestoreDefaultsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.MemDomainLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.MessageLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -152,7 +152,7 @@ namespace BizHawk.Client.EmuHawk
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.DisplayTypeDropdown = new System.Windows.Forms.ComboBox();
-			this.SearchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.SearchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ListViewContextMenu.SuspendLayout();
 			this.RamSearchMenu.SuspendLayout();
 			this.CompareToBox.SuspendLayout();
@@ -162,8 +162,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// SearchMenuItem
 			// 
-			this.SearchMenuItem.Name = "SearchMenuItem";
-			this.SearchMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.SearchMenuItem.Text = "&Search";
 			this.SearchMenuItem.Click += new System.EventHandler(this.SearchMenuItem_Click);
 			// 
@@ -220,18 +218,14 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// DoSearchContextMenuItem
 			// 
-			this.DoSearchContextMenuItem.Name = "DoSearchContextMenuItem";
-			this.DoSearchContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.DoSearchContextMenuItem.Text = "&Search";
 			this.DoSearchContextMenuItem.Click += new System.EventHandler(this.SearchMenuItem_Click);
 			// 
 			// NewSearchContextMenuItem
 			// 
-			this.NewSearchContextMenuItem.Name = "NewSearchContextMenuItem";
-			this.NewSearchContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.NewSearchContextMenuItem.Text = "&Start New Search";
 			this.NewSearchContextMenuItem.Click += new System.EventHandler(this.NewSearchMenuMenuItem_Click);
-			// 
+			//
 			// ContextMenuSeparator1
 			// 
 			this.ContextMenuSeparator1.Name = "ContextMenuSeparator1";
@@ -239,40 +233,30 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// RemoveContextMenuItem
 			// 
-			this.RemoveContextMenuItem.Name = "RemoveContextMenuItem";
 			this.RemoveContextMenuItem.ShortcutKeyDisplayString = "Del";
-			this.RemoveContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.RemoveContextMenuItem.Text = "Remove Selected";
 			this.RemoveContextMenuItem.Click += new System.EventHandler(this.RemoveMenuItem_Click);
 			// 
 			// AddToRamWatchContextMenuItem
 			// 
-			this.AddToRamWatchContextMenuItem.Name = "AddToRamWatchContextMenuItem";
 			this.AddToRamWatchContextMenuItem.ShortcutKeyDisplayString = "Ctrl+W";
-			this.AddToRamWatchContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.AddToRamWatchContextMenuItem.Text = "Add to RAM Watch";
 			this.AddToRamWatchContextMenuItem.Click += new System.EventHandler(this.AddToRamWatchMenuItem_Click);
 			// 
 			// PokeContextMenuItem
 			// 
-			this.PokeContextMenuItem.Name = "PokeContextMenuItem";
 			this.PokeContextMenuItem.ShortcutKeyDisplayString = "Ctrl+P";
-			this.PokeContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.PokeContextMenuItem.Text = "Poke Address";
 			this.PokeContextMenuItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
 			// 
 			// FreezeContextMenuItem
 			// 
-			this.FreezeContextMenuItem.Name = "FreezeContextMenuItem";
 			this.FreezeContextMenuItem.ShortcutKeyDisplayString = "Ctrl+F";
-			this.FreezeContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.FreezeContextMenuItem.Text = "Freeze Address";
 			this.FreezeContextMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
 			// 
 			// UnfreezeAllContextMenuItem
 			// 
-			this.UnfreezeAllContextMenuItem.Name = "UnfreezeAllContextMenuItem";
-			this.UnfreezeAllContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.UnfreezeAllContextMenuItem.Text = "Unfreeze &All";
 			this.UnfreezeAllContextMenuItem.Click += new System.EventHandler(this.UnfreezeAllContextMenuItem_Click);
 			// 
@@ -283,8 +267,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ViewInHexEditorContextMenuItem
 			// 
-			this.ViewInHexEditorContextMenuItem.Name = "ViewInHexEditorContextMenuItem";
-			this.ViewInHexEditorContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.ViewInHexEditorContextMenuItem.Text = "View in Hex Editor";
 			this.ViewInHexEditorContextMenuItem.Click += new System.EventHandler(this.ViewInHexEditorContextMenuItem_Click);
 			// 
@@ -295,8 +277,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearPreviewContextMenuItem
 			// 
-			this.ClearPreviewContextMenuItem.Name = "ClearPreviewContextMenuItem";
-			this.ClearPreviewContextMenuItem.Size = new System.Drawing.Size(217, 22);
 			this.ClearPreviewContextMenuItem.Text = "&Clear Preview";
 			this.ClearPreviewContextMenuItem.Click += new System.EventHandler(this.ClearPreviewContextMenuItem_Click);
 			// 
@@ -322,47 +302,35 @@ namespace BizHawk.Client.EmuHawk
             this.RecentSubMenu,
             this.toolStripSeparator4,
             this.exitToolStripMenuItem});
-			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
 			this.fileToolStripMenuItem.Text = "&File";
 			this.fileToolStripMenuItem.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
 			// OpenMenuItem
 			// 
-			this.OpenMenuItem.Name = "OpenMenuItem";
 			this.OpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-			this.OpenMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.OpenMenuItem.Text = "&Open...";
 			this.OpenMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
 			// SaveMenuItem
 			// 
-			this.SaveMenuItem.Name = "SaveMenuItem";
 			this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-			this.SaveMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveMenuItem.Text = "&Save";
 			this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
 			// 
 			// SaveAsMenuItem
 			// 
-			this.SaveAsMenuItem.Name = "SaveAsMenuItem";
 			this.SaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-			this.SaveAsMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.SaveAsMenuItem.Text = "Save As...";
 			this.SaveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItem_Click);
 			// 
 			// AppendFileMenuItem
 			// 
-			this.AppendFileMenuItem.Name = "AppendFileMenuItem";
-			this.AppendFileMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.AppendFileMenuItem.Text = "&Append File...";
 			this.AppendFileMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
 			// TruncateFromFileMenuItem
 			// 
-			this.TruncateFromFileMenuItem.Name = "TruncateFromFileMenuItem";
-			this.TruncateFromFileMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.TruncateFromFileMenuItem.Text = "&Truncate from File...";
 			this.TruncateFromFileMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
 			// 
@@ -370,8 +338,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator2});
-			this.RecentSubMenu.Name = "RecentSubMenu";
-			this.RecentSubMenu.Size = new System.Drawing.Size(195, 22);
 			this.RecentSubMenu.Text = "Recent";
 			this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
 			// 
@@ -387,9 +353,7 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// exitToolStripMenuItem
 			// 
-			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
 			this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-			this.exitToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
 			this.exitToolStripMenuItem.Text = "&Close";
 			this.exitToolStripMenuItem.Click += new System.EventHandler(this.CloseMenuItem_Click);
 			// 
@@ -404,8 +368,6 @@ namespace BizHawk.Client.EmuHawk
             this.BigEndianMenuItem,
             this.DisplayTypeSubMenu,
             this.DefinePreviousValueSubMenu});
-			this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-			this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
 			this.settingsToolStripMenuItem.Text = "&Settings";
 			this.settingsToolStripMenuItem.DropDownOpened += new System.EventHandler(this.SettingsSubMenu_DropDownOpened);
 			// 
@@ -414,22 +376,16 @@ namespace BizHawk.Client.EmuHawk
 			this.modeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.DetailedMenuItem,
             this.FastMenuItem});
-			this.modeToolStripMenuItem.Name = "modeToolStripMenuItem";
-			this.modeToolStripMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.modeToolStripMenuItem.Text = "&Mode";
 			this.modeToolStripMenuItem.DropDownOpened += new System.EventHandler(this.ModeSubMenu_DropDownOpened);
 			// 
 			// DetailedMenuItem
 			// 
-			this.DetailedMenuItem.Name = "DetailedMenuItem";
-			this.DetailedMenuItem.Size = new System.Drawing.Size(117, 22);
 			this.DetailedMenuItem.Text = "&Detailed";
 			this.DetailedMenuItem.Click += new System.EventHandler(this.DetailedMenuItem_Click);
 			// 
 			// FastMenuItem
 			// 
-			this.FastMenuItem.Name = "FastMenuItem";
-			this.FastMenuItem.Size = new System.Drawing.Size(117, 22);
 			this.FastMenuItem.Text = "&Fast";
 			this.FastMenuItem.Click += new System.EventHandler(this.FastMenuItem_Click);
 			// 
@@ -437,8 +393,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.MemoryDomainsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator6});
-			this.MemoryDomainsSubMenu.Name = "MemoryDomainsSubMenu";
-			this.MemoryDomainsSubMenu.Size = new System.Drawing.Size(187, 22);
 			this.MemoryDomainsSubMenu.Text = "&Memory Domains";
 			this.MemoryDomainsSubMenu.DropDownOpened += new System.EventHandler(this.MemoryDomainsSubMenu_DropDownOpened);
 			// 
@@ -453,36 +407,26 @@ namespace BizHawk.Client.EmuHawk
             this.ByteMenuItem,
             this.WordMenuItem,
             this.DWordMenuItem});
-			this.sizeToolStripMenuItem.Name = "sizeToolStripMenuItem";
-			this.sizeToolStripMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.sizeToolStripMenuItem.Text = "&Size";
 			this.sizeToolStripMenuItem.DropDownOpened += new System.EventHandler(this.SizeSubMenu_DropDownOpened);
 			// 
 			// ByteMenuItem
 			// 
-			this.ByteMenuItem.Name = "ByteMenuItem";
-			this.ByteMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.ByteMenuItem.Text = "&1 Byte";
 			this.ByteMenuItem.Click += new System.EventHandler(this.ByteMenuItem_Click);
 			// 
 			// WordMenuItem
 			// 
-			this.WordMenuItem.Name = "WordMenuItem";
-			this.WordMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.WordMenuItem.Text = "&2 Byte";
 			this.WordMenuItem.Click += new System.EventHandler(this.WordMenuItem_Click);
 			// 
 			// DWordMenuItem
 			// 
-			this.DWordMenuItem.Name = "DWordMenuItem";
-			this.DWordMenuItem.Size = new System.Drawing.Size(106, 22);
 			this.DWordMenuItem.Text = "&4 Byte";
 			this.DWordMenuItem.Click += new System.EventHandler(this.DWordMenuItem_Click_Click);
 			// 
 			// CheckMisalignedMenuItem
 			// 
-			this.CheckMisalignedMenuItem.Name = "CheckMisalignedMenuItem";
-			this.CheckMisalignedMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.CheckMisalignedMenuItem.Text = "Check Mis-aligned";
 			this.CheckMisalignedMenuItem.Click += new System.EventHandler(this.CheckMisalignedMenuItem_Click);
 			// 
@@ -493,8 +437,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// BigEndianMenuItem
 			// 
-			this.BigEndianMenuItem.Name = "BigEndianMenuItem";
-			this.BigEndianMenuItem.Size = new System.Drawing.Size(187, 22);
 			this.BigEndianMenuItem.Text = "&Big Endian";
 			this.BigEndianMenuItem.Click += new System.EventHandler(this.BigEndianMenuItem_Click);
 			// 
@@ -502,8 +444,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			this.DisplayTypeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator1});
-			this.DisplayTypeSubMenu.Name = "DisplayTypeSubMenu";
-			this.DisplayTypeSubMenu.Size = new System.Drawing.Size(187, 22);
 			this.DisplayTypeSubMenu.Text = "&Display Type";
 			this.DisplayTypeSubMenu.DropDownOpened += new System.EventHandler(this.DisplayTypeSubMenu_DropDownOpened);
 			// 
@@ -519,36 +459,26 @@ namespace BizHawk.Client.EmuHawk
             this.PreviousFrameMenuItem,
             this.Previous_OriginalMenuItem,
             this.Previous_LastChangeMenuItem});
-			this.DefinePreviousValueSubMenu.Name = "DefinePreviousValueSubMenu";
-			this.DefinePreviousValueSubMenu.Size = new System.Drawing.Size(187, 22);
 			this.DefinePreviousValueSubMenu.Text = "Define Previous Value";
 			this.DefinePreviousValueSubMenu.DropDownOpened += new System.EventHandler(this.DefinePreviousValueSubMenu_DropDownOpened);
 			// 
 			// Previous_LastSearchMenuItem
 			// 
-			this.Previous_LastSearchMenuItem.Name = "Previous_LastSearchMenuItem";
-			this.Previous_LastSearchMenuItem.Size = new System.Drawing.Size(155, 22);
 			this.Previous_LastSearchMenuItem.Text = "Last &Search";
 			this.Previous_LastSearchMenuItem.Click += new System.EventHandler(this.Previous_LastSearchMenuItem_Click);
 			// 
 			// PreviousFrameMenuItem
 			// 
-			this.PreviousFrameMenuItem.Name = "PreviousFrameMenuItem";
-			this.PreviousFrameMenuItem.Size = new System.Drawing.Size(155, 22);
 			this.PreviousFrameMenuItem.Text = "&Previous Frame";
 			this.PreviousFrameMenuItem.Click += new System.EventHandler(this.Previous_LastFrameMenuItem_Click);
 			// 
 			// Previous_OriginalMenuItem
 			// 
-			this.Previous_OriginalMenuItem.Name = "Previous_OriginalMenuItem";
-			this.Previous_OriginalMenuItem.Size = new System.Drawing.Size(155, 22);
 			this.Previous_OriginalMenuItem.Text = "&Original";
 			this.Previous_OriginalMenuItem.Click += new System.EventHandler(this.Previous_OriginalMenuItem_Click);
 			// 
 			// Previous_LastChangeMenuItem
 			// 
-			this.Previous_LastChangeMenuItem.Name = "Previous_LastChangeMenuItem";
-			this.Previous_LastChangeMenuItem.Size = new System.Drawing.Size(155, 22);
 			this.Previous_LastChangeMenuItem.Text = "Last &Change";
 			this.Previous_LastChangeMenuItem.Click += new System.EventHandler(this.Previous_LastChangeMenuItem_Click);
 			// 
@@ -570,15 +500,11 @@ namespace BizHawk.Client.EmuHawk
             this.FreezeAddressMenuItem,
             this.toolStripSeparator13,
             this.ClearUndoMenuItem});
-			this.searchToolStripMenuItem.Name = "searchToolStripMenuItem";
-			this.searchToolStripMenuItem.Size = new System.Drawing.Size(54, 20);
 			this.searchToolStripMenuItem.Text = "&Search";
 			this.searchToolStripMenuItem.DropDownOpened += new System.EventHandler(this.SearchSubMenu_DropDownOpened);
 			// 
 			// newSearchToolStripMenuItem
 			// 
-			this.newSearchToolStripMenuItem.Name = "newSearchToolStripMenuItem";
-			this.newSearchToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.newSearchToolStripMenuItem.Text = "&New Search";
 			this.newSearchToolStripMenuItem.Click += new System.EventHandler(this.NewSearchMenuMenuItem_Click);
 			// 
@@ -589,40 +515,30 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// UndoMenuItem
 			// 
-			this.UndoMenuItem.Name = "UndoMenuItem";
 			this.UndoMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-			this.UndoMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.UndoMenuItem.Text = "&Undo";
 			this.UndoMenuItem.Click += new System.EventHandler(this.UndoMenuItem_Click);
 			// 
 			// RedoMenuItem
 			// 
-			this.RedoMenuItem.Name = "RedoMenuItem";
 			this.RedoMenuItem.ShortcutKeyDisplayString = "";
 			this.RedoMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-			this.RedoMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.RedoMenuItem.Text = "&Redo";
 			this.RedoMenuItem.Click += new System.EventHandler(this.RedoMenuItem_Click);
 			// 
 			// CopyValueToPrevMenuItem
 			// 
-			this.CopyValueToPrevMenuItem.Name = "CopyValueToPrevMenuItem";
-			this.CopyValueToPrevMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.CopyValueToPrevMenuItem.Text = "Copy Value to Prev";
 			this.CopyValueToPrevMenuItem.Click += new System.EventHandler(this.CopyValueToPrevMenuItem_Click);
 			// 
 			// ClearChangeCountsMenuItem
 			// 
-			this.ClearChangeCountsMenuItem.Name = "ClearChangeCountsMenuItem";
-			this.ClearChangeCountsMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.ClearChangeCountsMenuItem.Text = "&Clear Change Counts";
 			this.ClearChangeCountsMenuItem.Click += new System.EventHandler(this.ClearChangeCountsMenuItem_Click);
 			// 
 			// RemoveMenuItem
 			// 
-			this.RemoveMenuItem.Name = "RemoveMenuItem";
 			this.RemoveMenuItem.ShortcutKeyDisplayString = "Delete";
-			this.RemoveMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.RemoveMenuItem.Text = "&Remove selected";
 			this.RemoveMenuItem.Click += new System.EventHandler(this.RemoveMenuItem_Click);
 			// 
@@ -633,33 +549,25 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// GoToAddressMenuItem
 			// 
-			this.GoToAddressMenuItem.Name = "GoToAddressMenuItem";
 			this.GoToAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-			this.GoToAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.GoToAddressMenuItem.Text = "&Go to Address...";
 			this.GoToAddressMenuItem.Click += new System.EventHandler(this.GoToAddressMenuItem_Click);
 			// 
 			// AddToRamWatchMenuItem
 			// 
-			this.AddToRamWatchMenuItem.Name = "AddToRamWatchMenuItem";
 			this.AddToRamWatchMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
-			this.AddToRamWatchMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.AddToRamWatchMenuItem.Text = "&Add to RAM Watch";
 			this.AddToRamWatchMenuItem.Click += new System.EventHandler(this.AddToRamWatchMenuItem_Click);
 			// 
 			// PokeAddressMenuItem
 			// 
-			this.PokeAddressMenuItem.Name = "PokeAddressMenuItem";
 			this.PokeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-			this.PokeAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.PokeAddressMenuItem.Text = "&Poke Address";
 			this.PokeAddressMenuItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
 			// 
 			// FreezeAddressMenuItem
 			// 
-			this.FreezeAddressMenuItem.Name = "FreezeAddressMenuItem";
 			this.FreezeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-			this.FreezeAddressMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.FreezeAddressMenuItem.Text = "Freeze Address";
 			this.FreezeAddressMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
 			// 
@@ -670,8 +578,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ClearUndoMenuItem
 			// 
-			this.ClearUndoMenuItem.Name = "ClearUndoMenuItem";
-			this.ClearUndoMenuItem.Size = new System.Drawing.Size(221, 22);
 			this.ClearUndoMenuItem.Text = "Clear Undo History";
 			this.ClearUndoMenuItem.Click += new System.EventHandler(this.ClearUndoMenuItem_Click);
 			// 
@@ -691,29 +597,21 @@ namespace BizHawk.Client.EmuHawk
             this.FloatingWindowMenuItem,
             this.toolStripSeparator3,
             this.RestoreDefaultsMenuItem});
-			this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-			this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
 			this.optionsToolStripMenuItem.Text = "&Options";
 			this.optionsToolStripMenuItem.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
 			// 
 			// PreviewModeMenuItem
 			// 
-			this.PreviewModeMenuItem.Name = "PreviewModeMenuItem";
-			this.PreviewModeMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.PreviewModeMenuItem.Text = "&Preview Mode";
 			this.PreviewModeMenuItem.Click += new System.EventHandler(this.PreviewModeMenuItem_Click);
 			// 
 			// AutoSearchMenuItem
 			// 
-			this.AutoSearchMenuItem.Name = "AutoSearchMenuItem";
-			this.AutoSearchMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.AutoSearchMenuItem.Text = "&Auto-Search";
 			this.AutoSearchMenuItem.Click += new System.EventHandler(this.AutoSearchMenuItem_Click);
 			// 
 			// AutoSearchAccountForLagMenuItem
 			// 
-			this.AutoSearchAccountForLagMenuItem.Name = "AutoSearchAccountForLagMenuItem";
-			this.AutoSearchAccountForLagMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.AutoSearchAccountForLagMenuItem.Text = "&Auto-Search Account for Lag";
 			this.AutoSearchAccountForLagMenuItem.Click += new System.EventHandler(this.AutoSearchAccountForLagMenuItem_Click);
 			// 
@@ -724,15 +622,11 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// ExcludeRamWatchMenuItem
 			// 
-			this.ExcludeRamWatchMenuItem.Name = "ExcludeRamWatchMenuItem";
-			this.ExcludeRamWatchMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.ExcludeRamWatchMenuItem.Text = "Always E&xclude RAM Search List";
 			this.ExcludeRamWatchMenuItem.Click += new System.EventHandler(this.ExcludeRamWatchMenuItem_Click);
 			// 
 			// UseUndoHistoryMenuItem
 			// 
-			this.UseUndoHistoryMenuItem.Name = "UseUndoHistoryMenuItem";
-			this.UseUndoHistoryMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.UseUndoHistoryMenuItem.Text = "&Use Undo History";
 			this.UseUndoHistoryMenuItem.Click += new System.EventHandler(this.UseUndoHistoryMenuItem_Click);
 			// 
@@ -743,29 +637,21 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// AutoloadDialogMenuItem
 			// 
-			this.AutoloadDialogMenuItem.Name = "AutoloadDialogMenuItem";
-			this.AutoloadDialogMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.AutoloadDialogMenuItem.Text = "Auto&load";
 			this.AutoloadDialogMenuItem.Click += new System.EventHandler(this.AutoloadDialogMenuItem_Click);
 			// 
 			// SaveWinPositionMenuItem
 			// 
-			this.SaveWinPositionMenuItem.Name = "SaveWinPositionMenuItem";
-			this.SaveWinPositionMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.SaveWinPositionMenuItem.Text = "&Save Window Position";
 			this.SaveWinPositionMenuItem.Click += new System.EventHandler(this.SaveWinPositionMenuItem_Click);
 			// 
 			// AlwaysOnTopMenuItem
 			// 
-			this.AlwaysOnTopMenuItem.Name = "AlwaysOnTopMenuItem";
-			this.AlwaysOnTopMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.AlwaysOnTopMenuItem.Text = "Always On &Top";
 			this.AlwaysOnTopMenuItem.Click += new System.EventHandler(this.AlwaysOnTopMenuItem_Click);
 			// 
 			// FloatingWindowMenuItem
 			// 
-			this.FloatingWindowMenuItem.Name = "FloatingWindowMenuItem";
-			this.FloatingWindowMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.FloatingWindowMenuItem.Text = "&Floating Window";
 			this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
 			// 
@@ -776,8 +662,6 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// RestoreDefaultsMenuItem
 			// 
-			this.RestoreDefaultsMenuItem.Name = "RestoreDefaultsMenuItem";
-			this.RestoreDefaultsMenuItem.Size = new System.Drawing.Size(242, 22);
 			this.RestoreDefaultsMenuItem.Text = "&Restore Default Settings";
 			this.RestoreDefaultsMenuItem.Click += new System.EventHandler(this.RestoreDefaultsMenuItem_Click);
 			// 
@@ -1325,77 +1209,77 @@ namespace BizHawk.Client.EmuHawk
 		#endregion
 
 		private BizHawk.WinForms.Controls.LocLabelEx TotalSearchLabel;
-		private System.Windows.Forms.ToolStripMenuItem SearchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SearchMenuItem;
 		private InputRoll WatchListView;
-		private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem optionsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RestoreDefaultsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveWinPositionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx fileToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx exitToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx optionsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestoreDefaultsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveWinPositionMenuItem;
 		private BizHawk.WinForms.Controls.LocLabelEx MemDomainLabel;
 		private BizHawk.WinForms.Controls.LocLabelEx MessageLabel;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem AppendFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendFileMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-		private System.Windows.Forms.ToolStripMenuItem searchToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearChangeCountsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UndoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx searchToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearChangeCountsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UndoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-		private System.Windows.Forms.ToolStripMenuItem AddToRamWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem TruncateFromFileMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ExcludeRamWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CopyValueToPrevMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx TruncateFromFileMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExcludeRamWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CopyValueToPrevMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ListViewContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem NewSearchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewSearchContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem DoSearchContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FreezeAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AddToRamWatchContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FreezeContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DoSearchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AddToRamWatchContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeContextMenuItem;
 		private MenuStripEx RamSearchMenu;
 		private System.Windows.Forms.ToolTip toolTip1;
-		private System.Windows.Forms.ToolStripMenuItem RedoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ViewInHexEditorContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoloadDialogMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RedoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoloadDialogMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
-		private System.Windows.Forms.ToolStripMenuItem UnfreezeAllContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem AlwaysOnTopMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysOnTopMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
-		private System.Windows.Forms.ToolStripMenuItem ClearUndoMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UseUndoHistoryMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearUndoMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UseUndoHistoryMenuItem;
 		private System.Windows.Forms.ToolStripSeparator ContextMenuSeparator2;
-		private System.Windows.Forms.ToolStripMenuItem ClearPreviewContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearPreviewContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem newSearchToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx newSearchToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem modeToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DetailedMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FastMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MemoryDomainsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx settingsToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx modeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DetailedMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FastMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripMenuItem sizeToolStripMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ByteMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem WordMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DWordMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DisplayTypeSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx sizeToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ByteMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WordMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DWordMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DisplayTypeSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem BigEndianMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem CheckMisalignedMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx BigEndianMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx CheckMisalignedMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-		private System.Windows.Forms.ToolStripMenuItem DefinePreviousValueSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PreviousFrameMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Previous_LastSearchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem Previous_OriginalMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DefinePreviousValueSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviousFrameMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Previous_LastSearchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Previous_OriginalMenuItem;
 		private System.Windows.Forms.GroupBox CompareToBox;
 		private System.Windows.Forms.RadioButton DifferenceRadio;
 		private UnsignedIntegerBox NumberOfChangesBox;
@@ -1421,14 +1305,14 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.RadioButton LessThanRadio;
 		private System.Windows.Forms.ToolStripButton CopyValueToPrevToolBarItem;
 		private System.Windows.Forms.ToolStripButton ClearChangeCountsToolBarItem;
-		private System.Windows.Forms.ToolStripMenuItem PreviewModeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviewModeMenuItem;
 		private System.Windows.Forms.ToolStripButton RemoveToolBarItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator16;
 		private System.Windows.Forms.ToolStripButton AddToRamWatchToolBarItem;
 		private System.Windows.Forms.ToolStripButton PokeAddressToolBarItem;
 		private System.Windows.Forms.ToolStripButton FreezeAddressToolBarItem;
 		private WatchValueBox DifferenceBox;
-		private System.Windows.Forms.ToolStripMenuItem AutoSearchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoSearchMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
 		private System.Windows.Forms.ToolStripButton UndoToolBarButton;
@@ -1441,10 +1325,10 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.LocLabelEx label1;
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
 		private System.Windows.Forms.ComboBox DisplayTypeDropdown;
-		private System.Windows.Forms.ToolStripMenuItem GoToAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FloatingWindowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx GoToAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FloatingWindowMenuItem;
 		private System.Windows.Forms.ToolStripButton ErrorIconButton;
-		private System.Windows.Forms.ToolStripMenuItem Previous_LastChangeMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AutoSearchAccountForLagMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx Previous_LastChangeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AutoSearchAccountForLagMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
@@ -33,23 +33,23 @@ namespace BizHawk.Client.EmuHawk
             this.components = new System.ComponentModel.Container();
             this.WatchCountLabel = new BizHawk.WinForms.Controls.LocLabelEx();
             this.ListViewContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.EditContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.RemoveContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.DuplicateContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.PokeContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.FreezeContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.UnfreezeAllContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ViewInHexEditorContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.newToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.EditContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RemoveContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DuplicateContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PokeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FreezeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.UnfreezeAllContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ViewInHexEditorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.Separator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.ReadBreakpointContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.WriteBreakpointContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ReadBreakpointContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.WriteBreakpointContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.Separator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.InsertSeperatorContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveUpContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveDownContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveTopContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveBottomContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.InsertSeperatorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveUpContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveDownContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveTopContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveBottomContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.statusStrip1 = new StatusStripEx();
             this.ErrorIconButton = new System.Windows.Forms.ToolStripButton();
             this.MessageLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -71,45 +71,45 @@ namespace BizHawk.Client.EmuHawk
             this.moveDownToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.RamWatchMenu = new MenuStripEx();
-            this.FileSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.NewListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.OpenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SaveMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SaveAsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.AppendMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.RecentSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.noneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.NewListMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.OpenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveAsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AppendMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.ExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.WatchesSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.MemoryDomainsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.WatchesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MemoryDomainsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.Separator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.NewWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.EditWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.RemoveWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.DuplicateWatchMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.PokeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.FreezeAddressMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.InsertSeparatorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ClearChangeCountsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.NewWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.EditWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.RemoveWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DuplicateWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PokeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.ClearChangeCountsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.MoveUpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveDownMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveTopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MoveBottomMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SelectAllMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.OptionsSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.DefinePreviousValueSubMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.PreviousFrameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.LastChangeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.OriginalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.WatchesOnScreenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.SaveWindowPositionMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.AlwaysOnTopMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.FloatingWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.MoveBottomMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SelectAllMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.OptionsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.DefinePreviousValueSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.PreviousFrameMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.LastChangeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.OriginalMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.WatchesOnScreenMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.SaveWindowPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+            this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.RestoreWindowSizeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.RestoreWindowSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.WatchListView = new InputRoll();
             this.ListViewContextMenu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -149,62 +149,46 @@ namespace BizHawk.Client.EmuHawk
             // 
             // newToolStripMenuItem
             // 
-            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(244, 22);
             this.newToolStripMenuItem.Text = "&New Watch";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.NewWatchMenuItem_Click);
             // 
             // EditContextMenuItem
             // 
-            this.EditContextMenuItem.Name = "EditContextMenuItem";
             this.EditContextMenuItem.ShortcutKeyDisplayString = "Ctrl+E";
-            this.EditContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.EditContextMenuItem.Text = "&Edit";
             this.EditContextMenuItem.Click += new System.EventHandler(this.EditWatchMenuItem_Click);
             // 
             // RemoveContextMenuItem
             // 
-            this.RemoveContextMenuItem.Name = "RemoveContextMenuItem";
             this.RemoveContextMenuItem.ShortcutKeyDisplayString = "Ctrl+R";
-            this.RemoveContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.RemoveContextMenuItem.Text = "&Remove";
             this.RemoveContextMenuItem.Click += new System.EventHandler(this.RemoveWatchMenuItem_Click);
             // 
             // DuplicateContextMenuItem
             // 
-            this.DuplicateContextMenuItem.Name = "DuplicateContextMenuItem";
             this.DuplicateContextMenuItem.ShortcutKeyDisplayString = "Ctrl+D";
-            this.DuplicateContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.DuplicateContextMenuItem.Text = "&Duplicate";
             this.DuplicateContextMenuItem.Click += new System.EventHandler(this.DuplicateWatchMenuItem_Click);
             // 
             // PokeContextMenuItem
             // 
-            this.PokeContextMenuItem.Name = "PokeContextMenuItem";
             this.PokeContextMenuItem.ShortcutKeyDisplayString = "Ctrl+P";
-            this.PokeContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.PokeContextMenuItem.Text = "&Poke";
             this.PokeContextMenuItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
             // 
             // FreezeContextMenuItem
             // 
-            this.FreezeContextMenuItem.Name = "FreezeContextMenuItem";
             this.FreezeContextMenuItem.ShortcutKeyDisplayString = "Ctrl+F";
-            this.FreezeContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.FreezeContextMenuItem.Text = "&Freeze";
             this.FreezeContextMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
             // 
             // UnfreezeAllContextMenuItem
             // 
-			this.UnfreezeAllContextMenuItem.Name = "UnfreezeAllContextMenuItem";
-            this.UnfreezeAllContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.UnfreezeAllContextMenuItem.Text = "Unfreeze &All";
             this.UnfreezeAllContextMenuItem.Click += new System.EventHandler(this.UnfreezeAllContextMenuItem_Click);
             // 
             // ViewInHexEditorContextMenuItem
             // 
-            this.ViewInHexEditorContextMenuItem.Name = "ViewInHexEditorContextMenuItem";
-            this.ViewInHexEditorContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.ViewInHexEditorContextMenuItem.Text = "View in Hex Editor";
             this.ViewInHexEditorContextMenuItem.Click += new System.EventHandler(this.ViewInHexEditorContextMenuItem_Click);
             // 
@@ -215,15 +199,11 @@ namespace BizHawk.Client.EmuHawk
             // 
             // ReadBreakpointContextMenuItem
             // 
-            this.ReadBreakpointContextMenuItem.Name = "ReadBreakpointContextMenuItem";
-            this.ReadBreakpointContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.ReadBreakpointContextMenuItem.Text = "Set Read Breakpoint";
             this.ReadBreakpointContextMenuItem.Click += new System.EventHandler(this.ReadBreakpointContextMenuItem_Click);
             // 
             // WriteBreakpointContextMenuItem
             // 
-            this.WriteBreakpointContextMenuItem.Name = "WriteBreakpointContextMenuItem";
-            this.WriteBreakpointContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.WriteBreakpointContextMenuItem.Text = "Set Write Breakpoint";
             this.WriteBreakpointContextMenuItem.Click += new System.EventHandler(this.WriteBreakpointContextMenuItem_Click);
             // 
@@ -234,43 +214,33 @@ namespace BizHawk.Client.EmuHawk
             // 
             // InsertSeperatorContextMenuItem
             // 
-            this.InsertSeperatorContextMenuItem.Name = "InsertSeperatorContextMenuItem";
             this.InsertSeperatorContextMenuItem.ShortcutKeyDisplayString = "Ctrl+I";
-            this.InsertSeperatorContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.InsertSeperatorContextMenuItem.Text = "&Insert Separator";
             this.InsertSeperatorContextMenuItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
             // 
             // MoveUpContextMenuItem
             // 
-            this.MoveUpContextMenuItem.Name = "MoveUpContextMenuItem";
             this.MoveUpContextMenuItem.ShortcutKeyDisplayString = "Ctrl+Up";
-            this.MoveUpContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveUpContextMenuItem.Text = "Move &Up";
             this.MoveUpContextMenuItem.Click += new System.EventHandler(this.MoveUpMenuItem_Click);
             // 
             // MoveDownContextMenuItem
             // 
-            this.MoveDownContextMenuItem.Name = "MoveDownContextMenuItem";
             this.MoveDownContextMenuItem.ShortcutKeyDisplayString = "Ctrl+Down";
-            this.MoveDownContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveDownContextMenuItem.Text = "Move &Down";
             this.MoveDownContextMenuItem.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
             // 
             // MoveTopContextMenuItem
             // 
-            this.MoveTopContextMenuItem.Name = "MoveTopContextMenuItem";
             this.MoveTopContextMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Up)));
-            this.MoveTopContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveTopContextMenuItem.Text = "Move &Top";
             this.MoveTopContextMenuItem.Click += new System.EventHandler(this.MoveTopMenuItem_Click);
             // 
             // MoveBottomContextMenuItem
             // 
-            this.MoveBottomContextMenuItem.Name = "MoveBottomContextMenuItem";
             this.MoveBottomContextMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Down)));
-            this.MoveBottomContextMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveBottomContextMenuItem.Text = "Move &Bottom";
             this.MoveBottomContextMenuItem.Click += new System.EventHandler(this.MoveBottomMenuItem_Click);
             // 
@@ -481,48 +451,36 @@ namespace BizHawk.Client.EmuHawk
             this.RecentSubMenu,
             this.toolStripSeparator1,
             this.ExitMenuItem});
-            this.FileSubMenu.Name = "FileSubMenu";
-            this.FileSubMenu.Size = new System.Drawing.Size(42, 20);
             this.FileSubMenu.Text = "&Files";
             this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
             // 
             // NewListMenuItem
             // 
-            this.NewListMenuItem.Name = "NewListMenuItem";
             this.NewListMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.NewListMenuItem.Size = new System.Drawing.Size(195, 22);
             this.NewListMenuItem.Text = "&New List";
             this.NewListMenuItem.Click += new System.EventHandler(this.NewListMenuItem_Click);
             // 
             // OpenMenuItem
             // 
-            this.OpenMenuItem.Name = "OpenMenuItem";
             this.OpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.OpenMenuItem.Size = new System.Drawing.Size(195, 22);
             this.OpenMenuItem.Text = "&Open...";
             this.OpenMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
             // 
             // SaveMenuItem
             // 
-            this.SaveMenuItem.Name = "SaveMenuItem";
             this.SaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.SaveMenuItem.Size = new System.Drawing.Size(195, 22);
             this.SaveMenuItem.Text = "&Save";
             this.SaveMenuItem.Click += new System.EventHandler(this.SaveMenuItem_Click);
             // 
             // SaveAsMenuItem
             // 
-            this.SaveAsMenuItem.Name = "SaveAsMenuItem";
             this.SaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-            this.SaveAsMenuItem.Size = new System.Drawing.Size(195, 22);
             this.SaveAsMenuItem.Text = "Save &As...";
             this.SaveAsMenuItem.Click += new System.EventHandler(this.SaveAsMenuItem_Click);
             // 
             // AppendMenuItem
             // 
-            this.AppendMenuItem.Name = "AppendMenuItem";
-            this.AppendMenuItem.Size = new System.Drawing.Size(195, 22);
             this.AppendMenuItem.Text = "A&ppend File...";
             this.AppendMenuItem.Click += new System.EventHandler(this.OpenMenuItem_Click);
             // 
@@ -530,15 +488,11 @@ namespace BizHawk.Client.EmuHawk
             // 
             this.RecentSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.noneToolStripMenuItem});
-            this.RecentSubMenu.Name = "RecentSubMenu";
-            this.RecentSubMenu.Size = new System.Drawing.Size(195, 22);
             this.RecentSubMenu.Text = "Recent";
             this.RecentSubMenu.DropDownOpened += new System.EventHandler(this.RecentSubMenu_DropDownOpened);
             // 
             // noneToolStripMenuItem
             // 
-            this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
-            this.noneToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.noneToolStripMenuItem.Text = "None";
             // 
             // toolStripSeparator1
@@ -548,9 +502,7 @@ namespace BizHawk.Client.EmuHawk
             // 
             // ExitMenuItem
             // 
-            this.ExitMenuItem.Name = "ExitMenuItem";
             this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            this.ExitMenuItem.Size = new System.Drawing.Size(195, 22);
             this.ExitMenuItem.Text = "&Close";
             this.ExitMenuItem.Click += new System.EventHandler(this.ExitMenuItem_Click);
             // 
@@ -573,8 +525,6 @@ namespace BizHawk.Client.EmuHawk
             this.MoveTopMenuItem,
             this.MoveBottomMenuItem,
             this.SelectAllMenuItem});
-            this.WatchesSubMenu.Name = "WatchesSubMenu";
-            this.WatchesSubMenu.Size = new System.Drawing.Size(64, 20);
             this.WatchesSubMenu.Text = "&Watches";
             this.WatchesSubMenu.DropDownOpened += new System.EventHandler(this.WatchesSubMenu_DropDownOpened);
             // 
@@ -582,8 +532,6 @@ namespace BizHawk.Client.EmuHawk
             // 
             this.MemoryDomainsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Separator2});
-            this.MemoryDomainsSubMenu.Name = "MemoryDomainsSubMenu";
-            this.MemoryDomainsSubMenu.Size = new System.Drawing.Size(244, 22);
             this.MemoryDomainsSubMenu.Text = "Default Domain";
             this.MemoryDomainsSubMenu.DropDownOpened += new System.EventHandler(this.MemoryDomainsSubMenu_DropDownOpened);
             // 
@@ -599,65 +547,49 @@ namespace BizHawk.Client.EmuHawk
             // 
             // NewWatchMenuItem
             // 
-            this.NewWatchMenuItem.Name = "NewWatchMenuItem";
             this.NewWatchMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
-            this.NewWatchMenuItem.Size = new System.Drawing.Size(244, 22);
             this.NewWatchMenuItem.Text = "&New Watch";
             this.NewWatchMenuItem.Click += new System.EventHandler(this.NewWatchMenuItem_Click);
             // 
             // EditWatchMenuItem
             // 
-            this.EditWatchMenuItem.Name = "EditWatchMenuItem";
             this.EditWatchMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-            this.EditWatchMenuItem.Size = new System.Drawing.Size(244, 22);
             this.EditWatchMenuItem.Text = "&Edit Watch";
             this.EditWatchMenuItem.Click += new System.EventHandler(this.EditWatchMenuItem_Click);
             // 
             // RemoveWatchMenuItem
             // 
-            this.RemoveWatchMenuItem.Name = "RemoveWatchMenuItem";
             this.RemoveWatchMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-            this.RemoveWatchMenuItem.Size = new System.Drawing.Size(244, 22);
             this.RemoveWatchMenuItem.Text = "&Remove Watch";
             this.RemoveWatchMenuItem.Click += new System.EventHandler(this.RemoveWatchMenuItem_Click);
             // 
             // DuplicateWatchMenuItem
             // 
-            this.DuplicateWatchMenuItem.Name = "DuplicateWatchMenuItem";
             this.DuplicateWatchMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
-            this.DuplicateWatchMenuItem.Size = new System.Drawing.Size(244, 22);
             this.DuplicateWatchMenuItem.Text = "&Duplicate Watch";
             this.DuplicateWatchMenuItem.Click += new System.EventHandler(this.DuplicateWatchMenuItem_Click);
             // 
             // PokeAddressMenuItem
             // 
-            this.PokeAddressMenuItem.Name = "PokeAddressMenuItem";
             this.PokeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-            this.PokeAddressMenuItem.Size = new System.Drawing.Size(244, 22);
             this.PokeAddressMenuItem.Text = "Poke Address";
             this.PokeAddressMenuItem.Click += new System.EventHandler(this.PokeAddressMenuItem_Click);
             // 
             // FreezeAddressMenuItem
             // 
-            this.FreezeAddressMenuItem.Name = "FreezeAddressMenuItem";
             this.FreezeAddressMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.FreezeAddressMenuItem.Size = new System.Drawing.Size(244, 22);
             this.FreezeAddressMenuItem.Text = "Freeze Address";
             this.FreezeAddressMenuItem.Click += new System.EventHandler(this.FreezeAddressMenuItem_Click);
             // 
             // InsertSeparatorMenuItem
             // 
-            this.InsertSeparatorMenuItem.Name = "InsertSeparatorMenuItem";
             this.InsertSeparatorMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-            this.InsertSeparatorMenuItem.Size = new System.Drawing.Size(244, 22);
             this.InsertSeparatorMenuItem.Text = "Insert Separator";
             this.InsertSeparatorMenuItem.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
             // 
             // ClearChangeCountsMenuItem
             // 
-            this.ClearChangeCountsMenuItem.Name = "ClearChangeCountsMenuItem";
             this.ClearChangeCountsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.C)));
-            this.ClearChangeCountsMenuItem.Size = new System.Drawing.Size(244, 22);
             this.ClearChangeCountsMenuItem.Text = "&Clear Change Counts";
             this.ClearChangeCountsMenuItem.Click += new System.EventHandler(this.ClearChangeCountsMenuItem_Click);
             // 
@@ -668,43 +600,33 @@ namespace BizHawk.Client.EmuHawk
             // 
             // MoveUpMenuItem
             // 
-            this.MoveUpMenuItem.Name = "MoveUpMenuItem";
             this.MoveUpMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
-            this.MoveUpMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveUpMenuItem.Text = "Move &Up";
             this.MoveUpMenuItem.Click += new System.EventHandler(this.MoveUpMenuItem_Click);
             // 
             // MoveDownMenuItem
             // 
-            this.MoveDownMenuItem.Name = "MoveDownMenuItem";
             this.MoveDownMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
-            this.MoveDownMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveDownMenuItem.Text = "Move &Down";
             this.MoveDownMenuItem.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
             // 
             // MoveTopMenuItem
             // 
-            this.MoveTopMenuItem.Name = "MoveTopMenuItem";
             this.MoveTopMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Up)));
-            this.MoveTopMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveTopMenuItem.Text = "Move &Top";
             this.MoveTopMenuItem.Click += new System.EventHandler(this.MoveTopMenuItem_Click);
             // 
             // MoveBottomMenuItem
             // 
-            this.MoveBottomMenuItem.Name = "MoveBottomMenuItem";
             this.MoveBottomMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Down)));
-            this.MoveBottomMenuItem.Size = new System.Drawing.Size(244, 22);
             this.MoveBottomMenuItem.Text = "Move &Bottom";
             this.MoveBottomMenuItem.Click += new System.EventHandler(this.MoveBottomMenuItem_Click);
             // 
             // SelectAllMenuItem
             // 
-            this.SelectAllMenuItem.Name = "SelectAllMenuItem";
             this.SelectAllMenuItem.ShortcutKeyDisplayString = "Ctrl+A";
-            this.SelectAllMenuItem.Size = new System.Drawing.Size(244, 22);
             this.SelectAllMenuItem.Text = "Select &All";
             this.SelectAllMenuItem.Click += new System.EventHandler(this.SelectAllMenuItem_Click);
 			// 
@@ -718,8 +640,6 @@ namespace BizHawk.Client.EmuHawk
             this.FloatingWindowMenuItem,
             this.toolStripSeparator7,
             this.RestoreWindowSizeMenuItem});
-            this.OptionsSubMenu.Name = "OptionsSubMenu";
-            this.OptionsSubMenu.Size = new System.Drawing.Size(61, 20);
             this.OptionsSubMenu.Text = "&Options";
             this.OptionsSubMenu.DropDownOpened += new System.EventHandler(this.OptionsSubMenu_DropDownOpened);
             // 
@@ -729,57 +649,41 @@ namespace BizHawk.Client.EmuHawk
             this.PreviousFrameMenuItem,
             this.LastChangeMenuItem,
             this.OriginalMenuItem});
-            this.DefinePreviousValueSubMenu.Name = "DefinePreviousValueSubMenu";
-            this.DefinePreviousValueSubMenu.Size = new System.Drawing.Size(217, 22);
             this.DefinePreviousValueSubMenu.Text = "Define Previous Value";
             this.DefinePreviousValueSubMenu.DropDownOpened += new System.EventHandler(this.DefinePreviousValueSubMenu_DropDownOpened);
             // 
             // PreviousFrameMenuItem
             // 
-            this.PreviousFrameMenuItem.Name = "PreviousFrameMenuItem";
-            this.PreviousFrameMenuItem.Size = new System.Drawing.Size(155, 22);
             this.PreviousFrameMenuItem.Text = "Previous Frame";
             this.PreviousFrameMenuItem.Click += new System.EventHandler(this.PreviousFrameMenuItem_Click);
             // 
             // LastChangeMenuItem
             // 
-            this.LastChangeMenuItem.Name = "LastChangeMenuItem";
-            this.LastChangeMenuItem.Size = new System.Drawing.Size(155, 22);
             this.LastChangeMenuItem.Text = "Last Change";
             this.LastChangeMenuItem.Click += new System.EventHandler(this.LastChangeMenuItem_Click);
             // 
             // OriginalMenuItem
             // 
-            this.OriginalMenuItem.Name = "OriginalMenuItem";
-            this.OriginalMenuItem.Size = new System.Drawing.Size(155, 22);
             this.OriginalMenuItem.Text = "&Original";
             this.OriginalMenuItem.Click += new System.EventHandler(this.OriginalMenuItem_Click);
             // 
             // WatchesOnScreenMenuItem
             // 
-            this.WatchesOnScreenMenuItem.Name = "WatchesOnScreenMenuItem";
-            this.WatchesOnScreenMenuItem.Size = new System.Drawing.Size(217, 22);
             this.WatchesOnScreenMenuItem.Text = "Display Watches On Screen";
             this.WatchesOnScreenMenuItem.Click += new System.EventHandler(this.WatchesOnScreenMenuItem_Click);
             // 
             // SaveWindowPositionMenuItem
             // 
-            this.SaveWindowPositionMenuItem.Name = "SaveWindowPositionMenuItem";
-            this.SaveWindowPositionMenuItem.Size = new System.Drawing.Size(217, 22);
             this.SaveWindowPositionMenuItem.Text = "Save Window Position";
             this.SaveWindowPositionMenuItem.Click += new System.EventHandler(this.SaveWindowPositionMenuItem_Click);
             // 
             // AlwaysOnTopMenuItem
             // 
-            this.AlwaysOnTopMenuItem.Name = "AlwaysOnTopMenuItem";
-            this.AlwaysOnTopMenuItem.Size = new System.Drawing.Size(217, 22);
             this.AlwaysOnTopMenuItem.Text = "&Always On Top";
             this.AlwaysOnTopMenuItem.Click += new System.EventHandler(this.AlwaysOnTopMenuItem_Click);
             // 
             // FloatingWindowMenuItem
             // 
-            this.FloatingWindowMenuItem.Name = "FloatingWindowMenuItem";
-            this.FloatingWindowMenuItem.Size = new System.Drawing.Size(217, 22);
             this.FloatingWindowMenuItem.Text = "&Floating Window";
             this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
             // 
@@ -790,8 +694,6 @@ namespace BizHawk.Client.EmuHawk
             // 
             // RestoreWindowSizeMenuItem
             // 
-            this.RestoreWindowSizeMenuItem.Name = "RestoreWindowSizeMenuItem";
-            this.RestoreWindowSizeMenuItem.Size = new System.Drawing.Size(217, 22);
             this.RestoreWindowSizeMenuItem.Text = "Restore Default Settings";
             this.RestoreWindowSizeMenuItem.Click += new System.EventHandler(this.RestoreDefaultsMenuItem_Click);
             // 
@@ -854,39 +756,39 @@ namespace BizHawk.Client.EmuHawk
 
 		private InputRoll WatchListView;
 		private MenuStripEx RamWatchMenu;
-		private System.Windows.Forms.ToolStripMenuItem FileSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem NewListMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OpenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveAsMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AppendMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RecentSubMenu;
-        private System.Windows.Forms.ToolStripMenuItem noneToolStripMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FileSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewListMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OpenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveAsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-		private System.Windows.Forms.ToolStripMenuItem ExitMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem WatchesSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem MemoryDomainsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WatchesSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsSubMenu;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
-		private System.Windows.Forms.ToolStripMenuItem NewWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem EditWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DuplicateWatchMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FreezeAddressMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem InsertSeparatorMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ClearChangeCountsMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DuplicateWatchMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeparatorMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearChangeCountsMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-		private System.Windows.Forms.ToolStripMenuItem MoveUpMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MoveDownMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SelectAllMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem OptionsSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem DefinePreviousValueSubMenu;
-		private System.Windows.Forms.ToolStripMenuItem PreviousFrameMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem LastChangeMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem WatchesOnScreenMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem SaveWindowPositionMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OptionsSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DefinePreviousValueSubMenu;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PreviousFrameMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LastChangeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WatchesOnScreenMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveWindowPositionMenuItem;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-		private System.Windows.Forms.ToolStripMenuItem RestoreWindowSizeMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestoreWindowSizeMenuItem;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton newToolStripButton;
 		private System.Windows.Forms.ToolStripButton openToolStripButton;
@@ -905,32 +807,32 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton moveDownToolStripButton;
 		private BizHawk.WinForms.Controls.LocLabelEx WatchCountLabel;
 		private System.Windows.Forms.ToolStripSeparator Separator2;
-		private System.Windows.Forms.ToolStripMenuItem OriginalMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OriginalMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ListViewContextMenu;
-		private System.Windows.Forms.ToolStripMenuItem EditContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem RemoveContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem DuplicateContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem PokeContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FreezeContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem UnfreezeAllContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem ViewInHexEditorContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx DuplicateContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx PokeContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
 		private System.Windows.Forms.ToolStripSeparator Separator6;
-		private System.Windows.Forms.ToolStripMenuItem InsertSeperatorContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MoveUpContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem MoveDownContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem AlwaysOnTopMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem FloatingWindowMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeperatorContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AlwaysOnTopMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FloatingWindowMenuItem;
 		private StatusStripEx statusStrip1;
 		private System.Windows.Forms.ToolStripStatusLabel MessageLabel;
 		private System.Windows.Forms.ToolStripButton ErrorIconButton;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
 		private System.Windows.Forms.ToolStripSeparator Separator4;
-		private System.Windows.Forms.ToolStripMenuItem ReadBreakpointContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem WriteBreakpointContextMenuItem;
-		private System.Windows.Forms.ToolStripMenuItem newToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem MoveTopMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem MoveBottomMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem MoveTopContextMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem MoveBottomContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReadBreakpointContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WriteBreakpointContextMenuItem;
+		private BizHawk.WinForms.Controls.ToolStripMenuItemEx newToolStripMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveTopMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveBottomMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveTopContextMenuItem;
+        private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveBottomContextMenuItem;
     }
 }

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
@@ -41,10 +41,10 @@ namespace BizHawk.Client.EmuHawk
             this.FreezeContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.UnfreezeAllContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.ViewInHexEditorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Separator4 = new System.Windows.Forms.ToolStripSeparator();
+            this.Separator4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.ReadBreakpointContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.WriteBreakpointContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Separator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.Separator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.InsertSeperatorContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.MoveUpContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.MoveDownContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -57,7 +57,7 @@ namespace BizHawk.Client.EmuHawk
             this.newToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.openToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.saveToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.newWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.editWatchToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.cutToolStripButton = new System.Windows.Forms.ToolStripButton();
@@ -66,10 +66,10 @@ namespace BizHawk.Client.EmuHawk
             this.PokeAddressToolBarItem = new System.Windows.Forms.ToolStripButton();
             this.FreezeAddressToolBarItem = new System.Windows.Forms.ToolStripButton();
             this.seperatorToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator6 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.moveUpToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.moveDownToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator5 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.RamWatchMenu = new MenuStripEx();
             this.FileSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.NewListMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -79,12 +79,12 @@ namespace BizHawk.Client.EmuHawk
             this.AppendMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.RecentSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.noneToolStripMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator1 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.ExitMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.WatchesSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.MemoryDomainsSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.Separator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.Separator2 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
+            this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.NewWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.EditWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.RemoveWatchMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -93,7 +93,7 @@ namespace BizHawk.Client.EmuHawk
             this.FreezeAddressMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.InsertSeparatorMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.ClearChangeCountsMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator3 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.MoveUpMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.MoveDownMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.MoveTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -108,7 +108,7 @@ namespace BizHawk.Client.EmuHawk
             this.SaveWindowPositionMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.AlwaysOnTopMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.FloatingWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator7 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
             this.RestoreWindowSizeMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
             this.WatchListView = new InputRoll();
             this.ListViewContextMenu.SuspendLayout();
@@ -192,11 +192,6 @@ namespace BizHawk.Client.EmuHawk
             this.ViewInHexEditorContextMenuItem.Text = "View in Hex Editor";
             this.ViewInHexEditorContextMenuItem.Click += new System.EventHandler(this.ViewInHexEditorContextMenuItem_Click);
             // 
-            // Separator4
-            // 
-            this.Separator4.Name = "Separator4";
-            this.Separator4.Size = new System.Drawing.Size(241, 6);
-            // 
             // ReadBreakpointContextMenuItem
             // 
             this.ReadBreakpointContextMenuItem.Text = "Set Read Breakpoint";
@@ -206,11 +201,6 @@ namespace BizHawk.Client.EmuHawk
             // 
             this.WriteBreakpointContextMenuItem.Text = "Set Write Breakpoint";
             this.WriteBreakpointContextMenuItem.Click += new System.EventHandler(this.WriteBreakpointContextMenuItem_Click);
-            // 
-            // Separator6
-            // 
-            this.Separator6.Name = "Separator6";
-            this.Separator6.Size = new System.Drawing.Size(241, 6);
             // 
             // InsertSeperatorContextMenuItem
             // 
@@ -320,11 +310,6 @@ namespace BizHawk.Client.EmuHawk
             this.saveToolStripButton.Text = "&Save";
             this.saveToolStripButton.Click += new System.EventHandler(this.SaveMenuItem_Click);
             // 
-            // toolStripSeparator
-            // 
-            this.toolStripSeparator.Name = "toolStripSeparator";
-            this.toolStripSeparator.Size = new System.Drawing.Size(6, 25);
-            // 
             // newWatchToolStripButton
             // 
             this.newWatchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -402,11 +387,6 @@ namespace BizHawk.Client.EmuHawk
             this.seperatorToolStripButton.ToolTipText = "Insert Separator";
             this.seperatorToolStripButton.Click += new System.EventHandler(this.InsertSeparatorMenuItem_Click);
             // 
-            // toolStripSeparator6
-            // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(6, 25);
-            // 
             // moveUpToolStripButton
             // 
             this.moveUpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -424,11 +404,6 @@ namespace BizHawk.Client.EmuHawk
             this.moveDownToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.moveDownToolStripButton.Text = "Move Down";
             this.moveDownToolStripButton.Click += new System.EventHandler(this.MoveDownMenuItem_Click);
-            // 
-            // toolStripSeparator5
-            // 
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
 			// 
             // RamWatchMenu
             // 
@@ -495,11 +470,6 @@ namespace BizHawk.Client.EmuHawk
             // 
             this.noneToolStripMenuItem.Text = "None";
             // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(192, 6);
-            // 
             // ExitMenuItem
             // 
             this.ExitMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
@@ -534,16 +504,6 @@ namespace BizHawk.Client.EmuHawk
             this.Separator2});
             this.MemoryDomainsSubMenu.Text = "Default Domain";
             this.MemoryDomainsSubMenu.DropDownOpened += new System.EventHandler(this.MemoryDomainsSubMenu_DropDownOpened);
-            // 
-            // Separator2
-            // 
-            this.Separator2.Name = "Separator2";
-            this.Separator2.Size = new System.Drawing.Size(57, 6);
-            // 
-            // toolStripSeparator8
-            // 
-            this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(241, 6);
             // 
             // NewWatchMenuItem
             // 
@@ -592,11 +552,6 @@ namespace BizHawk.Client.EmuHawk
             this.ClearChangeCountsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.C)));
             this.ClearChangeCountsMenuItem.Text = "&Clear Change Counts";
             this.ClearChangeCountsMenuItem.Click += new System.EventHandler(this.ClearChangeCountsMenuItem_Click);
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(241, 6);
             // 
             // MoveUpMenuItem
             // 
@@ -687,11 +642,6 @@ namespace BizHawk.Client.EmuHawk
             this.FloatingWindowMenuItem.Text = "&Floating Window";
             this.FloatingWindowMenuItem.Click += new System.EventHandler(this.FloatingWindowMenuItem_Click);
             // 
-            // toolStripSeparator7
-            // 
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(214, 6);
-            // 
             // RestoreWindowSizeMenuItem
             // 
             this.RestoreWindowSizeMenuItem.Text = "Restore Default Settings";
@@ -764,11 +714,11 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx AppendMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RecentSubMenu;
         private BizHawk.WinForms.Controls.ToolStripMenuItemEx noneToolStripMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator1;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ExitMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WatchesSubMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MemoryDomainsSubMenu;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NewWatchMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditWatchMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RemoveWatchMenuItem;
@@ -777,7 +727,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeAddressMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeparatorMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ClearChangeCountsMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator3;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SelectAllMenuItem;
@@ -787,13 +737,13 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx LastChangeMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WatchesOnScreenMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx SaveWindowPositionMenuItem;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator7;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx RestoreWindowSizeMenuItem;
 		private ToolStripEx toolStrip1;
 		private System.Windows.Forms.ToolStripButton newToolStripButton;
 		private System.Windows.Forms.ToolStripButton openToolStripButton;
 		private System.Windows.Forms.ToolStripButton saveToolStripButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator;
 		private System.Windows.Forms.ToolStripButton newWatchToolStripButton;
 		private System.Windows.Forms.ToolStripButton editWatchToolStripButton;
 		private System.Windows.Forms.ToolStripButton cutToolStripButton;
@@ -802,11 +752,11 @@ namespace BizHawk.Client.EmuHawk
 		private System.Windows.Forms.ToolStripButton PokeAddressToolBarItem;
 		private System.Windows.Forms.ToolStripButton FreezeAddressToolBarItem;
 		private System.Windows.Forms.ToolStripButton seperatorToolStripButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator5;
 		private System.Windows.Forms.ToolStripButton moveUpToolStripButton;
 		private System.Windows.Forms.ToolStripButton moveDownToolStripButton;
 		private BizHawk.WinForms.Controls.LocLabelEx WatchCountLabel;
-		private System.Windows.Forms.ToolStripSeparator Separator2;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx Separator2;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx OriginalMenuItem;
 		private System.Windows.Forms.ContextMenuStrip ListViewContextMenu;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx EditContextMenuItem;
@@ -816,7 +766,7 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx FreezeContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx UnfreezeAllContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ViewInHexEditorContextMenuItem;
-		private System.Windows.Forms.ToolStripSeparator Separator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx Separator6;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx InsertSeperatorContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveUpContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx MoveDownContextMenuItem;
@@ -825,8 +775,8 @@ namespace BizHawk.Client.EmuHawk
 		private StatusStripEx statusStrip1;
 		private System.Windows.Forms.ToolStripStatusLabel MessageLabel;
 		private System.Windows.Forms.ToolStripButton ErrorIconButton;
-		private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-		private System.Windows.Forms.ToolStripSeparator Separator4;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator6;
+		private BizHawk.WinForms.Controls.ToolStripSeparatorEx Separator4;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx ReadBreakpointContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx WriteBreakpointContextMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx newToolStripMenuItem;

--- a/src/BizHawk.WinForms.Controls/MenuEx/MenuItemEx.cs
+++ b/src/BizHawk.WinForms.Controls/MenuEx/MenuItemEx.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace BizHawk.WinForms.Controls
+{
+	public class ToolStripMenuItemEx : ToolStripMenuItem
+	{
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new Size Size => base.Size;
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new string Name => Guid.NewGuid().ToString();
+	}
+
+	public class ToolStripSeparatorEx : ToolStripSeparator
+	{
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new Size Size => base.Size;
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new string Name => Guid.NewGuid().ToString();
+	}
+}

--- a/src/BizHawk.WinForms.Controls/MenuEx/StatusLabelEx.cs
+++ b/src/BizHawk.WinForms.Controls/MenuEx/StatusLabelEx.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace BizHawk.WinForms.Controls
+{
+	public class StatusLabelEx : ToolStripStatusLabel
+	{
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new Size Size => base.Size;
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public new string Name => Guid.NewGuid().ToString();
+	}
+}


### PR DESCRIPTION
Add various controls that do not need a size parameter, and use them consistently.  Particularly useful is the toolstrip separator that now has no auto-generator designer properties!  Greatly reduces auto-generated code, particularly unused size variables that change based on the developer's DPI settings