### PR TITLE
mGBA: Update SaveRAM mem domain to a hardcoded size. 

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/LibmGBA.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/LibmGBA.cs
@@ -111,7 +111,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			public IntPtr oam;
 			public IntPtr rom;
 			public IntPtr sram;
-			public int sram_size;
 		}
 
 		[BizImport(cc, Compatibility = true)]

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
@@ -31,7 +31,10 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			mm.Add(_vram = new MemoryDomainIntPtr("VRAM", le, IntPtr.Zero, 96 * 1024, true, 4));
 			mm.Add(_oam = new MemoryDomainIntPtr("OAM", le, IntPtr.Zero, 1024, true, 4));
 			mm.Add(_rom = new MemoryDomainIntPtr("ROM", le, IntPtr.Zero, romsize, true, 4));
-			mm.Add(_sram = new MemoryDomainIntPtr("SRAM", le, IntPtr.Zero, 0, true, 4)); // size will be fixed in wireup
+			// 128 KB is the max size for GBA savedata
+			// mGBA does not know a game's save type (and as a result actual savedata size) on startup.
+			// Instead, BizHawk's savedata buffer will be accessed directly for a consistent interface.
+			mm.Add(_sram = new MemoryDomainIntPtr("SRAM", le, IntPtr.Zero, 128 * 1024, true, 4));
 			mm.Add(_cwram = new MemoryDomainDelegate("Combined WRAM", (256 + 32) * 1024, le, null, null, 4));
 
 			mm.Add(new MemoryDomainDelegate("System Bus", 0x10000000, le,
@@ -73,7 +76,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			_oam.Data = s.oam;
 			_rom.Data = s.rom;
 			_sram.Data = s.sram;
-			_sram.SetSize(s.sram_size);
 
 			// special combined ram memory domain
 			_cwram.Peek =

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.IMemoryDomains.cs
@@ -60,16 +60,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			WireMemoryDomainPointers();
 		}
 
-		private void WireMemoryDomainPointers_SaveRam()
-		{
-			var s = new LibmGBA.MemoryAreas();
-			LibmGBA.BizGetMemoryAreas(Core, s);
-
-			_sram.Data = s.sram;
-			if (s.sram == IntPtr.Zero) s.sram_size = 0;
-			_sram.SetSize(s.sram_size);
-		}
-
 		private void WireMemoryDomainPointers()
 		{
 			var s = new LibmGBA.MemoryAreas();
@@ -83,7 +73,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			_oam.Data = s.oam;
 			_rom.Data = s.rom;
 			_sram.Data = s.sram;
-			if (s.sram == IntPtr.Zero) s.sram_size = 0;
 			_sram.SetSize(s.sram_size);
 
 			// special combined ram memory domain

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
@@ -139,10 +139,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 				(short)controller.AxisValue("Tilt Z"),
 				(byte)(255 - controller.AxisValue("Light Sensor")));
 
-			//autodetection may have progressed.
-			//this isn't a great time to do it, but we have to do it some time. maybe it's the best time.
-			WireMemoryDomainPointers_SaveRam();
-
 			if (IsLagFrame)
 			{
 				LagCount++;


### PR DESCRIPTION
Fixes #1620

Before merging this, https://github.com/TASVideos/mgba/pull/4 should be accepted, and the submodule and dlls should be updated with the newest mGBA.