### PR TITLE
rohmloader tweak

### DIFF
--- a/src/BizHawk.Client.Common/RomLoader.cs
+++ b/src/BizHawk.Client.Common/RomLoader.cs
@@ -362,6 +362,8 @@ namespace BizHawk.Client.Common
 				}
 				catch (Exception e)
 				{
+					if (e is MissingFirmwareException || e.InnerException is MissingFirmwareException)
+						throw;
 					exceptions.Add(e);
 				}
 			}


### PR DESCRIPTION
When a missingfirmwareexception is encountered, do not fallback.  It's presumed that these cases are fixable by the end user.

Absolutely does not in any way fix #2327 - the user was emphatic that they had the BIOS file, so they must have hit some other situation.