### PR TITLE
I don't understand why we're clearing the rewind buffer...

### DIFF
--- a/src/BizHawk.Client.Common/rewind/IRewinder.cs
+++ b/src/BizHawk.Client.Common/rewind/IRewinder.cs
@@ -19,5 +19,7 @@ namespace BizHawk.Client.Common
 
 		void Suspend();
 		void Resume();
+
+		void Clear();
 	}
 }

--- a/src/BizHawk.Client.Common/rewind/Zwinder.cs
+++ b/src/BizHawk.Client.Common/rewind/Zwinder.cs
@@ -85,5 +85,10 @@ namespace BizHawk.Client.Common
 		{
 			// this possess no resources to dispose of, but other IRewinder impls might
 		}
+
+		public void Clear()
+		{
+			_buffer.InvalidateEnd(0);
+		}
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -888,16 +888,11 @@ namespace BizHawk.Client.EmuHawk
 
 		public void CreateRewinder()
 		{
-			RecreateRewinder();
-			AddOnScreenMessage(Rewinder?.Active == true ? "Rewind started" : "Rewind disabled");
-		}
-
-		void RecreateRewinder()
-		{
 			Rewinder?.Dispose();
 			Rewinder = Emulator.HasSavestates() && Config.Rewind.Enabled
 				? new Zwinder(Emulator.AsStatable(), Config.Rewind)
 				: null;
+			AddOnScreenMessage(Rewinder?.Active == true ? "Rewind started" : "Rewind disabled");
 		}
 
 		private FirmwareManager FirmwareManager => GlobalWin.FirmwareManager;
@@ -3992,7 +3987,7 @@ namespace BizHawk.Client.EmuHawk
 				//so purge rewind history when loading a state while doing a movie
 				if (!IsRewindSlave && MovieSession.Movie.IsActive())
 				{
-					RecreateRewinder();
+					Rewinder?.Clear();
 				}
 
 				if (!suppressOSD)


### PR DESCRIPTION
... but if we want to do that, just do it, and don't deallocate + reallocate many megs of ram on every loadstate