### PR TITLE
Keep emuVersion up-to-date when saving movies

### DIFF
--- a/src/BizHawk.Client.Common/movie/HeaderKeys.cs
+++ b/src/BizHawk.Client.Common/movie/HeaderKeys.cs
@@ -4,7 +4,8 @@ namespace BizHawk.Client.Common
 {
 	public static class HeaderKeys
 	{
-		public const string EmulationVersion = "emuVersion";
+		public const string EmulatorVersion = "emuVersion";
+		public const string OriginalEmulatorVersion = "OriginalEmuVersion";
 		public const string MovieVersion = "MovieVersion";
 		public const string Platform = "Platform";
 		public const string GameName = "GameName";

--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -191,6 +191,7 @@ namespace BizHawk.Client.Common
 		{
 			movie.Author = author;
 			movie.EmulatorVersion = VersionInfo.GetEmuVersion();
+			movie.OriginalEmulatorVersion = VersionInfo.GetEmuVersion();
 			movie.SystemID = emulator.SystemId;
 
 			var settable = new SettingsAdapter(emulator);

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
@@ -167,13 +167,26 @@ namespace BizHawk.Client.Common
 
 		public string EmulatorVersion
 		{
-			get => Header[HeaderKeys.EmulationVersion];
+			get => Header[HeaderKeys.EmulatorVersion];
 			set
 			{
-				if (Header[HeaderKeys.EmulationVersion] != value)
+				if (Header[HeaderKeys.EmulatorVersion] != value)
 				{
 					Changes = true;
-					Header[HeaderKeys.EmulationVersion] = value;
+					Header[HeaderKeys.EmulatorVersion] = value;
+				}
+			}
+		}
+
+		public string OriginalEmulatorVersion
+		{
+			get => Header[HeaderKeys.OriginalEmulatorVersion];
+			set
+			{
+				if (Header[HeaderKeys.OriginalEmulatorVersion] != value)
+				{
+					Changes = true;
+					Header[HeaderKeys.OriginalEmulatorVersion] = value;
 				}
 			}
 		}

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
@@ -176,6 +176,12 @@ namespace BizHawk.Client.Common
 					}
 				}
 			});
+			// EmulatorVersion used to store the unchanging original emulator version.
+			if (!Header.ContainsKey(HeaderKeys.OriginalEmulatorVersion))
+			{
+				Header[HeaderKeys.OriginalEmulatorVersion] = Header[HeaderKeys.EmulatorVersion];
+			}
+			Header[HeaderKeys.EmulatorVersion] = VersionInfo.GetEmuVersion();
 
 			bl.GetLump(BinaryStateLump.Comments, false, delegate(TextReader tr)
 			{

--- a/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
+++ b/src/BizHawk.Client.Common/movie/interfaces/IMovie.cs
@@ -90,6 +90,7 @@ namespace BizHawk.Client.Common
 		string Author { get; set; }
 		string Core { get; set; }
 		string EmulatorVersion { get; set; }
+		string OriginalEmulatorVersion { get; set; }
 		string FirmwareHash { get; set; }
 		string BoardName { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
+++ b/src/BizHawk.Client.EmuHawk/movie/PlayMovie.cs
@@ -420,7 +420,7 @@ namespace BizHawk.Client.EmuHawk
 							toolTip1.SetToolTip(DetailsView, $"Current SHA1: {_game.Hash}");
 						}
 						break;
-					case HeaderKeys.EmulationVersion:
+					case HeaderKeys.EmulatorVersion:
 						if (kvp.Value != VersionInfo.GetEmuVersion())
 						{
 							item.BackColor = Color.Yellow;


### PR DESCRIPTION
This main goal is to address #2152. There are a few alternatives to the specific implementation I propose here:

1) As feos suggested, maintain a list of all emulator versions that have edited a movie. This could be a set or a sequential list.

2) Don't even maintain OriginalEmuVersion as a field, and move it to the Comments, in the same way as some information from converted movies is stored. This has the downside of automatically populating comments for every new movie created.

3) Just don't even keep OriginalEmuVersion. Not preferrable in my opinion, because it's interesting info and may be useful to get back in some cases.