### PR TITLE
GBA: allow light sensor to reach 255 and default it to 0

### DIFF
--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -14,7 +14,7 @@ namespace BizHawk.Client.Common
 			Definition = definition;
 			foreach (var kvp in Definition.Axes)
 			{
-				_axes[kvp.Key] = kvp.Value.Mid;
+				_axes[kvp.Key] = kvp.Value.RestingValue;
 				_axisRanges[kvp.Key] = kvp.Value;
 			}
 		}

--- a/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
+++ b/src/BizHawk.Client.Common/display/IInputDisplayGenerator.cs
@@ -41,7 +41,7 @@ namespace BizHawk.Client.Common
 						{
 							var val = _source.AxisValue(button);
 
-							if (val == range.Mid)
+							if (val == range.RestingValue)
 							{
 								sb.Append("      ");
 							}

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Controller.cs
@@ -69,7 +69,7 @@ namespace BizHawk.Client.Common
 			// axes don't have sticky logic, so latch default value
 			foreach (var kvp in Definition.Axes)
 			{
-				_myAxisControls[kvp.Key] = kvp.Value.Mid;
+				_myAxisControls[kvp.Key] = kvp.Value.RestingValue;
 			}
 		}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2LogEntryGenerator.cs
@@ -75,7 +75,7 @@ namespace BizHawk.Client.Common
 					{
 						if (_source.Definition.Axes.TryGetValue(button, out var range))
 						{
-							var val = createEmpty ? range.Mid : _source.AxisValue(button);
+							var val = createEmpty ? range.RestingValue : _source.AxisValue(button);
 
 							sb.Append(val.ToString().PadLeft(5, ' ')).Append(',');
 						}

--- a/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Macros/MovieZone.cs
@@ -296,7 +296,7 @@ namespace BizHawk.Client.EmuHawk
 			foreach (string name in latching.Definition.Axes.Keys)
 			{
 				var axisValue = source.AxisValue(name);
-				if (axisValue == source.Definition.Axes[name].Mid)
+				if (axisValue == source.Definition.Axes[name].RestingValue)
 				{
 					latching.SetAxis(name, axisValue);
 				}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -359,7 +359,7 @@ namespace BizHawk.Client.EmuHawk
 						if (column.Type == ColumnType.Axis)
 						{
 							// feos: this could be cached, but I don't notice any slowdown this way either
-							if (text == ((float) ControllerType.Axes[columnName].Mid).ToString())
+							if (text == ((float) ControllerType.Axes[columnName].RestingValue).ToString())
 							{
 								text = "";
 							}

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/VirtualPadAnalogStick.cs
@@ -42,13 +42,13 @@ namespace BizHawk.Client.EmuHawk
 				PolarToRectHelper = (r, θ) =>
 				{
 					var (x, y) = PolarRectConversion.PolarToRectLookup((ushort) r, (ushort) θ);
-					var x1 = (RangeX.IsReversed ? RangeX.Mid - x : RangeX.Mid + x).ConstrainWithin(RangeX.Range);
-					var y1 = (RangeY.IsReversed ? RangeY.Mid - y : RangeY.Mid + y).ConstrainWithin(RangeY.Range);
+					var x1 = (RangeX.IsReversed ? RangeX.RestingValue - x : RangeX.RestingValue + x).ConstrainWithin(RangeX.Range);
+					var y1 = (RangeY.IsReversed ? RangeY.RestingValue - y : RangeY.RestingValue + y).ConstrainWithin(RangeY.Range);
 					return ((short) x1, (short) y1);
 				};
 				RectToPolarHelper = (x, y) => PolarRectConversion.RectToPolarLookup(
-					(sbyte) (RangeX.IsReversed ? RangeX.Mid - x : x - RangeX.Mid),
-					(sbyte) (RangeY.IsReversed ? RangeY.Mid - y : y - RangeY.Mid)
+					(sbyte) (RangeX.IsReversed ? RangeX.RestingValue - x : x - RangeX.RestingValue),
+					(sbyte) (RangeY.IsReversed ? RangeY.RestingValue - y : y - RangeY.RestingValue)
 				);
 			}
 			else
@@ -60,14 +60,14 @@ namespace BizHawk.Client.EmuHawk
 				{
 					var x = (short) (r * Math.Cos(θ * DEG_TO_RAD_FACTOR));
 					var y = (short) (r * Math.Sin(θ * DEG_TO_RAD_FACTOR));
-					var x1 = (RangeX.IsReversed ? RangeX.Mid - x : RangeX.Mid + x).ConstrainWithin(RangeX.Range);
-					var y1 = (RangeY.IsReversed ? RangeY.Mid - y : RangeY.Mid + y).ConstrainWithin(RangeY.Range);
+					var x1 = (RangeX.IsReversed ? RangeX.RestingValue - x : RangeX.RestingValue + x).ConstrainWithin(RangeX.Range);
+					var y1 = (RangeY.IsReversed ? RangeY.RestingValue - y : RangeY.RestingValue + y).ConstrainWithin(RangeY.Range);
 					return ((short) x1, (short) y1);
 				};
 				RectToPolarHelper = (x, y) =>
 				{
-					double x1 = RangeX.IsReversed ? RangeX.Mid - x : x - RangeX.Mid;
-					double y1 = RangeY.IsReversed ? RangeY.Mid - y : y - RangeY.Mid;
+					double x1 = RangeX.IsReversed ? RangeX.RestingValue - x : x - RangeX.RestingValue;
+					double y1 = RangeY.IsReversed ? RangeY.RestingValue - y : y - RangeY.RestingValue;
 					var θ = Math.Atan2(y1, x1) * RAD_TO_DEG_FACTOR;
 					return ((uint) Math.Sqrt(x1 * x1 + y1 * y1), (uint) (θ < 0 ? 360.0 + θ : θ));
 				};

--- a/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/VirtualPads/controls/components/AnalogStickPanel.cs
@@ -90,10 +90,10 @@ namespace BizHawk.Client.EmuHawk
 			_reverseX = _fullRangeX.IsReversed ^ _userRangePercentageX < 0;
 			_reverseY = _fullRangeY.IsReversed ^ _userRangePercentageY < 0;
 
-			_rangeX = (_fullRangeX.Mid - (_fullRangeX.Mid - _fullRangeX.Min) * _userRangePercentageX / 100)
-				.RangeTo(_fullRangeX.Mid + (_fullRangeX.Max - _fullRangeX.Mid) * _userRangePercentageX / 100);
-			_rangeY = (_fullRangeY.Mid - (_fullRangeY.Mid - _fullRangeY.Min) * _userRangePercentageY / 100)
-				.RangeTo(_fullRangeY.Mid + (_fullRangeY.Max - _fullRangeY.Mid) * _userRangePercentageY / 100);
+			_rangeX = (_fullRangeX.RestingValue - (_fullRangeX.RestingValue - _fullRangeX.Min) * _userRangePercentageX / 100)
+				.RangeTo(_fullRangeX.RestingValue + (_fullRangeX.Max - _fullRangeX.RestingValue) * _userRangePercentageX / 100);
+			_rangeY = (_fullRangeY.RestingValue - (_fullRangeY.RestingValue - _fullRangeY.Min) * _userRangePercentageY / 100)
+				.RangeTo(_fullRangeY.RestingValue + (_fullRangeY.Max - _fullRangeY.RestingValue) * _userRangePercentageY / 100);
 
 			_x = _x.ConstrainWithin(_rangeX);
 			_y = _y.ConstrainWithin(_rangeY);

--- a/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
@@ -25,7 +25,7 @@ namespace BizHawk.Emulation.Common
 		/// <remarks>does not include the extra char needed for a minus sign</remarks>
 		public int MaxDigits => Math.Max(Math.Abs(Min).ToString().Length, Math.Abs(Max).ToString().Length);
 
-		public readonly int Mid;
+		public readonly int RestingValue;
 
 		public int Min => Range.Start;
 
@@ -33,11 +33,11 @@ namespace BizHawk.Emulation.Common
 
 		public readonly Range<int> Range;
 
-		public AxisSpec(Range<int> range, int mid, bool isReversed = false, AxisConstraint? constraint = null)
+		public AxisSpec(Range<int> range, int resting, bool isReversed = false, AxisConstraint? constraint = null)
 		{
 			Constraint = constraint;
 			IsReversed = isReversed;
-			Mid = mid;
+			RestingValue = resting;
 			Range = range;
 		}
 	}

--- a/src/BizHawk.Emulation.Common/Extensions.cs
+++ b/src/BizHawk.Emulation.Common/Extensions.cs
@@ -405,9 +405,9 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		/// <param name="constraint">pass only for one axis in a pair, by convention the X axis</param>
 		/// <returns>identical reference to <paramref name="def"/>; the object is mutated</returns>
-		public static ControllerDefinition AddAxis(this ControllerDefinition def, string name, Range<int> range, int mid, bool isReversed = false, AxisConstraint constraint = null)
+		public static ControllerDefinition AddAxis(this ControllerDefinition def, string name, Range<int> range, int resting, bool isReversed = false, AxisConstraint constraint = null)
 		{
-			def.Axes.Add(name, new AxisSpec(range, mid, isReversed, constraint));
+			def.Axes.Add(name, new AxisSpec(range, resting, isReversed, constraint));
 			return def;
 		}
 
@@ -445,6 +445,6 @@ namespace BizHawk.Emulation.Common
 				.AddAxis(string.Format(nameFormat, "Y"), rangeAll, midAll)
 				.AddAxis(string.Format(nameFormat, "Z"), rangeAll, midAll);
 
-		public static AxisSpec With(this in AxisSpec spec, Range<int> range, int mid) => new AxisSpec(range, mid, spec.IsReversed, spec.Constraint);
+		public static AxisSpec With(this in AxisSpec spec, Range<int> range, int resting) => new AxisSpec(range, resting, spec.IsReversed, spec.Constraint);
 	}
 }

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
@@ -271,6 +271,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			Name = "GBA Controller",
 			BoolButtons = { "Up", "Down", "Left", "Right", "Start", "Select", "B", "A", "L", "R", "Power" }
 		}.AddXYZTriple("Tilt {0}", (-32767).RangeTo(32767), 0)
-			.AddAxis("Light Sensor", 0.RangeTo(200), 100);
+			.AddAxis("Light Sensor", 0.RangeTo(255), 0);
 	}
 }


### PR DESCRIPTION
Rename AxisSpec.Mid to AxisSpec.RestingValue to better reflect its purpose

The goal here is to fix #2323.

There's still a problem where TAStudio recording mode (and general gameplay, probably?) defaults to 128 for the light sensor value instead of 0. This is due to `Controller.NormalizeAxes` setting it to the midpoint between `min` and `max`.