### PR TITLE
Majorly refactor ZwinderStatemanager to address # 2287

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
@@ -23,12 +23,6 @@ namespace BizHawk.Client.Common
 		void Capture(int frame, IStatable source, bool force = false);
 
 		/// <summary>
-		/// Guarantee's a state will be captured and "reserved" for future use
-		/// Reserved states do not get evicted from memory when decay logic is applied
-		/// </summary>
-		void CaptureReserved(int frame, IStatable source);
-
-		/// <summary>
 		/// Commands the state manager to remove a reserved state for the given frame, if it is exists
 		/// </summary>
 		void EvictReserved(int frame);

--- a/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
@@ -22,6 +22,12 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		void Capture(int frame, IStatable source, bool force = false);
 
+		/// <summary>
+		/// Guarantee's a state will be captured and "reserved" for future use
+		/// Reserved states do not get evicted from memory when decay logic is applied
+		/// </summary>
+		void CaptureReserved(int frame, IStatable source);
+
 		bool HasState(int frame);
 
 		/// <summary>

--- a/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/IStateManager.cs
@@ -28,6 +28,11 @@ namespace BizHawk.Client.Common
 		/// </summary>
 		void CaptureReserved(int frame, IStatable source);
 
+		/// <summary>
+		/// Commands the state manager to remove a reserved state for the given frame, if it is exists
+		/// </summary>
+		void EvictReserved(int frame);
+
 		bool HasState(int frame);
 
 		/// <summary>

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
@@ -167,7 +167,7 @@ namespace BizHawk.Client.Common
 
 			bl.GetLump(BinaryStateLump.StateHistory, false, delegate(BinaryReader br, long length)
 			{
-				TasStateManager = ZwinderStateManager.Create(br, TasStateManager.Settings);
+				TasStateManager = ZwinderStateManager.Create(br, TasStateManager.Settings, IsReserved);
 			});
 		}
 	}

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-
+using System.Linq;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
@@ -23,7 +23,7 @@ namespace BizHawk.Client.Common
 			Markers = new TasMovieMarkerList(this);
 			Markers.CollectionChanged += Markers_CollectionChanged;
 			Markers.Add(0, "Power on");
-			TasStateManager = new ZwinderStateManager();
+			TasStateManager = new ZwinderStateManager(IsReserved);
 		}
 
 		public override void Attach(IEmulator emulator)
@@ -338,5 +338,12 @@ namespace BizHawk.Client.Common
 
 		public void ClearChanges() => Changes = false;
 		public void FlagChanges() => Changes = true;
+
+		private bool IsReserved(int frame)
+		{
+			// Branches should already be in the reserved list, but it doesn't hurt to check
+			return Markers.Any(m => m.Frame == frame)
+				|| Branches.Any(b => b.Frame == frame);
+		}
 	}
 }

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -341,9 +341,12 @@ namespace BizHawk.Client.Common
 
 		private bool IsReserved(int frame)
 		{
-			// Branches should already be in the reserved list, but it doesn't hurt to check
-			return Markers.Any(m => m.Frame == frame)
-				|| Branches.Any(b => b.Frame == frame);
+			
+			// Why the frame before?
+			// because we always navigate to the frame before and emulate 1 frame so that we ensure a proper frame buffer on the screen
+			// users want instant navigation to markers, so to do this, we need to reserve the frame before the marker, not the marker itself
+			return Markers.Any(m => m.Frame - 1 == frame)
+				|| Branches.Any(b => b.Frame == frame); // Branches should already be in the reserved list, but it doesn't hurt to check
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovieMarker.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovieMarker.cs
@@ -206,6 +206,7 @@ namespace BizHawk.Client.Common
 				return;
 			}
 
+			_movie.TasStateManager.EvictReserved(item.Frame);
 			_movie.ChangeLog.AddMarkerChange(null, item.Frame, item.Message);
 
 			base.Remove(item);
@@ -220,6 +221,7 @@ namespace BizHawk.Client.Common
 				if (match.Invoke(m))
 				{
 					_movie.ChangeLog.AddMarkerChange(null, m.Frame, m.Message);
+					_movie.TasStateManager.EvictReserved(m.Frame);
 				}
 			}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -212,6 +212,11 @@ namespace BizHawk.Client.Common
 			_reserved.Add(new KeyValuePair<int, byte[]>(frame, ms.ToArray()));
 		}
 
+		public void EvictReserved(int frame)
+		{
+			_reserved.RemoveAll(r => r.Key == frame);
+		}
+
 		private void AddToReserved(ZwinderBuffer.StateInformation state)
 		{
 			if (_reserved.Any(r => r.Key == state.Frame))

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -18,8 +18,8 @@ namespace BizHawk.Client.Common
 		// Used to re-fill gaps when still replaying input, but in a non-current area, also needed when switching branches
 		private ZwinderBuffer _gapFiller;
 
-		// These never decay, but can be invalidated, but can be invalidated, they are for reserved states
-		// such as markers and branches, but also we naturally evict states from recent to hear, based
+		// These never decay, but can be invalidated, they are for reserved states
+		// such as markers and branches, but also we naturally evict states from recent to reserved, based
 		// on _ancientInterval
 		private Dictionary<int, byte[]> _reserved = new Dictionary<int, byte[]>();
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -8,6 +8,8 @@ namespace BizHawk.Client.Common
 {
 	public class ZwinderStateManager : IStateManager
 	{
+		private static readonly byte[] NonState = new byte[0];
+
 		private readonly ZwinderBuffer _current;
 		private readonly ZwinderBuffer _recent;
 		private readonly ZwinderBuffer _gapFiller; // Used to re-fill gaps when still replaying input, but in a non-current area, also needed when switching branches
@@ -66,7 +68,7 @@ namespace BizHawk.Client.Common
 				var kvp = GetStateClosestToFrame(frame);
 				if (kvp.Key != frame)
 				{
-					return new byte[0];
+					return NonState;
 				}
 
 				var ms = new MemoryStream();

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -183,9 +183,10 @@ namespace BizHawk.Client.Common
 				return;
 			}
 
-			var ms = new MemoryStream();
+			var bb = new byte[state.Size];
+			var ms = new MemoryStream(bb);
 			state.GetReadStream().CopyTo(ms);
-			_reserved.Add(state.Frame, ms.ToArray());
+			_reserved.Add(state.Frame, bb);
 			StateCache.Add(state.Frame);
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -286,16 +286,6 @@ namespace BizHawk.Client.Common
 
 		private bool InvalidateNormal(int frame)
 		{
-			for (var i = 0; i < _reserved.Count; i++)
-			{
-				if (_reserved[i].Key > frame)
-				{
-					_reserved.RemoveRange(i, _reserved.Count - i);
-					_recent.InvalidateEnd(0);
-					_current.InvalidateEnd(0);
-					return true;
-				}
-			}
 			for (var i = 0; i < _recent.Count; i++)
 			{
 				if (_recent.GetState(i).Frame > frame)
@@ -305,6 +295,7 @@ namespace BizHawk.Client.Common
 					return true;
 				}
 			}
+
 			for (var i = 0; i < _current.Count; i++)
 			{
 				if (_current.GetState(i).Frame > frame)
@@ -324,7 +315,8 @@ namespace BizHawk.Client.Common
 				throw new ArgumentOutOfRangeException(nameof(frame));
 			var b1 = InvalidateNormal(frame);
 			var b2 = InvalidateGaps(frame);
-			return b1 || b2;
+			var b3 = _reserved.RemoveAll(r => r.Key > frame) > 0;
+			return b1 || b2 || b3;
 		}
 
 		public static ZwinderStateManager Create(BinaryReader br, ZwinderStateManagerSettings settings, Func<int, bool> reserveCallback)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -199,17 +199,17 @@ namespace BizHawk.Client.Common
 
 		public void Capture(int frame, IStatable source, bool force = false)
 		{
+			// We already have this state, no need to capture
+			if (StateCache.Contains(frame))
+			{
+				return;
+			}
+
 			// We do not want to consider reserved states for a notion of Last
 			// reserved states can include future states in the case of branch states
 			if (frame <= LastRing)
 			{
 				CaptureGap(frame, source);
-				return;
-			}
-
-			// We already have this state, no need to capture
-			if (_reserved.ContainsKey(frame))
-			{
 				return;
 			}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -63,8 +63,11 @@ namespace BizHawk.Client.Common
 
 		public void Engage(byte[] frameZeroState)
 		{
-			_reserved.Add(0, frameZeroState);
-			StateCache.Add(0);
+			if (!_reserved.ContainsKey(0))
+			{
+				_reserved.Add(0, frameZeroState);
+				StateCache.Add(0);
+			}
 		}
 
 		private ZwinderStateManager(ZwinderBuffer current, ZwinderBuffer recent, ZwinderBuffer gapFiller, int ancientInterval, Func<int, bool> reserveCallback)
@@ -160,7 +163,7 @@ namespace BizHawk.Client.Common
 
 		private int LastRing => CurrentAndRecentStates().FirstOrDefault()?.Frame ?? 0;
 
-		public void CaptureReserved(int frame, IStatable source)
+		internal void CaptureReserved(int frame, IStatable source)
 		{
 			if (_reserved.ContainsKey(frame))
 			{
@@ -202,6 +205,12 @@ namespace BizHawk.Client.Common
 			// We already have this state, no need to capture
 			if (StateCache.Contains(frame))
 			{
+				return;
+			}
+
+			if (_reserveCallback(frame))
+			{
+				CaptureReserved(frame, source);
 				return;
 			}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -273,13 +273,12 @@ namespace BizHawk.Client.Common
 				return true;
 			}
 
-			if (CurrentAndRecentStates().Any())
+			if (CurrentAndRecentStates().Any(si => si.Frame == frame))
 			{
 				return true;
 			}
 
-			if (GapStates()
-				.Any())
+			if (GapStates().Any(si => si.Frame == frame))
 			{
 				return true;
 			}

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -136,7 +136,7 @@ namespace BizHawk.Client.Common
 		}
 
 		// Only considers Current and Recent
-		private IEnumerable<StateInfo> RecentAndCurrentStates()
+		private IEnumerable<StateInfo> RingStates()
 		{
 			for (var i = _current.Count - 1; i >= 0; i--)
 			{
@@ -159,7 +159,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Enumerate all states in reverse order
 		/// </summary>
-		private IEnumerable<StateInfo> AllRingStates()
+		private IEnumerable<StateInfo> AllStates()
 		{
 			var l1 = NormalStates().GetEnumerator();
 			var l2 = GapStates().GetEnumerator();
@@ -196,9 +196,9 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public int Last => Math.Max(AllRingStates().First().Frame, _reserved.Max(r => r.Key));
+		public int Last => AllStates().First().Frame;
 
-		private int LastRing => RecentAndCurrentStates().FirstOrDefault()?.Frame ?? 0;
+		private int LastRing => RingStates().FirstOrDefault()?.Frame ?? 0;
 
 		public void CaptureReserved(int frame, IStatable source)
 		{
@@ -300,13 +300,13 @@ namespace BizHawk.Client.Common
 			if (frame < 0)
 				throw new ArgumentOutOfRangeException(nameof(frame));
 
-			var si = AllRingStates().First(s => s.Frame <= frame);
+			var si = AllStates().First(s => s.Frame <= frame);
 			return new KeyValuePair<int, Stream>(si.Frame, si.Read());
 		}
 
 		public bool HasState(int frame)
 		{
-			return AllRingStates().Any(s => s.Frame == frame);
+			return AllStates().Any(s => s.Frame == frame);
 		}
 
 		private bool InvalidateGaps(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -94,7 +94,7 @@ namespace BizHawk.Client.Common
 		// TODO: private set, refactor LoadTasprojExtras to hold onto a settings object and pass it in to Create() method
 		public ZwinderStateManagerSettings Settings { get; set; }
 
-		public int Count => _current.Count + _recent.Count + _gapFiller.Count + _reserved.Count + 1;
+		public int Count => _current.Count + _recent.Count + _gapFiller.Count + _reserved.Count;
 
 		private class StateInfo
 		{

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -268,7 +268,23 @@ namespace BizHawk.Client.Common
 
 		public bool HasState(int frame)
 		{
-			return AllStates().Any(s => s.Frame == frame);
+			if (_reserved.Any(r => r.Key == frame))
+			{
+				return true;
+			}
+
+			if (CurrentAndRecentStates().Any())
+			{
+				return true;
+			}
+
+			if (GapStates()
+				.Any())
+			{
+				return true;
+			}
+
+			return false;
 		}
 
 		private bool InvalidateGaps(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -97,7 +97,7 @@ namespace BizHawk.Client.Common
 
 		public int Count => _current.Count + _recent.Count + _gapFiller.Count + _reserved.Count;
 
-		private class StateInfo
+		internal class StateInfo
 		{
 			public int Frame { get; }
 			public Func<Stream> Read { get; }
@@ -148,7 +148,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Enumerate all states in reverse order
 		/// </summary>
-		private IEnumerable<StateInfo> AllStates()
+		internal IEnumerable<StateInfo> AllStates()
 		{
 			return CurrentAndRecentStates()
 				.Concat(GapStates())
@@ -288,31 +288,7 @@ namespace BizHawk.Client.Common
 
 		public bool HasState(int frame)
 		{
-			var result = false;
-
-			var cache = StateCache.Contains(frame);
-
-			if (_reserved.ContainsKey(frame))
-			{
-				result = true;
-			}
-
-			else if (CurrentAndRecentStates().Any(si => si.Frame == frame))
-			{
-				result = true;
-			}
-
-			else if (GapStates().Any(si => si.Frame == frame))
-			{
-				result = true;
-			}
-
-			if (result != cache)
-			{
-				int zzz = 0;
-			}
-
-			return result;
+			return StateCache.Contains(frame);
 		}
 
 		private bool InvalidateGaps(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -214,6 +214,11 @@ namespace BizHawk.Client.Common
 
 		public void EvictReserved(int frame)
 		{
+			if (frame == 0)
+			{
+				throw new InvalidOperationException("Frame 0 can not be evicted.");
+			}
+
 			_reserved.RemoveAll(r => r.Key == frame);
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Client.Common
 		private static readonly byte[] NonState = new byte[0];
 
 		private readonly Func<int, bool> _reserveCallback;
-		private readonly SortedSet<int> _stateCache = new SortedSet<int>();
+		internal readonly SortedSet<int> _stateCache = new SortedSet<int>();
 		private ZwinderBuffer _current;
 		private ZwinderBuffer _recent;
 
@@ -53,8 +53,6 @@ namespace BizHawk.Client.Common
 
 			_ancientInterval = settings.AncientStateInterval;
 		}
-
-		internal SortedSet<int> StateCache => _stateCache;
 
 		/// <param name="reserveCallback">Called when deciding to evict a state for the given frame, if true is returned, the state will be reserved</param>
 		public ZwinderStateManager(Func<int, bool> reserveCallback)
@@ -215,11 +213,6 @@ namespace BizHawk.Client.Common
 				return;
 			}
 
-			if (frame == 16409)
-			{
-				int zzz = 0;
-			}
-
 			_current.Capture(frame,
 				s =>
 				{
@@ -256,22 +249,11 @@ namespace BizHawk.Client.Common
 							// Add to reserved if reserved, or if it matches an "ancient" state consideration
 							if (isReserved || state2.Frame - from >= _ancientInterval)
 							{
-								AddToReserved(state);
+								AddToReserved(state2);
 							}
 						});
 				},
 				force);
-
-			var currentHas = Enumerable
-				.Range(0, _current.Count)
-				.Select(i => _current.GetState(i))
-				.Any(s => s.Frame == frame);
-			var hasState = HasState(frame);
-			var hasCache = StateCache.Contains(frame);
-			if (hasState != hasCache)
-			{
-				int zzz = 0;
-			}
 		}
 
 		private void CaptureGap(int frame, IStatable source)
@@ -315,12 +297,12 @@ namespace BizHawk.Client.Common
 				result = true;
 			}
 
-			if (CurrentAndRecentStates().Any(si => si.Frame == frame))
+			else if (CurrentAndRecentStates().Any(si => si.Frame == frame))
 			{
 				result = true;
 			}
 
-			if (GapStates().Any(si => si.Frame == frame))
+			else if (GapStates().Any(si => si.Frame == frame))
 			{
 				result = true;
 			}

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -197,6 +197,11 @@ namespace BizHawk.Client.Common
 
 		public void CaptureReserved(int frame, IStatable source)
 		{
+			if (_reserved.Any(r => r.Key == frame))
+			{
+				return;
+			}
+
 			var ms = new MemoryStream();
 			source.SaveStateBinary(new BinaryWriter(ms));
 			_reserved.Add(new KeyValuePair<int, byte[]>(frame, ms.ToArray()));
@@ -209,6 +214,12 @@ namespace BizHawk.Client.Common
 			if (frame <= LastRing)
 			{
 				CaptureGap(frame, source);
+				return;
+			}
+
+			// We already have this state, no need to capture
+			if (_reserved.Any(r => r.Key == frame))
+			{
 				return;
 			}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -161,7 +161,7 @@ namespace BizHawk.Client.Common
 
 		public void CaptureReserved(int frame, IStatable source)
 		{
-			if (_reserved.Any(r => r.Key == frame))
+			if (_reserved.ContainsKey(frame))
 			{
 				return;
 			}
@@ -241,7 +241,7 @@ namespace BizHawk.Client.Common
 				force);
 		}
 
-		public void CaptureGap(int frame, IStatable source)
+		private void CaptureGap(int frame, IStatable source)
 		{
 			_gapFiller.Capture(frame, s => source.SaveStateBinary(new BinaryWriter(s)));
 		}

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -384,6 +384,12 @@ namespace BizHawk.Client.Common
 				ret._reserved.Add(key, data);
 			}
 
+			var allStates = ret.AllStates().ToList();
+			foreach (var state in allStates)
+			{
+				ret.StateCache.Add(state.Frame);
+			}
+
 			return ret;
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -6,17 +6,17 @@ using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
 {
-	public class ZwinderStateManager : IStateManager
+	public class ZwinderStateManager : IStateManager, IDisposable
 	{
 		private static readonly byte[] NonState = new byte[0];
 
 		private readonly Func<int, bool> _reserveCallback;
 
-		private readonly ZwinderBuffer _current;
-		private readonly ZwinderBuffer _recent;
+		private ZwinderBuffer _current;
+		private ZwinderBuffer _recent;
 
 		// Used to re-fill gaps when still replaying input, but in a non-current area, also needed when switching branches
-		private readonly ZwinderBuffer _gapFiller;
+		private ZwinderBuffer _gapFiller;
 
 		// These never decay, but can be invalidated, but can be invalidated, they are for reserved states
 		// such as markers and branches, but also we naturally evict states from recent to hear, based
@@ -381,6 +381,18 @@ namespace BizHawk.Client.Common
 				bw.Write(s.Value.Length);
 				bw.Write(s.Value);
 			}
+		}
+
+		public void Dispose()
+		{
+			_current?.Dispose();
+			_current = null;
+
+			_recent?.Dispose();
+			_recent = null;
+
+			_gapFiller?.Dispose();
+			_gapFiller = null;
 		}
 	}
 }

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -136,7 +136,7 @@ namespace BizHawk.Client.Common
 		}
 
 		// Only considers Current and Recent
-		private IEnumerable<StateInfo> RingStates()
+		private IEnumerable<StateInfo> RecentAndCurrentStates()
 		{
 			for (var i = _current.Count - 1; i >= 0; i--)
 			{
@@ -159,7 +159,7 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Enumerate all states in reverse order
 		/// </summary>
-		private IEnumerable<StateInfo> AllStates()
+		private IEnumerable<StateInfo> AllRingStates()
 		{
 			var l1 = NormalStates().GetEnumerator();
 			var l2 = GapStates().GetEnumerator();
@@ -196,9 +196,9 @@ namespace BizHawk.Client.Common
 			}
 		}
 
-		public int Last => AllStates().First().Frame;
+		public int Last => Math.Max(AllRingStates().First().Frame, _reserved.Max(r => r.Key));
 
-		private int LastRing => RingStates().FirstOrDefault()?.Frame ?? 0;
+		private int LastRing => RecentAndCurrentStates().FirstOrDefault()?.Frame ?? 0;
 
 		public void CaptureReserved(int frame, IStatable source)
 		{
@@ -300,13 +300,13 @@ namespace BizHawk.Client.Common
 			if (frame < 0)
 				throw new ArgumentOutOfRangeException(nameof(frame));
 
-			var si = AllStates().First(s => s.Frame <= frame);
+			var si = AllRingStates().First(s => s.Frame <= frame);
 			return new KeyValuePair<int, Stream>(si.Frame, si.Read());
 		}
 
 		public bool HasState(int frame)
 		{
-			return AllStates().Any(s => s.Frame == frame);
+			return AllRingStates().Any(s => s.Frame == frame);
 		}
 
 		private bool InvalidateGaps(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -274,7 +274,9 @@ namespace BizHawk.Client.Common
 			_gapFiller.InvalidateEnd(0);
 			StateCache.Clear();
 			StateCache.Add(0);
-			_reserved.Clear();
+			_reserved = _reserved
+				.Where(kvp => kvp.Key == 0)
+				.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 		}
 
 		public KeyValuePair<int, Stream> GetStateClosestToFrame(int frame)

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -290,7 +290,7 @@ namespace BizHawk.Client.Common
 		{
 			var result = false;
 
-			var cache = StateCache.Contains(frame);
+			var cache = _stateCache.Contains(frame);
 
 			if (_reserved.ContainsKey(frame))
 			{

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
@@ -16,9 +16,9 @@ namespace BizHawk.Client.Common
 			RecentBufferSize = settings.RecentBufferSize;
 			RecentTargetFrameLength = settings.RecentTargetFrameLength;
 
-			PriorityUseCompression = settings.PriorityUseCompression;
-			PriorityBufferSize = settings.PriorityBufferSize;
-			PriorityTargetFrameLength = settings.PriorityTargetFrameLength;
+			GapsUseCompression = settings.GapsUseCompression;
+			GapsBufferSize = settings.GapsBufferSize;
+			GapsTargetFrameLength = settings.GapsTargetFrameLength;
 
 			AncientStateInterval = settings.AncientStateInterval;
 		}

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
@@ -54,16 +54,16 @@ namespace BizHawk.Client.Common
 		/// <summary>
 		/// Priority States for special use cases
 		/// </summary>
-		[DisplayName("Priority - Use Compression")]
-		public bool PriorityUseCompression { get; set; }
+		[DisplayName("Gaps - Use Compression")]
+		public bool GapsUseCompression { get; set; }
 
-		[DisplayName("Priority - Buffer Size")]
+		[DisplayName("Gaps - Buffer Size")]
 		[Description("Max amount of buffer space to use in MB")]
-		public int PriorityBufferSize { get; set; } = 64;
+		public int GapsBufferSize { get; set; } = 64;
 
-		[DisplayName("Priority - Target Frame Length")]
+		[DisplayName("Gaps - Target Frame Length")]
 		[Description("Desired frame length (number of emulated frames you can go back before running out of buffer)")]
-		public int PriorityTargetFrameLength { get; set; } = 10000;
+		public int GapsTargetFrameLength { get; set; } = 1000;
 
 		[DisplayName("Ancient State Interval")]
 		[Description("How often to maintain states when outside of Current and Recent intervals")]

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Runtime.InteropServices;
 using BizHawk.BizInvoke;
 using BizHawk.Common;

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Runtime.InteropServices;
 using BizHawk.BizInvoke;
 using BizHawk.Common;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -191,7 +191,7 @@ namespace BizHawk.Client.EmuHawk
 
 			Movie.LoadBranch(branch);
 			Tastudio.LoadState(new KeyValuePair<int, Stream>(branch.Frame, new MemoryStream(branch.CoreData, false)));
-			Movie.TasStateManager.CaptureReserved(Tastudio.Emulator.Frame, Tastudio.Emulator.AsStatable());
+			Movie.TasStateManager.Capture(Tastudio.Emulator.Frame, Tastudio.Emulator.AsStatable());
 			QuickBmpFile.Copy(new BitmapBufferVideoProvider(branch.CoreFrameBuffer), Tastudio.VideoProvider);
 
 			if (Tastudio.Settings.OldControlSchemeForBranches && Tastudio.TasPlaybackBox.RecordingMode)

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -191,7 +191,7 @@ namespace BizHawk.Client.EmuHawk
 
 			Movie.LoadBranch(branch);
 			Tastudio.LoadState(new KeyValuePair<int, Stream>(branch.Frame, new MemoryStream(branch.CoreData, false)));
-			Movie.TasStateManager.Capture(Tastudio.Emulator.Frame, Tastudio.Emulator.AsStatable(), true);
+			Movie.TasStateManager.CaptureReserved(Tastudio.Emulator.Frame, Tastudio.Emulator.AsStatable());
 			QuickBmpFile.Copy(new BitmapBufferVideoProvider(branch.CoreFrameBuffer), Tastudio.VideoProvider);
 
 			if (Tastudio.Settings.OldControlSchemeForBranches && Tastudio.TasPlaybackBox.RecordingMode)

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -19,7 +19,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 				RecentTargetFrameLength = 100000,
 
 				AncientStateInterval = 50000
-			});
+			}, f => false);
 
 			var ms = new MemoryStream();
 			ss.SaveStateBinary(new BinaryWriter(ms));
@@ -42,7 +42,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 				RecentTargetFrameLength = 100000,
 
 				AncientStateInterval = 50000
-			});
+			}, f => false);
 			zw.SaveStateHistory(new BinaryWriter(ms));
 			var buff = ms.ToArray();
 			var rms = new MemoryStream(buff, false);
@@ -124,7 +124,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 				RecentTargetFrameLength = 100000,
 
 				AncientStateInterval = 50000
-			});
+			}, f => false);
 			{
 				var ms = new MemoryStream();
 				ss.SaveStateBinary(new BinaryWriter(ms));
@@ -358,33 +358,36 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void DeleteMe()
 		{
 			var ss = CreateStateSource();
-			var zw = new ZwinderStateManager(f => false);
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings
+			{
+				CurrentBufferSize = 2,
+				CurrentTargetFrameLength = 1000,
+				RecentBufferSize = 2,
+				RecentTargetFrameLength = 1000,
+				AncientStateInterval = 100
+			}, f => false);
 
-			for (int i = 0; i < 10000; i += 200)
+			for (int i = 0; i < 1000; i += 200)
 			{
 				zw.CaptureReserved(i, ss);
 			}
 
-			for (int i = 400; i < 10000; i += 400)
+			for (int i = 400; i < 1000; i += 400)
 			{
 				zw.EvictReserved(i);
 			}
 
-			for (int i = 0; i < 100000; i++)
+			for (int i = 0; i < 10000; i++)
 			{
 				zw.Capture(i, ss);
 			}
 
-			for (int i = 31183; i < 100000; i++)
+			zw.Capture(101, ss);
+
+			for (int i = 0; i < 10000; i++)
 			{
 				var hasState = zw.HasState(i);
-				var hasCache = zw._stateCache.Contains(i);
-
-				if (hasState != hasCache)
-				{
-					int zzz = 0;
-				}
-
+				var hasCache = zw.StateCache.Contains(i);
 				Assert.AreEqual(hasState, hasCache);
 			}
 		}

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -114,6 +114,130 @@ namespace BizHawk.Tests.Client.Common.Movie
 			Assert.IsTrue(actual <= 10440);
 		}
 
+		[TestMethod]
+		public void Last_Correct_WhenReservedGreaterThanCurrent()
+		{
+			const int futureReservedFrame = 1000;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			zw.CaptureReserved(futureReservedFrame, ss);
+			for (int i = 1; i < 10; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			Assert.AreEqual(futureReservedFrame, zw.Last);
+		}
+
+		[TestMethod]
+		public void Last_Correct_WhenCurrentIsLast()
+		{
+			const int totalCurrentFrames = 10;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			Assert.AreEqual(totalCurrentFrames - 1, zw.Last);
+		}
+
+		[TestMethod]
+		public void HasState_Correct_WhenReservedGreaterThanCurrent()
+		{
+			const int futureReservedFrame = 1000;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			zw.CaptureReserved(futureReservedFrame, ss);
+			for (int i = 1; i < 10; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			var actual = zw.HasState(futureReservedFrame);
+			Assert.IsTrue(actual);
+		}
+
+		[TestMethod]
+		public void HasState_Correct_WhenCurrentIsLast()
+		{
+			const int totalCurrentFrames = 10;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			var actual = zw.HasState(totalCurrentFrames - 1);
+			Assert.IsTrue(actual);
+		}
+
+		[TestMethod]
+		public void GetStateClosestToFrame_Correct_WhenReservedGreaterThanCurrent()
+		{
+			const int futureReservedFrame = 1000;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			zw.CaptureReserved(futureReservedFrame, ss);
+			for (int i = 1; i < 10; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			var actual = zw.GetStateClosestToFrame(futureReservedFrame + 1);
+
+			Assert.IsNotNull(actual);
+			Assert.AreEqual(futureReservedFrame, actual.Key);
+		}
+
+		[TestMethod]
+		public void GetStateClosestToFrame_Correct_WhenCurrentIsLast()
+		{
+			const int totalCurrentFrames = 10;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			var actual = zw.GetStateClosestToFrame(totalCurrentFrames);
+
+			Assert.AreEqual(totalCurrentFrames - 1, actual.Key);
+		}
+
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -375,10 +375,10 @@ namespace BizHawk.Tests.Client.Common.Movie
 				zw.Capture(i, ss);
 			}
 
-			for (int i = 0; i < 100000; i++)
+			for (int i = 31183; i < 100000; i++)
 			{
 				var hasState = zw.HasState(i);
-				var hasCache = zw.StateCache.Contains(i);
+				var hasCache = zw._stateCache.Contains(i);
 
 				if (hasState != hasCache)
 				{

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -12,12 +12,12 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void SaveCreateRoundTrip()
 		{
 			var ms = new MemoryStream();
-			var zw = new ZwinderStateManager();
+			var zw = new ZwinderStateManager(f => false);
 			zw.SaveStateHistory(new BinaryWriter(ms));
 			var buff = ms.ToArray();
 			var rms = new MemoryStream(buff, false);
 
-			var zw2 = ZwinderStateManager.Create(new BinaryReader(rms), new ZwinderStateManagerSettings());
+			var zw2 = ZwinderStateManager.Create(new BinaryReader(rms), new ZwinderStateManagerSettings(), f => false);
 
 			// TODO: we could assert more things here to be thorough
 			Assert.IsNotNull(zw2);

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -397,6 +397,27 @@ namespace BizHawk.Tests.Client.Common.Movie
 			}
 		}
 
+		[TestMethod]
+		public void Clear_KeepsZeroState()
+		{
+			// Arrange
+			var ss = CreateStateSource();
+			using var zw = CreateSmallZwinder(ss);
+
+			zw.CaptureReserved(1000, ss);
+			for (int i = 1; i < 10; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			// Act
+			zw.Clear();
+
+			// Assert
+			Assert.AreEqual(1, zw.AllStates().Count());
+			Assert.AreEqual(0, zw.AllStates().Single().Frame);
+		}
+
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -138,7 +138,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			// Arrange
 			const int futureReservedFrame = 1000;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 			
 			zw.CaptureReserved(futureReservedFrame, ss);
 			for (int i = 1; i < 20; i++)
@@ -160,7 +160,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			const int totalCurrentFrames = 20;
 			const int expectedFrameGap = 9;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			for (int i = 1; i < totalCurrentFrames; i++)
 			{
@@ -180,7 +180,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			// Arrange
 			const int futureReservedFrame = 1000;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			zw.CaptureReserved(futureReservedFrame, ss);
 			for (int i = 1; i < 20; i++)
@@ -202,7 +202,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			const int totalCurrentFrames = 20;
 			const int expectedFrameGap = 9;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			for (int i = 1; i < totalCurrentFrames; i++)
 			{
@@ -222,7 +222,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			// Arrange
 			const int futureReservedFrame = 1000;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			zw.CaptureReserved(futureReservedFrame, ss);
 			for (int i = 1; i < 10; i++)
@@ -245,7 +245,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			const int totalCurrentFrames = 20;
 			const int expectedFrameGap = 9;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			for (int i = 1; i < totalCurrentFrames; i++)
 			{
@@ -265,7 +265,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			// Arrange
 			const int futureReservedFrame = 1000;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			zw.CaptureReserved(futureReservedFrame, ss);
 			for (int i = 1; i < 10; i++)
@@ -286,7 +286,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 			// Arrange
 			const int totalCurrentFrames = 10;
 			var ss = CreateStateSource();
-			var zw = CreateSmallZwinder(ss);
+			using var zw = CreateSmallZwinder(ss);
 
 			for (int i = 1; i < totalCurrentFrames; i++)
 			{

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -309,6 +309,51 @@ namespace BizHawk.Tests.Client.Common.Movie
 			Assert.IsFalse(zw.HasState(totalCurrentFrames));
 		}
 
+		[TestMethod]
+		public void Count_NoReserved()
+		{
+			// Arrange
+			const int totalCurrentFrames = 20;
+			const int expectedFrameGap = 10;
+			var ss = CreateStateSource();
+			using var zw = CreateSmallZwinder(ss);
+
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			// Act
+			var actual = zw.Count;
+
+			// Assert
+			var expected = (totalCurrentFrames / expectedFrameGap) + 1;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Count_WithReserved()
+		{
+			// Arrange
+			const int totalCurrentFrames = 20;
+			const int expectedFrameGap = 10;
+			var ss = CreateStateSource();
+			using var zw = CreateSmallZwinder(ss);
+
+			zw.CaptureReserved(1000, ss);
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			// Act
+			var actual = zw.Count;
+
+			// Assert
+			var expected = (totalCurrentFrames / expectedFrameGap) + 2;
+			Assert.AreEqual(expected, actual);
+		}
+
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -354,6 +354,41 @@ namespace BizHawk.Tests.Client.Common.Movie
 			Assert.AreEqual(expected, actual);
 		}
 
+		[TestMethod]
+		public void DeleteMe()
+		{
+			var ss = CreateStateSource();
+			var zw = new ZwinderStateManager(f => false);
+
+			for (int i = 0; i < 10000; i += 200)
+			{
+				zw.CaptureReserved(i, ss);
+			}
+
+			for (int i = 400; i < 10000; i += 400)
+			{
+				zw.EvictReserved(i);
+			}
+
+			for (int i = 0; i < 100000; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			for (int i = 0; i < 100000; i++)
+			{
+				var hasState = zw.HasState(i);
+				var hasCache = zw.StateCache.Contains(i);
+
+				if (hasState != hasCache)
+				{
+					int zzz = 0;
+				}
+
+				Assert.AreEqual(hasState, hasCache);
+			}
+		}
+
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -114,6 +114,46 @@ namespace BizHawk.Tests.Client.Common.Movie
 			Assert.IsTrue(actual <= 10440);
 		}
 
+		[TestMethod]
+		public void Last_Correct_WhenReservedGreaterThanCurrent()
+		{
+			const int futureReservedFrame = 1000;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			zw.CaptureReserved(futureReservedFrame, ss);
+			for (int i = 1; i < 10; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			Assert.AreEqual(futureReservedFrame, zw.Last);
+		}
+
+		[TestMethod]
+		public void Last_Correct_WhenCurrentIsLast()
+		{
+			const int totalCurrentFrames = 10;
+			var ss = new StateSource { PaddingData = new byte[1000] };
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
+			
+			var ms = new MemoryStream();
+			ss.SaveStateBinary(new BinaryWriter(ms));
+			zw.Engage(ms.ToArray());
+
+			for (int i = 1; i < totalCurrentFrames; i++)
+			{
+				zw.Capture(i, ss);
+			}
+
+			Assert.AreEqual(totalCurrentFrames - 1, zw.Last);
+		}
+
+
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -114,46 +114,6 @@ namespace BizHawk.Tests.Client.Common.Movie
 			Assert.IsTrue(actual <= 10440);
 		}
 
-		[TestMethod]
-		public void Last_Correct_WhenReservedGreaterThanCurrent()
-		{
-			const int futureReservedFrame = 1000;
-			var ss = new StateSource { PaddingData = new byte[1000] };
-			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
-			
-			var ms = new MemoryStream();
-			ss.SaveStateBinary(new BinaryWriter(ms));
-			zw.Engage(ms.ToArray());
-
-			zw.CaptureReserved(futureReservedFrame, ss);
-			for (int i = 1; i < 10; i++)
-			{
-				zw.Capture(i, ss);
-			}
-
-			Assert.AreEqual(futureReservedFrame, zw.Last);
-		}
-
-		[TestMethod]
-		public void Last_Correct_WhenCurrentIsLast()
-		{
-			const int totalCurrentFrames = 10;
-			var ss = new StateSource { PaddingData = new byte[1000] };
-			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings());
-			
-			var ms = new MemoryStream();
-			ss.SaveStateBinary(new BinaryWriter(ms));
-			zw.Engage(ms.ToArray());
-
-			for (int i = 1; i < totalCurrentFrames; i++)
-			{
-				zw.Capture(i, ss);
-			}
-
-			Assert.AreEqual(totalCurrentFrames - 1, zw.Last);
-		}
-
-
 		private class StateSource : IStatable
 		{
 			public int Frame { get; set; }

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using BizHawk.Client.Common;
 using BizHawk.Emulation.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -355,7 +356,7 @@ namespace BizHawk.Tests.Client.Common.Movie
 		}
 
 		[TestMethod]
-		public void DeleteMe()
+		public void StateCache()
 		{
 			var ss = CreateStateSource();
 			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings
@@ -384,11 +385,15 @@ namespace BizHawk.Tests.Client.Common.Movie
 
 			zw.Capture(101, ss);
 
+			var allStates = zw.AllStates()
+				.Select(s => s.Frame)
+				.ToList();
+
 			for (int i = 0; i < 10000; i++)
 			{
-				var hasState = zw.HasState(i);
-				var hasCache = zw.StateCache.Contains(i);
-				Assert.AreEqual(hasState, hasCache);
+				var actual = zw.HasState(i);
+				var expected = allStates.Contains(i);
+				Assert.AreEqual(expected, actual);
 			}
 		}
 

--- a/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
+++ b/src/BizHawk.Tests/Client.Common/Movie/ZwinderStateManagerTests.cs
@@ -33,12 +33,21 @@ namespace BizHawk.Tests.Client.Common.Movie
 		public void SaveCreateRoundTrip()
 		{
 			var ms = new MemoryStream();
-			var zw = new ZwinderStateManager(f => false);
+			var zw = new ZwinderStateManager(new ZwinderStateManagerSettings
+			{
+				CurrentBufferSize = 16,
+				CurrentTargetFrameLength = 10000,
+
+				RecentBufferSize = 16,
+				RecentTargetFrameLength = 100000,
+
+				AncientStateInterval = 50000
+			});
 			zw.SaveStateHistory(new BinaryWriter(ms));
 			var buff = ms.ToArray();
 			var rms = new MemoryStream(buff, false);
 
-			var zw2 = ZwinderStateManager.Create(new BinaryReader(rms), new ZwinderStateManagerSettings(), f => false);
+			var zw2 = ZwinderStateManager.Create(new BinaryReader(rms), zw.Settings, f => false);
 
 			// TODO: we could assert more things here to be thorough
 			Assert.IsNotNull(zw2);


### PR DESCRIPTION
A lot of fixes and refactors here.
1) Rename ancient to reserved and make it a dictionary
2) roll frameZeroState into the reserved section
3) roll bookmark states into reserved
4) add a reserved callback that the client code can pass in, that will check this and put things in reserved rather than evict them,
client code will check if marker or branch state
4) refactor assumptions about reserved always being states before current or recent
5) add a gapFiller, that will do the job highPriority was badly doing, and do it better
6) add a state cache that keeps track of all frames that have a state, use this in HasState, for a huge performance boost, compared to both the previous zwinder code and the old state manager, both had a O(n) problem, where performance slowed down greatly as the size of the movie increased
7) add unit tests to cover a variety of scenarios