### PR TITLE
Unify setting of window titles, and add static title option

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -313,5 +313,7 @@ namespace BizHawk.Client.Common
 		public string LastWrittenFromDetailed { get; set; } = VersionInfo.GetEmuVersion();
 
 		public EHostInputMethod HostInputMethod { get; set; } = OSTailoredCode.IsUnixHost ? EHostInputMethod.OpenTK : EHostInputMethod.DirectInput;
+
+		public bool UseStaticWindowTitles { get; set; }
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.Designer.cs
@@ -132,7 +132,6 @@
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "CoreFeatureAnalysis";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Core Features";
 			this.tabControl1.ResumeLayout(false);
 			this.tabPage1.ResumeLayout(false);
 			this.tabPage2.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.cs
+++ b/src/BizHawk.Client.EmuHawk/CoreFeatureAnalysis.cs
@@ -108,6 +108,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		IEmulator Emulator { get; set; }
 
+		protected override string WindowTitleStatic => "Core Features";
+
 		public CoreFeatureAnalysis()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/FormBase.cs
+++ b/src/BizHawk.Client.EmuHawk/FormBase.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+using BizHawk.Client.Common;
+
+namespace BizHawk.Client.EmuHawk
+{
+	public class FormBase : Form
+	{
+		private string? _windowTitleStatic;
+
+		public Config? Config { get; protected set; }
+
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		public override string Text
+		{
+			get => base.Text;
+			set => throw new InvalidOperationException("window title can only be changed by calling " + nameof(UpdateWindowTitle) + " (which calls " + nameof(WindowTitle) + " getter)");
+		}
+
+		protected virtual string WindowTitle => WindowTitleStatic;
+
+		/// <remarks>To enforce the "static title" semantics for implementations, this getter will be called once and cached.</remarks>
+		protected virtual string WindowTitleStatic => throw new NotImplementedException("you have to implement this; the Designer prevents this from being an abstract method");
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			UpdateWindowTitle();
+		}
+
+		public void UpdateWindowTitle()
+			=> base.Text = Config?.UseStaticWindowTitles == true
+				? (_windowTitleStatic ??= WindowTitleStatic)
+				: WindowTitle;
+	}
+}

--- a/src/BizHawk.Client.EmuHawk/LogWindow.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/LogWindow.Designer.cs
@@ -155,7 +155,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Name = "LogWindow";
 			this.ShowIcon = true;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Log Window";
 			this.Load += new System.EventHandler(this.LogWindow_Load);
 			this.tableLayoutPanel1.ResumeLayout(false);
 			this.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/LogWindow.cs
+++ b/src/BizHawk.Client.EmuHawk/LogWindow.cs
@@ -23,6 +23,12 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		private IEmulator Emulator { get; set; }
 
+		private string _windowTitle = "Log Window";
+
+		protected override string WindowTitle => _windowTitle;
+
+		protected override string WindowTitleStatic => "Log Window";
+
 		public LogWindow()
 		{
 			InitializeComponent();
@@ -66,7 +72,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			virtualListView1.VirtualListSize = ss.Length;
-			Text = title;
+			_windowTitle = title;
+			UpdateWindowTitle();
 			btnClear.Visible = false;
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -2404,7 +2404,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.MainMenuStrip = this.MainformMenu;
 			this.Name = "MainForm";
-			this.Text = "BizHawk";
 			this.Activated += new System.EventHandler(this.MainForm_Activated);
 			this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
 			this.Load += new System.EventHandler(this.MainForm_Load);

--- a/src/BizHawk.Client.EmuHawk/Program.cs
+++ b/src/BizHawk.Client.EmuHawk/Program.cs
@@ -222,9 +222,9 @@ namespace BizHawk.Client.EmuHawk
 				else
 				{
 					var mf = new MainForm(args);
-					var title = mf.Text;
+//					var title = mf.Text;
 					mf.Show();
-					mf.Text = title;
+//					mf.Text = title;
 					try
 					{
 						GlobalWin.ExitCode = mf.ProgramRunLoop();

--- a/src/BizHawk.Client.EmuHawk/config/DisplayConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/DisplayConfig.Designer.cs
@@ -87,6 +87,9 @@
 			this.label7 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.rbGDIPlus = new System.Windows.Forms.RadioButton();
 			this.tpMisc = new System.Windows.Forms.TabPage();
+			this.flpStaticWindowTitles = new BizHawk.WinForms.Controls.LocSzSingleColumnFLP();
+			this.cbStaticWindowTitles = new BizHawk.WinForms.Controls.CheckBoxEx();
+			this.lblStaticWindowTitles = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.groupBox5 = new System.Windows.Forms.GroupBox();
 			this.rbDisplayAbsoluteZero = new System.Windows.Forms.RadioButton();
 			this.rbDisplayMinimal = new System.Windows.Forms.RadioButton();
@@ -119,6 +122,7 @@
 			this.tpDispMethod.SuspendLayout();
 			this.groupBox3.SuspendLayout();
 			this.tpMisc.SuspendLayout();
+			this.flpStaticWindowTitles.SuspendLayout();
 			this.groupBox5.SuspendLayout();
 			this.tabPage1.SuspendLayout();
 			this.groupBox4.SuspendLayout();
@@ -696,6 +700,7 @@
 			// 
 			// tpMisc
 			// 
+			this.tpMisc.Controls.Add(this.flpStaticWindowTitles);
 			this.tpMisc.Controls.Add(this.groupBox5);
 			this.tpMisc.Location = new System.Drawing.Point(4, 22);
 			this.tpMisc.Name = "tpMisc";
@@ -703,6 +708,27 @@
 			this.tpMisc.TabIndex = 3;
 			this.tpMisc.Text = "Misc";
 			this.tpMisc.UseVisualStyleBackColor = true;
+			// 
+			// flpStaticWindowTitles
+			// 
+			this.flpStaticWindowTitles.Controls.Add(this.cbStaticWindowTitles);
+			this.flpStaticWindowTitles.Controls.Add(this.lblStaticWindowTitles);
+			this.flpStaticWindowTitles.Location = new System.Drawing.Point(6, 109);
+			this.flpStaticWindowTitles.Name = "flpStaticWindowTitles";
+			this.flpStaticWindowTitles.Size = new System.Drawing.Size(490, 52);
+			// 
+			// cbStaticWindowTitles
+			// 
+			this.cbStaticWindowTitles.Name = "cbStaticWindowTitles";
+			this.cbStaticWindowTitles.Text = "Keep window titles static";
+			// 
+			// lblStaticWindowTitles
+			// 
+			this.lblStaticWindowTitles.Location = new System.Drawing.Point(19, 23);
+			this.lblStaticWindowTitles.Margin = new System.Windows.Forms.Padding(19, 0, 3, 0);
+			this.lblStaticWindowTitles.Name = "lblStaticWindowTitles";
+			this.lblStaticWindowTitles.Text = "Some tools put filenames, status, etc. in their window titles.\nChecking this disa" +
+    "bles those features, but may fix problems with window capture (i.e. in OBS).";
 			// 
 			// groupBox5
 			// 
@@ -946,6 +972,8 @@
 			this.groupBox3.PerformLayout();
 			this.tpMisc.ResumeLayout(false);
 			this.tpMisc.PerformLayout();
+			this.flpStaticWindowTitles.ResumeLayout(false);
+			this.flpStaticWindowTitles.PerformLayout();
 			this.groupBox5.ResumeLayout(false);
 			this.groupBox5.PerformLayout();
 			this.tabPage1.ResumeLayout(false);
@@ -1040,5 +1068,8 @@
 		private System.Windows.Forms.TextBox txtCropTop;
 		private BizHawk.WinForms.Controls.LocLabelEx label14;
 		private System.Windows.Forms.TextBox txtCropLeft;
+		private WinForms.Controls.LocSzSingleColumnFLP flpStaticWindowTitles;
+		private WinForms.Controls.CheckBoxEx cbStaticWindowTitles;
+		private WinForms.Controls.LocLabelEx lblStaticWindowTitles;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/DisplayConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/DisplayConfig.cs
@@ -44,6 +44,8 @@ namespace BizHawk.Client.EmuHawk
 			if (_config.DispSpeedupFeatures == 1) rbDisplayMinimal.Checked = true;
 			if (_config.DispSpeedupFeatures == 0) rbDisplayAbsoluteZero.Checked = true;
 
+			cbStaticWindowTitles.Checked = _config.UseStaticWindowTitles;
+
 			rbOpenGL.Checked = _config.DispMethod == EDispMethod.OpenGL;
 			rbGDIPlus.Checked = _config.DispMethod == EDispMethod.GdiPlus;
 			rbD3D9.Checked = _config.DispMethod == EDispMethod.SlimDX9;
@@ -137,6 +139,8 @@ namespace BizHawk.Client.EmuHawk
 			if (rbDisplayFull.Checked) _config.DispSpeedupFeatures = 2;
 			if (rbDisplayMinimal.Checked) _config.DispSpeedupFeatures = 1;
 			if (rbDisplayAbsoluteZero.Checked) _config.DispSpeedupFeatures = 0;
+
+			_config.UseStaticWindowTitles = cbStaticWindowTitles.Checked;
 
 			if (rbUseRaw.Checked)
 				_config.DispManagerAR = EDispManagerAR.None;

--- a/src/BizHawk.Client.EmuHawk/config/NES/NESSoundConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/NES/NESSoundConfig.Designer.cs
@@ -98,7 +98,6 @@
 			this.Name = "NESSoundConfig";
 			this.ShowIcon = false;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "NES Sound Channels";
 			this.Load += new System.EventHandler(this.NESSoundConfig_Load);
 			((System.ComponentModel.ISupportInitialize)(this.trackBar1)).EndInit();
 			this.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/config/NES/NESSoundConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/NES/NESSoundConfig.cs
@@ -18,6 +18,8 @@ namespace BizHawk.Client.EmuHawk
 			NESSoundConfig_Load(null, null);
 		}
 
+		protected override string WindowTitleStatic => "NES Sound Channels";
+
 		public NESSoundConfig()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.Designer.cs
@@ -1031,7 +1031,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MainMenuStrip = this.BotMenu;
 			this.Name = "BasicBot";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Basic Bot";
 			this.Load += new System.EventHandler(this.BasicBot_Load);
 			this.BotMenu.ResumeLayout(false);
 			this.BotMenu.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/BasicBot/BasicBot.cs
@@ -16,8 +16,6 @@ namespace BizHawk.Client.EmuHawk
 {
 	public partial class BasicBot : ToolFormBase, IToolFormAutoConfig
 	{
-		private const string DialogTitle = "Basic Bot";
-
 		private string _currentFileName = "";
 
 		private string CurrentFileName
@@ -27,9 +25,10 @@ namespace BizHawk.Client.EmuHawk
 			{
 				_currentFileName = value;
 
-				Text = !string.IsNullOrWhiteSpace(_currentFileName)
-					? $"{DialogTitle} - {Path.GetFileNameWithoutExtension(_currentFileName)}"
-					: DialogTitle;
+				_windowTitle = !string.IsNullOrWhiteSpace(_currentFileName)
+					? $"{WindowTitleStatic} - {Path.GetFileNameWithoutExtension(_currentFileName)}"
+					: WindowTitleStatic;
+				UpdateWindowTitle();
 			}
 
 		}
@@ -79,6 +78,12 @@ namespace BizHawk.Client.EmuHawk
 			public bool InvisibleEmulation { get; set; }
 		}
 
+		private string _windowTitle = "Basic Bot";
+
+		protected override string WindowTitle => _windowTitle;
+
+		protected override string WindowTitleStatic => "Basic Bot";
+
 		public BasicBot()
 		{
 			InitializeComponent();
@@ -93,7 +98,6 @@ namespace BizHawk.Client.EmuHawk
 			PlayBestButton.Image = Resources.Play;
 			ClearBestButton.Image = Resources.Close;
 			StopBtn.Image = Resources.Stop;
-			Text = DialogTitle;
 			Settings = new BasicBotSettings();
 
 			_comparisonBotAttempt = new BotAttempt();

--- a/src/BizHawk.Client.EmuHawk/tools/CDL.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/CDL.cs
@@ -40,9 +40,10 @@ namespace BizHawk.Client.EmuHawk
 		private void SetCurrentFilename(string fname)
 		{
 			_currentFilename = fname;
-			Text = _currentFilename == null
-				? "Code Data Logger"
-				: $"Code Data Logger - {fname}";
+			_windowTitle = _currentFilename == null
+				? WindowTitleStatic
+				: $"{WindowTitleStatic} - {fname}";
+			UpdateWindowTitle();
 		}
 
 		[RequiredService]
@@ -66,6 +67,12 @@ namespace BizHawk.Client.EmuHawk
 
 		private string _currentFilename;
 		private CodeDataLog _cdl;
+
+		private string _windowTitle = "Code Data Logger";
+
+		protected override string WindowTitle => _windowTitle;
+
+		protected override string WindowTitleStatic => "Code Data Logger";
 
 		public CDL()
 		{

--- a/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/CDL.designer.cs
@@ -228,7 +228,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(150, 130);
 			this.Name = "CDL";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Code Data Logger";
 			this.Load += new System.EventHandler(this.CDL_Load);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.CDL_DragDrop);
 			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.CDL_DragEnter);

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.Designer.cs
@@ -428,7 +428,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Controls.Add(this.CheatListView);
 			this.MinimumSize = new System.Drawing.Size(285, 384);
 			this.Name = "Cheats";
-			this.Text = "Cheats";
 			this.Load += new System.EventHandler(this.Cheats_Load);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.NewCheatForm_DragDrop);
 			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.NewCheatForm_DragEnter);

--- a/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Cheats/Cheats.cs
@@ -29,6 +29,8 @@ namespace BizHawk.Client.EmuHawk
 		private string _sortedColumn;
 		private bool _sortReverse;
 
+		protected override string WindowTitleStatic => "Cheats";
+
 		public Cheats()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.Designer.cs
@@ -329,7 +329,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "GenericDebugger";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Debugger";
 			this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GenericDebugger_MouseMove);
 			this.menuStrip1.ResumeLayout(false);
 			this.menuStrip1.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Debugger/GenericDebugger.cs
@@ -13,6 +13,8 @@ namespace BizHawk.Client.EmuHawk
 		private const string AddressColumnName = "Address";
 		private const string InstructionColumnName = "Instruction";
 
+		protected override string WindowTitleStatic => "Debugger";
+
 		public GenericDebugger()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/GB/GBGPUView.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GB/GBGPUView.Designer.cs
@@ -471,7 +471,6 @@
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "GbGpuView";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "GPU Viewer";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.GbGpuView_FormClosed);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GbGpuView_KeyDown);
 			this.groupBox1.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/GB/GBGPUView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GB/GBGPUView.cs
@@ -54,6 +54,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		protected override string WindowTitleStatic => "GPU Viewer";
+
 		public GbGpuView()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.Designer.cs
@@ -115,7 +115,6 @@
             this.MaximizeBox = false;
             this.Name = "GBPrinterView";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Printer Viewer";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
 			this.FormClosed += GBPrinterView_FormClosed;

--- a/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GB/GBPrinterView.cs
@@ -27,6 +27,8 @@ namespace BizHawk.Client.EmuHawk
 		// the entire bitmap
 		private Bitmap _printerHistory;
 
+		protected override string WindowTitleStatic => "Printer Viewer";
+
 		public GBPrinterView()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/GBA/GBAGPUView.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GBA/GBAGPUView.Designer.cs
@@ -173,7 +173,6 @@
 			this.Name = "GbaGpuView";
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "GBA GPU Viewer";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.GbaGpuView_FormClosed);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GbaGpuView_KeyDown);
 			this.groupBox1.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/GBA/GBAGPUView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GBA/GBAGPUView.cs
@@ -30,6 +30,8 @@ namespace BizHawk.Client.EmuHawk
 
 		// MobileDetailView memory;
 
+		protected override string WindowTitleStatic => "GBA GPU Viewer";
+
 		public GbaGpuView()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/GameShark.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GameShark.Designer.cs
@@ -116,7 +116,6 @@
 			this.MinimumSize = new System.Drawing.Size(230, 155);
 			this.Name = "GameShark";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Cheat Code Converter";
 			this.ResumeLayout(false);
 			this.PerformLayout();
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/GameShark.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/GameShark.cs
@@ -22,6 +22,8 @@ namespace BizHawk.Client.EmuHawk
 		// ReSharper disable once UnusedAutoPropertyAccessor.Local
 		private IEmulator Emulator { get; set; }
 
+		protected override string WindowTitleStatic => "Cheat Code Converter";
+
 		public GameShark()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.Designer.cs
@@ -211,7 +211,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "GenVdpViewer";
 			this.ShowIcon = false;
-			this.Text = "VDP Viewer";
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.VDPViewer_KeyDown);
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox2.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Genesis/VDPViewer.cs
@@ -26,6 +26,8 @@ namespace BizHawk.Client.EmuHawk
 			return DisplayRectangle.Location;
 		}
 
+		protected override string WindowTitleStatic => "VDP Viewer";
+
 		public GenVdpViewer()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.Designer.cs
@@ -473,7 +473,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(360, 180);
 			this.Name = "HexEditor";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Hex Editor";
 			this.Load += new System.EventHandler(this.HexEditor_Load);
 			this.ResizeEnd += new System.EventHandler(this.HexEditor_ResizeEnd);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HexEditor_KeyDown);

--- a/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/HexEditor/HexEditor.cs
@@ -106,6 +106,12 @@ namespace BizHawk.Client.EmuHawk
 		private SolidBrush _highlightBrush;
 		private SolidBrush _secondaryHighlightBrush;
 
+		private string _windowTitle = "Hex Editor";
+
+		protected override string WindowTitle => _windowTitle;
+
+		protected override string WindowTitleStatic => "Hex Editor";
+
 		public HexEditor()
 		{
 			_hexFind = new HexFind(this);
@@ -729,15 +735,21 @@ namespace BizHawk.Client.EmuHawk
 
 		private void UpdateFormText()
 		{
-			Text = "Hex Editor";
-			if (_highlightedAddress.HasValue)
+			if (!_highlightedAddress.HasValue)
 			{
-				Text += " - Editing Address 0x" + string.Format(_numDigitsStr, _highlightedAddress);
+				_windowTitle = WindowTitleStatic;
+			}
+			else
+			{
+				var newTitle = "Hex Editor";
+				newTitle += " - Editing Address 0x" + string.Format(_numDigitsStr, _highlightedAddress);
 				if (_secondaryHighlightedAddresses.Any())
 				{
-					Text += $" (Selected 0x{_secondaryHighlightedAddresses.Count + (_secondaryHighlightedAddresses.Contains(_highlightedAddress.Value) ? 0 : 1):X})";
+					newTitle += $" (Selected 0x{_secondaryHighlightedAddresses.Count + (_secondaryHighlightedAddresses.Contains(_highlightedAddress.Value) ? 0 : 1):X})";
 				}
+				_windowTitle = newTitle;
 			}
+			UpdateWindowTitle();
 		}
 
 		private bool IsVisible(long address) => ((long) HexScrollBar.Value).RangeToExclusive(HexScrollBar.Value + _rowsVisible).Contains(address >> 4);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.Designer.cs
@@ -678,7 +678,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(400, 180);
 			this.Name = "LuaConsole";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Lua Console";
 			this.Load += new System.EventHandler(this.LuaConsole_Load);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.LuaConsole_DragDrop);
 			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.DragEnterWrapper);

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -67,6 +67,8 @@ namespace BizHawk.Client.EmuHawk
 		[ConfigPersist]
 		public LuaConsoleSettings Settings { get; set; }
 
+		protected override string WindowTitleStatic => "Lua Console";
+
 		public LuaConsole()
 		{
 			Settings = new LuaConsoleSettings();

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.Designer.cs
@@ -245,7 +245,6 @@
 			this.MainMenuStrip = this.MacroMenu;
 			this.Name = "MacroInputTool";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Macro Input";
 			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MacroInputTool_FormClosing);
 			this.Load += new System.EventHandler(this.MacroInputTool_Load);
 			this.Resize += new System.EventHandler(this.MacroInputTool_Resize);

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MacroInput.cs
@@ -27,6 +27,9 @@ namespace BizHawk.Client.EmuHawk
 		// have options only available for TasMovie
 
 		private bool _initializing;
+
+		protected override string WindowTitleStatic => "Macro Input";
+
 		public MacroInputTool()
 		{
 			_initializing = true;

--- a/src/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.Designer.cs
@@ -190,7 +190,6 @@
             this.MainMenuStrip = this.MultiDiskMenuStrip;
             this.Name = "MultiDiskBundler";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Multi-disk Bundler";
             this.Load += new System.EventHandler(this.MultiGameCreator_Load);
             this.grpName.ResumeLayout(false);
             this.grpName.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/MultiDiskBundler/MultiDiskBundler.cs
@@ -22,6 +22,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		public IEmulator Emulator { get; set; }
 
+		protected override string WindowTitleStatic => "Multi-disk Bundler";
+
 		public MultiDiskBundler()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/NES/BarcodeEntry.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/BarcodeEntry.Designer.cs
@@ -85,7 +85,6 @@
 			this.Controls.Add(this.label1);
 			this.Controls.Add(this.textBox1);
 			this.Name = "BarcodeEntry";
-			this.Text = "Barcode Entry";
 			this.ResumeLayout(false);
 			this.PerformLayout();
 

--- a/src/BizHawk.Client.EmuHawk/tools/NES/BarcodeEntry.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/BarcodeEntry.cs
@@ -10,6 +10,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		private DatachBarcode Reader { get; set; }
 
+		protected override string WindowTitleStatic => "Barcode Entry";
+
 		public BarcodeEntry()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.Designer.cs
@@ -159,7 +159,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Controls.Add(this.menuStrip1);
 			this.Name = "NESMusicRipper";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Music Ripper";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.NESMusicRipper_FormClosed);
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox1.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESMusicRipper.cs
@@ -20,6 +20,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		private NES Nes { get; set; }
 
+		protected override string WindowTitleStatic => "Music Ripper";
+
 		public NESMusicRipper()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.Designer.cs
@@ -366,7 +366,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(687, 588);
 			this.Name = "NESNameTableViewer";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Nametable Viewer";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.NESNameTableViewer_FormClosed);
 			this.Load += new System.EventHandler(this.NESNameTableViewer_Load);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.NesNameTableViewer_KeyDown);

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESNameTableViewer.cs
@@ -27,6 +27,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private int _scanline;
 
+		protected override string WindowTitleStatic => "Nametable Viewer";
+
 		public NESNameTableViewer()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.Designer.cs
@@ -705,7 +705,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(767, 445);
 			this.Name = "NesPPU";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "PPU Viewer";
 			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.NesPPU_FormClosed);
 			this.Load += new System.EventHandler(this.NesPPU_Load);
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.NesPPU_KeyDown);

--- a/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/NES/NESPPU.cs
@@ -44,6 +44,8 @@ namespace BizHawk.Client.EmuHawk
 			set { _chrRomView = value; CalculateFormSize(); }
 		}
 
+		protected override string WindowTitleStatic => "PPU Viewer";
+
 		public NesPPU()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.Designer.cs
@@ -214,7 +214,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MainMenuStrip = this.PceBgViewerMenu;
 			this.Name = "PceBgViewer";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Background Viewer";
 			this.PceBgViewerMenu.ResumeLayout(false);
 			this.PceBgViewerMenu.PerformLayout();
 			this.groupBox1.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCEBGViewer.cs
@@ -27,6 +27,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private int _vdcType;
 
+		protected override string WindowTitleStatic => "Background Viewer";
+
 		public PceBgViewer()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.Designer.cs
@@ -261,7 +261,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MainMenuStrip = this.SoundMenuStrip;
 			this.Name = "PCESoundDebugger";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Sound Debugger";
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox2.ResumeLayout(false);
 			this.groupBox3.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCESoundDebugger.cs
@@ -18,6 +18,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		private PCEngine PCE { get; set; }
 
+		protected override string WindowTitleStatic => "Sound Debugger";
+
 		public PCESoundDebugger()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.Designer.cs
@@ -156,7 +156,6 @@ namespace BizHawk.Client.EmuHawk
 			this.KeyPreview = true;
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "PceTileViewer";
-			this.Text = "Tile Viewer";
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.PceTileViewer_KeyDown);
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox2.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/PCE/PCETileViewer.cs
@@ -19,6 +19,8 @@ namespace BizHawk.Client.EmuHawk
 		private int _bgPalNum;
 		private int _spPalNum;
 
+		protected override string WindowTitleStatic => "Tile Viewer";
+
 		public PceTileViewer()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.Designer.cs
@@ -152,7 +152,6 @@ namespace BizHawk.Client.EmuHawk
 			this.KeyPreview = true;
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "SmsVdpViewer";
-			this.Text = "VDP Viewer";
 			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.VDPViewer_KeyDown);
 			this.groupBox1.ResumeLayout(false);
 			this.groupBox2.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SMS/VDPViewer.cs
@@ -17,6 +17,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private int _palIndex;
 
+		protected override string WindowTitleStatic => "VDP Viewer";
+
 		public SmsVdpViewer()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.Designer.cs
@@ -2457,7 +2457,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Name = "SNESGraphicsDebugger";
 			this.ShowIcon = false;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Graphics Debugger";
 			this.Load += new System.EventHandler(this.SNESGraphicsDebugger_Load);
 			this.menuStrip1.ResumeLayout(false);
 			this.menuStrip1.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/SNES/SNESGraphicsDebugger.cs
@@ -57,6 +57,8 @@ namespace BizHawk.Client.EmuHawk
 		{
 		}
 
+		protected override string WindowTitleStatic => "Graphics Debugger";
+
 		public SNESGraphicsDebugger()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.Designer.cs
@@ -1190,7 +1190,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(200, 148);
 			this.Name = "TAStudio";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "TAStudio";
 			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Tastudio_Closing);
 			this.Load += new System.EventHandler(this.Tastudio_Load);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.TAStudio_DragDrop);

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -130,7 +130,7 @@ namespace BizHawk.Client.EmuHawk
 							_engaged = true;
 							WantsToControlReboot = true;
 							SetUpColumns();
-							SetTextProperty();
+							UpdateWindowTitle();
 						}
 					}
 					else

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -264,7 +264,7 @@ namespace BizHawk.Client.EmuHawk
 
 			MainForm.AddOnScreenMessage("TAStudio engaged");
 			SetTasMovieCallbacks(CurrentTasMovie);
-			SetTextProperty();
+			UpdateWindowTitle();
 			MainForm.RelinquishControl(this);
 			_originalEndAction = Config.Movies.MovieEndAction;
 			MainForm.DisableRewind();
@@ -652,7 +652,7 @@ namespace BizHawk.Client.EmuHawk
 			CurrentTasMovie.ChangeLog.Clear();
 			CurrentTasMovie.ClearChanges();
 
-			SetTextProperty();
+			UpdateWindowTitle();
 			MessageStatusLabel.Text = $"{Path.GetFileName(CurrentTasMovie.Filename)} loaded.";
 
 			return true;
@@ -811,7 +811,7 @@ namespace BizHawk.Client.EmuHawk
 				Update();
 				CurrentTasMovie.Save();
 				Settings.RecentTas.Add(CurrentTasMovie.Filename);
-				SetTextProperty();
+				UpdateWindowTitle();
 				MessageStatusLabel.Text = "File saved.";
 				Cursor = Cursors.Default;
 			}
@@ -826,23 +826,14 @@ namespace BizHawk.Client.EmuHawk
 			GlobalWin.Sound.StartSound();
 		}
 
-		private void SetTextProperty()
-		{
-			var text = "TAStudio";
-			if (CurrentTasMovie != null)
-			{
-				text += $" - {CurrentTasMovie.Name}{(CurrentTasMovie.Changes ? "*" : "")}";
-			}
+		protected override string WindowTitle
+			=> CurrentTasMovie == null
+				? "TAStudio"
+				: CurrentTasMovie.Changes
+					? $"TAStudio - {CurrentTasMovie.Name}*"
+					: $"TAStudio - {CurrentTasMovie.Name}";
 
-			if (InvokeRequired)
-			{
-				this.Invoke(() => Text = text);
-			}
-			else
-			{
-				Text = text;
-			}
-		}
+		protected override string WindowTitleStatic => "TAStudio";
 
 		public IEnumerable<int> GetSelection() => TasView.SelectedRows;
 
@@ -1133,7 +1124,7 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		private void TasMovie_OnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			SetTextProperty();
+			UpdateWindowTitle();
 		}
 
 		private void TAStudio_DragDrop(object sender, DragEventArgs e)

--- a/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.Designer.cs
@@ -1638,7 +1638,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Name = "TI83KeyPad";
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "TI-83 Virtual KeyPad";
 			this.Load += new System.EventHandler(this.TI83KeyPad_Load);
 			this.menuStrip1.ResumeLayout(false);
 			this.menuStrip1.PerformLayout();

--- a/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TI83/TI83KeyPad.cs
@@ -12,6 +12,8 @@ namespace BizHawk.Client.EmuHawk
 		// ReSharper disable once UnusedAutoPropertyAccessor.Local
 		public TI83 Emu { get; private set; }
 
+		protected override string WindowTitleStatic => "TI-83 Virtual KeyPad";
+
 		public TI83KeyPad()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/ToolBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolBox.cs
@@ -16,6 +16,8 @@ namespace BizHawk.Client.EmuHawk
 		[RequiredService]
 		private IEmulator Emulator { get; set; }
 
+		protected override string WindowTitleStatic => string.Empty;
+
 		public ToolBox()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
@@ -9,10 +9,16 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
-	public class ToolFormBase : Form
+	public abstract class ToolFormBase : FormBase
 	{
 		public ToolManager Tools { get; set; }
-		public Config Config { get; set; }
+
+		public new Config Config
+		{
+			get => base.Config;
+			set => base.Config = value; //TODO used once in ToolManager (for init) and twice in dumb ways
+		}
+
 		public InputManager InputManager { get; set; }
 		public IMainFormForTools MainForm { get; set; }
 

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.Designer.cs
@@ -280,7 +280,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(400, 230);
 			this.Name = "TraceLogger";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Trace Logger";
 			this.Load += new System.EventHandler(this.TraceLogger_Load);
 			this.TracerBox.ResumeLayout(false);
 			this.TraceContextMenu.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TraceLogger.cs
@@ -59,6 +59,9 @@ namespace BizHawk.Client.EmuHawk
 
 		private const string DisasmColumnName = "Disasm";
 		private const string RegistersColumnName = "Registers";
+
+		protected override string WindowTitleStatic => "Trace Logger";
+
 		public TraceLogger()
 		{
 			InitializeComponent();

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.Designer.cs
@@ -146,7 +146,6 @@ namespace BizHawk.Client.EmuHawk
 			this.Controls.Add(this.ControllerBox);
 			this.Controls.Add(this.PadMenu);
 			this.Name = "VirtualpadTool";
-			this.Text = "Virtual Pads";
 			this.Load += new System.EventHandler(this.VirtualpadTool_Load);
 			this.ControllerBox.ResumeLayout(false);
 			this.PadBoxContextMenu.ResumeLayout(false);

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/VirtualpadsTool.cs
@@ -38,6 +38,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		protected override string WindowTitleStatic => "Virtual Pads";
+
 		public VirtualpadTool()
 		{
 			StickyPads = true;

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.Designer.cs
@@ -1041,7 +1041,6 @@ namespace BizHawk.Client.EmuHawk
 			this.MinimumSize = new System.Drawing.Size(290, 399);
 			this.Name = "RamSearch";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "RAM Search";
 			this.Activated += new System.EventHandler(this.NewRamSearch_Activated);
 			this.Load += new System.EventHandler(this.RamSearch_Load);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.NewRamSearch_DragDrop);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -39,6 +39,8 @@ namespace BizHawk.Client.EmuHawk
 
 		private bool _dropdownDontfire; // Used as a hack to get around lame .net dropdowns, there's no way to set their index without firing the SelectedIndexChanged event!
 
+		protected override string WindowTitleStatic => "RAM Search";
+
 		public RamSearch()
 		{
 			SetStyle(ControlStyles.AllPaintingInWmPaint, true);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.Designer.cs
@@ -643,7 +643,6 @@ namespace BizHawk.Client.EmuHawk
             this.Controls.Add(this.WatchListView);
             this.Name = "RamWatch";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = " RAM Watch";
             this.Load += new System.EventHandler(this.RamWatch_Load);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.RamWatch_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.DragEnterWrapper);

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -31,6 +31,8 @@ namespace BizHawk.Client.EmuHawk
 		[OptionalService]
 		private IDebuggable Debuggable { get; set; }
 
+		protected override string WindowTitleStatic => "RAM Watch";
+
 		public RamWatch()
 		{
 			InitializeComponent();


### PR DESCRIPTION
From commit desc.:
> The only forms that did anything special with their window title were Basic Bot, CDL, Hex Editor, Log Window, MainForm, and TAStudio. That behaviour is in `WindowTitle`, while the rest use `WindowTitleStatic`.
> The implementations of `WindowTitleStatic` in those six forms are new. There's a checkbox in `Config` > `Display...` > `Misc` to disable their special behaviour and use the new static titles.

fixes #1996