### PR TITLE
Make tastudio automatically switch to read-only mode when input painting

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/PlaybackBox.cs
@@ -127,7 +127,6 @@ namespace BizHawk.Client.EmuHawk
 		private void RecordingModeCheckbox_MouseClick(object sender, MouseEventArgs e)
 		{
 			RecordingMode ^= true;
-			Tastudio.WasRecording = RecordingMode; // hard reset at manual click
 		}
 
 		private void RewindButton_MouseDown(object sender, MouseEventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -62,7 +62,6 @@ namespace BizHawk.Client.EmuHawk
 
 		private ControllerDefinition ControllerType => MovieSession.MovieController.Definition;
 
-		public bool WasRecording { get; set; }
 		public AutoPatternBool[] BoolPatterns;
 		public AutoPatternAxis[] AxisPatterns;
 
@@ -85,7 +84,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (MainForm.PauseOnFrame != null)
 				{
-					StopSeeking(true); // don't restore rec mode just yet, as with heavy editing checkbox updating causes lag
+					StopSeeking();
 				}
 				_seekStartFrame = Emulator.Frame;
 			}
@@ -93,7 +92,6 @@ namespace BizHawk.Client.EmuHawk
 			MainForm.PauseOnFrame = frame.Value;
 			int? diff = MainForm.PauseOnFrame - _seekStartFrame;
 
-			WasRecording = CurrentTasMovie.IsRecording() || WasRecording;
 			TastudioPlayMode(); // suspend rec mode until seek ends, to allow mouse editing
 			MainForm.UnpauseEmulator();
 
@@ -103,14 +101,9 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		public void StopSeeking(bool skipRecModeCheck = false)
+		public void StopSeeking()
 		{
 			_seekBackgroundWorker.CancelAsync();
-			if (WasRecording && !skipRecModeCheck)
-			{
-				TastudioRecordMode();
-				WasRecording = false;
-			}
 
 			MainForm.PauseOnFrame = null;
 			if (_unpauseAfterSeeking)
@@ -553,7 +546,6 @@ namespace BizHawk.Client.EmuHawk
 
 			int frame = TasView.CurrentCell.RowIndex.Value;
 			string buttonName = TasView.CurrentCell.Column.Name;
-			WasRecording = CurrentTasMovie.IsRecording() || WasRecording;
 
 			if (e.Button == MouseButtons.Left)
 			{
@@ -966,7 +958,6 @@ namespace BizHawk.Client.EmuHawk
 			// skip rerecord counting on drawing entirely, mouse down is enough
 			// avoid introducing another global
 			bool wasCountingRerecords = CurrentTasMovie.IsCountingRerecords;
-			WasRecording = CurrentTasMovie.IsRecording() || WasRecording;
 
 			int startVal, endVal;
 			int frame = e.NewCell.RowIndex.Value;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Navigation.cs
@@ -1,6 +1,4 @@
-﻿using BizHawk.Client.Common;
-
-namespace BizHawk.Client.EmuHawk
+﻿namespace BizHawk.Client.EmuHawk
 {
 	public partial class TAStudio
 	{
@@ -29,8 +27,6 @@ namespace BizHawk.Client.EmuHawk
 		{
 			// If seeking to a frame before or at the end of the movie, use StartAtNearestFrameAndEmulate
 			// Otherwise, load the latest state (if not already there) and seek while recording.
-			WasRecording = CurrentTasMovie.IsRecording() || WasRecording;
-
 			if (frame <= CurrentTasMovie.InputLogLength)
 			{
 				// Get as close as we can then emulate there

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -961,7 +961,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			_unpauseAfterSeeking = (fromRewinding || WasRecording) && !MainForm.EmulatorPaused;
+			_unpauseAfterSeeking = fromRewinding && !MainForm.EmulatorPaused;
 			TastudioPlayMode();
 			var closestState = CurrentTasMovie.TasStateManager.GetStateClosestToFrame(frame);
 			if (closestState.Value.Length > 0 && (frame < Emulator.Frame || closestState.Key > Emulator.Frame))
@@ -986,21 +986,13 @@ namespace BizHawk.Client.EmuHawk
 				{
 					MainForm.UnpauseEmulator();
 				}
-
-				// lua botting users will want to re-activate record mode automatically -- it should be like nothing ever happened
-				if (WasRecording)
-				{
-					TastudioRecordMode();
-				}
-
-				// now the next section won't happen since we're at the right spot
 			}
 
 			// frame == Emulator.Frame when frame == 0
 			if (frame > Emulator.Frame)
 			{
 				// make seek frame keep up with emulation on fast scrolls
-				if (MainForm.EmulatorPaused || MainForm.IsSeeking || fromRewinding || WasRecording)
+				if (MainForm.EmulatorPaused || MainForm.IsSeeking || fromRewinding)
 				{
 					StartSeeking(frame);
 				}


### PR DESCRIPTION
The approach is simple, remove all the code that was try really hard to not make this happen automatically. This is to address the feature request in #2144

I'd like some feedback here. What situations am I not considering?