### PR TITLE
Merge redundant copy-pasted movie loading code.

### DIFF
--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.HeaderApi.cs
@@ -32,7 +32,8 @@ namespace BizHawk.Client.Common
 			{
 				if (!Header.ContainsKey(HeaderKeys.Rerecords))
 				{
-					Header[HeaderKeys.Rerecords] = "0";
+					// Modifying the header itself can cause a race condition between loading a movie and rendering the rerecord count, causing a movie's rerecord count to be overwritten with 0 during loading.
+					return 0;
 				}
 
 				return ulong.Parse(Header[HeaderKeys.Rerecords]);

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
@@ -42,7 +42,121 @@ namespace BizHawk.Client.Common
 			}
 
 			ClearBeforeLoad();
+			LoadFields(bl, preload);
 
+			Changes = false;
+			return true;
+		}
+
+		public bool PreLoadHeaderAndLength(HawkFile hawkFile)
+		{
+			var file = new FileInfo(Filename);
+			if (!file.Exists)
+			{
+				return false;
+			}
+
+			Filename = file.FullName;
+			return Load(true);
+		}
+
+		protected virtual void Write(string fn, bool isBackup = false)
+		{
+			SetCycleValues(); // We are pretending these only need to be set on save
+			CreateDirectoryIfNotExists(fn);
+
+			using var bs = new ZipStateSaver(fn, Session.Settings.MovieCompressionLevel);
+			AddLumps(bs);
+
+			if (!isBackup)
+			{
+				Changes = false;
+			}
+		}
+
+		private void SetCycleValues()
+		{
+			if (Emulator is Emulation.Cores.Nintendo.SubNESHawk.SubNESHawk subNes)
+			{
+				Header[HeaderKeys.VBlankCount] = subNes.VblankCount.ToString();
+			}
+			else if (Emulator is Emulation.Cores.Nintendo.Gameboy.Gameboy gameboy)
+			{
+				Header[HeaderKeys.CycleCount] = gameboy.CycleCount.ToString();
+			}
+			else if (Emulator is Emulation.Cores.Nintendo.SubGBHawk.SubGBHawk subGb)
+			{
+				Header[HeaderKeys.CycleCount] = subGb.CycleCount.ToString();
+			}
+		}
+
+		private void CreateDirectoryIfNotExists(string fn)
+		{
+			var file = new FileInfo(fn);
+			if (file.Directory != null && !file.Directory.Exists)
+			{
+				Directory.CreateDirectory(file.Directory.ToString());
+			}
+		}
+
+		protected virtual void AddLumps(ZipStateSaver bs, bool isBackup = false)
+		{
+			AddBk2Lumps(bs);
+		}
+
+		protected void AddBk2Lumps(ZipStateSaver bs)
+		{
+			bs.PutLump(BinaryStateLump.Movieheader, tw => tw.WriteLine(Header.ToString()));
+			bs.PutLump(BinaryStateLump.Comments, tw => tw.WriteLine(CommentsString()));
+			bs.PutLump(BinaryStateLump.Subtitles, tw => tw.WriteLine(Subtitles.ToString()));
+			bs.PutLump(BinaryStateLump.SyncSettings, tw => tw.WriteLine(SyncSettingsJson));
+			bs.PutLump(BinaryStateLump.Input, WriteInputLog);
+
+			if (StartsFromSavestate)
+			{
+				if (TextSavestate != null)
+				{
+					bs.PutLump(BinaryStateLump.CorestateText, (TextWriter tw) => tw.Write(TextSavestate));
+				}
+				else
+				{
+					bs.PutLump(BinaryStateLump.Corestate, (BinaryWriter bw) => bw.Write(BinarySavestate));
+				}
+
+				if (SavestateFramebuffer != null)
+				{
+					bs.PutLump(BinaryStateLump.Framebuffer, (BinaryWriter bw) => bw.Write(SavestateFramebuffer));
+				}
+			}
+			else if (StartsFromSaveRam)
+			{
+				bs.PutLump(BinaryStateLump.MovieSaveRam, (BinaryWriter bw) => bw.Write(SaveRam));
+			}
+		}
+
+		protected virtual void ClearBeforeLoad()
+		{
+			ClearBk2Fields();
+		}
+		
+		protected void ClearBk2Fields()
+		{
+			Header.Clear();
+			Log.Clear();
+			Subtitles.Clear();
+			Comments.Clear();
+			_syncSettingsJson = "";
+			TextSavestate = null;
+			BinarySavestate = null;
+		}
+		
+		protected virtual void LoadFields(ZipStateLoader bl, bool preload)
+		{
+			LoadBk2Fields(bl);
+		}
+		
+		protected void LoadBk2Fields(ZipStateLoader bl)
+		{
 			bl.GetLump(BinaryStateLump.Movieheader, true, delegate(TextReader tr)
 			{
 				string line;
@@ -137,106 +251,6 @@ namespace BizHawk.Client.Common
 						SaveRam = br.ReadBytes((int)length);
 					});
 			}
-
-			Changes = false;
-			return true;
-		}
-
-		public bool PreLoadHeaderAndLength(HawkFile hawkFile)
-		{
-			var file = new FileInfo(Filename);
-			if (!file.Exists)
-			{
-				return false;
-			}
-
-			Filename = file.FullName;
-			return Load(true);
-		}
-
-		protected virtual void Write(string fn, bool isBackup = false)
-		{
-			SetCycleValues(); // We are pretending these only need to be set on save
-			CreateDirectoryIfNotExists(fn);
-
-			using var bs = new ZipStateSaver(fn, Session.Settings.MovieCompressionLevel);
-			AddLumps(bs);
-
-			if (!isBackup)
-			{
-				Changes = false;
-			}
-		}
-
-		private void SetCycleValues()
-		{
-			if (Emulator is Emulation.Cores.Nintendo.SubNESHawk.SubNESHawk subNes)
-			{
-				Header[HeaderKeys.VBlankCount] = subNes.VblankCount.ToString();
-			}
-			else if (Emulator is Emulation.Cores.Nintendo.Gameboy.Gameboy gameboy)
-			{
-				Header[HeaderKeys.CycleCount] = gameboy.CycleCount.ToString();
-			}
-			else if (Emulator is Emulation.Cores.Nintendo.SubGBHawk.SubGBHawk subGb)
-			{
-				Header[HeaderKeys.CycleCount] = subGb.CycleCount.ToString();
-			}
-		}
-
-		private void CreateDirectoryIfNotExists(string fn)
-		{
-			var file = new FileInfo(fn);
-			if (file.Directory != null && !file.Directory.Exists)
-			{
-				Directory.CreateDirectory(file.Directory.ToString());
-			}
-		}
-
-		protected virtual void AddLumps(ZipStateSaver bs, bool isBackup = false)
-		{
-			AddBk2Lumps(bs);
-		}
-
-		protected void AddBk2Lumps(ZipStateSaver bs)
-		{
-			bs.PutLump(BinaryStateLump.Movieheader, tw => tw.WriteLine(Header.ToString()));
-			bs.PutLump(BinaryStateLump.Comments, tw => tw.WriteLine(CommentsString()));
-			bs.PutLump(BinaryStateLump.Subtitles, tw => tw.WriteLine(Subtitles.ToString()));
-			bs.PutLump(BinaryStateLump.SyncSettings, tw => tw.WriteLine(SyncSettingsJson));
-			bs.PutLump(BinaryStateLump.Input, WriteInputLog);
-
-			if (StartsFromSavestate)
-			{
-				if (TextSavestate != null)
-				{
-					bs.PutLump(BinaryStateLump.CorestateText, (TextWriter tw) => tw.Write(TextSavestate));
-				}
-				else
-				{
-					bs.PutLump(BinaryStateLump.Corestate, (BinaryWriter bw) => bw.Write(BinarySavestate));
-				}
-
-				if (SavestateFramebuffer != null)
-				{
-					bs.PutLump(BinaryStateLump.Framebuffer, (BinaryWriter bw) => bw.Write(SavestateFramebuffer));
-				}
-			}
-			else if (StartsFromSaveRam)
-			{
-				bs.PutLump(BinaryStateLump.MovieSaveRam, (BinaryWriter bw) => bw.Write(SaveRam));
-			}
-		}
-
-		protected void ClearBeforeLoad()
-		{
-			Header.Clear();
-			Log.Clear();
-			Subtitles.Clear();
-			Comments.Clear();
-			_syncSettingsJson = "";
-			TextSavestate = null;
-			BinarySavestate = null;
 		}
 	}
 }


### PR DESCRIPTION
Split off from my ill-constructed #2193, which had its purpose muddied by the differently-motivated changes presented here.

Before I implemented my direct goal of altering emuVersion, I found a significant redundancy between Bk2Movie and TASMovie's Load() that seemed necessary to correct before adding new behavior. Along with significantly reducing the amount of code to maintain (removing almost 100 lines), the first change also makes Bk2 and TASMovie behavior more consistent:

- Duplicate keys in the header now use the first value given ([previously Bk2Movie-specific](https://github.com/TASVideos/BizHawk/commit/dd28c386de642e7858d910b7f53e9144f2bc2cbb)). Incidentally, testing exposed a race condition between rerecords and rendering related to this, which could have caused movie's rerecord count to be overwritten by 0 during the loading process.
- Subtitles are now sorted when loaded ([previously Bk2Movie-specific](https://github.com/TASVideos/BizHawk/commit/35a07f42eb2f023306e022f03a8a9cf9932735ed))
- Movies missing Comments, Subtitles, or SyncSettings will no longer be aborted during loading (previously Bk2Movie-specific [1](https://github.com/TASVideos/BizHawk/commit/21ae27dd9486653982f911715d1dd01a146eb861), [2](https://github.com/TASVideos/BizHawk/commit/5a408f9321fe99da518bb19e3452cfb763812aea))
- Savestate-anchored tasprojs will now load the framebuffer ([previously Bk2Movie-specific](https://github.com/TASVideos/BizHawk/commit/daf74eb91be9832e9588ea1b3b186d621346cd64)); this may be unnecessary for tasprojs, but it won't hurt anything because it's ignored if it's missing.

Deleting redundant code did not mean TASMovie's differences weren't taken into consideration. The main functionality of Load() had some differences, so these were split into separate overridable methods ClearBeforeLoad() and LoadFields(), with these methods overriden to call both the original code and Tasproj-specific code.