### PR TITLE
Move some more stuff to Client.Common

### DIFF
--- a/src/BizHawk.Client.Common/DisplayManager/DisplaySurface.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/DisplaySurface.cs
@@ -4,7 +4,7 @@ using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using BizHawk.Common;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// This is a wrapper for a Bitmap, basically, which can also be a int[].

--- a/src/BizHawk.Client.Common/DisplayManager/FilterManager.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/FilterManager.cs
@@ -1,12 +1,12 @@
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Drawing;
-using BizHawk.Client.EmuHawk.Filters;
+using BizHawk.Client.Common.Filters;
 
 using BizHawk.Bizware.BizwareGL;
 using OpenTK;
 
-namespace BizHawk.Client.EmuHawk.FilterManager
+namespace BizHawk.Client.Common.FilterManager
 {
 	public enum SurfaceDisposition
 	{

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/BaseFilter.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/BaseFilter.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Drawing;
-using BizHawk.Client.EmuHawk.FilterManager;
+using BizHawk.Client.Common.FilterManager;
 
 using BizHawk.Bizware.BizwareGL;
 using OpenTK;
@@ -15,7 +15,7 @@ using OpenTK;
 // 4. In SetInputFormat(), use DeclareOutput to set the output based on your desires, or the provided input format.
 // 5. In Run(), the render target is already set. If using a texture, use InputTexture
 // 6. In Run(), if supplying an output texture, use YieldOutput
-namespace BizHawk.Client.EmuHawk.Filters
+namespace BizHawk.Client.Common.Filters
 {
 	public class BaseFilter
 	{

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/Gui.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/Gui.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Drawing;
-using BizHawk.Client.EmuHawk.FilterManager;
+using BizHawk.Client.Common.FilterManager;
 using BizHawk.Emulation.Cores.Consoles.Nintendo.NDS;
 
 using BizHawk.Bizware.BizwareGL;
 using OpenTK;
 
-namespace BizHawk.Client.EmuHawk.Filters
+namespace BizHawk.Client.Common.Filters
 {
 	/// <summary>
 	/// applies letterboxing logic to figure out how to fit the source dimensions into the target dimensions.
@@ -444,7 +444,7 @@ namespace BizHawk.Client.EmuHawk.Filters
 		/// <summary>
 		/// only use with Config_PadOnly
 		/// </summary>
-		public System.Windows.Forms.Padding Padding;
+		public (int Left, int Top, int Right, int Bottom) Padding;
 
 		public override void Initialize()
 		{
@@ -522,8 +522,8 @@ namespace BizHawk.Client.EmuHawk.Filters
 			{
 				int ow = OutputSize.Width;
 				int oh = OutputSize.Height;
-				ow -= Padding.Horizontal;
-				oh -= Padding.Vertical;
+				ow -= Padding.Left + Padding.Right;
+				oh -= Padding.Top + Padding.Bottom;
 				LL = new LetterboxingLogic(Config_FixAspectRatio, Config_FixScaleInteger, ow, oh, InputSize.Width, InputSize.Height, TextureSize, VirtualTextureSize);
 				LL.vx += Padding.Left;
 				LL.vy += Padding.Top;

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/Retro.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/Retro.cs
@@ -7,12 +7,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Drawing;
-using BizHawk.Client.EmuHawk.FilterManager;
+using BizHawk.Client.Common.FilterManager;
 
 using BizHawk.Bizware.BizwareGL;
 using OpenTK;
 
-namespace BizHawk.Client.EmuHawk.Filters
+namespace BizHawk.Client.Common.Filters
 {
 	public class RetroShaderChain : IDisposable
 	{

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/Utils.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/Utils.cs
@@ -1,9 +1,9 @@
 using System.Drawing;
-using BizHawk.Client.EmuHawk.FilterManager;
+using BizHawk.Client.Common.FilterManager;
 
 using BizHawk.Bizware.BizwareGL;
 
-namespace BizHawk.Client.EmuHawk.Filters
+namespace BizHawk.Client.Common.Filters
 {
 	public class SourceImage : BaseFilter
 	{

--- a/src/BizHawk.Client.Common/DisplayManager/RenderTargetFrugalizer.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/RenderTargetFrugalizer.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 using BizHawk.Bizware.BizwareGL;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// Recycles a pair of temporary render targets, as long as the dimensions match.

--- a/src/BizHawk.Client.Common/DisplayManager/SwappableDisplaySurfaceSet.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/SwappableDisplaySurfaceSet.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// encapsulates thread-safe concept of pending/current display surfaces, reusing buffers where matching 

--- a/src/BizHawk.Client.Common/DisplayManager/TextureFrugalizer.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/TextureFrugalizer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using BizHawk.Bizware.BizwareGL;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	/// <summary>
 	/// Recycles a pair of temporary textures (in case double-buffering helps any) to contain a BitmapBuffer's or DisplaySurface's contents, as long as the dimensions match.

--- a/src/BizHawk.Client.Common/Sound/Interfaces/IBufferedSoundProvider.cs
+++ b/src/BizHawk.Client.Common/Sound/Interfaces/IBufferedSoundProvider.cs
@@ -1,6 +1,6 @@
 ﻿using BizHawk.Emulation.Common;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	public interface IBufferedSoundProvider
 	{

--- a/src/BizHawk.Client.Common/Sound/Interfaces/ISoundOutput.cs
+++ b/src/BizHawk.Client.Common/Sound/Interfaces/ISoundOutput.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	public interface ISoundOutput : IDisposable
 	{

--- a/src/BizHawk.Client.Common/Sound/Utilities/BufferedAsync.cs
+++ b/src/BizHawk.Client.Common/Sound/Utilities/BufferedAsync.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 using BizHawk.Emulation.Common;
 
-namespace BizHawk.Client.EmuHawk
+namespace BizHawk.Client.Common
 {
 	// Generates SEMI-synchronous sound, or "buffered asynchronous" sound.
 

--- a/src/BizHawk.Client.EmuHawk/Sound/Output/DirectSoundSoundOutput.cs
+++ b/src/BizHawk.Client.EmuHawk/Sound/Output/DirectSoundSoundOutput.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
+using BizHawk.Client.Common;
+
 using SlimDX.DirectSound;
 using SlimDX.Multimedia;
 

--- a/src/BizHawk.Client.EmuHawk/Sound/Output/DummySoundOutput.cs
+++ b/src/BizHawk.Client.EmuHawk/Sound/Output/DummySoundOutput.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
 
+using BizHawk.Client.Common;
+
 namespace BizHawk.Client.EmuHawk
 {
 	public class DummySoundOutput : ISoundOutput

--- a/src/BizHawk.Client.EmuHawk/Sound/Output/OpenALSoundOutput.cs
+++ b/src/BizHawk.Client.EmuHawk/Sound/Output/OpenALSoundOutput.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using BizHawk.Client.Common;
+
 using OpenTK.Audio;
 using OpenTK.Audio.OpenAL;
 

--- a/src/BizHawk.Client.EmuHawk/Sound/Output/XAudio2SoundOutput.cs
+++ b/src/BizHawk.Client.EmuHawk/Sound/Output/XAudio2SoundOutput.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+using BizHawk.Client.Common;
+
 using SlimDX;
 using SlimDX.Multimedia;
 using SlimDX.XAudio2;

--- a/src/BizHawk.Client.EmuHawk/Sound/Utilities/SoundOutputProvider.cs
+++ b/src/BizHawk.Client.EmuHawk/Sound/Utilities/SoundOutputProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk

--- a/src/BizHawk.Client.EmuHawk/config/DisplayConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/DisplayConfig.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Windows.Forms;
 using BizHawk.Client.Common;
-using BizHawk.Client.EmuHawk.Filters;
+using BizHawk.Client.Common.Filters;
 using BizHawk.Common;
 
 namespace BizHawk.Client.EmuHawk

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -12,7 +12,6 @@ using BizHawk.Emulation.Common;
 using BizHawk.Client.Common;
 using BizHawk.Client.EmuHawk.Properties;
 using BizHawk.Client.EmuHawk.ToolExtensions;
-using BizHawk.Client.EmuHawk.Filters;
 
 namespace BizHawk.Client.EmuHawk
 {


### PR DESCRIPTION
natt wanted to know why this code should be moved, and why EmuHawk needed to be common-ised when it's our only frontend. This PR's motivations are to have less code targeting Framework (see also #1801), and to reduce the amount of non-UI code in the EmuHawk project. It's also uncertain if we'll be able to keep one executable that runs both on Windows and on Linux via Mono; though should EmuHawk split, most files can be included in both Core- and Framework-targeting projects without any modification or preprocessor guarding.