### PR TITLE
Fix scaling of axes

### DIFF
--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -68,15 +68,11 @@ namespace BizHawk.Client.Common
 				// scale by user-set multiplier (which is 0..1, i.e. value can only shrink and is therefore still in -1..1)
 				value *= kvp.Value.Mult;
 
-				// -1..1 -> 0..1
-				value = (value + 1.0f) / 2.0f;
+				// -1..1 -> range
+				value += range.Mid;
+				value *= Math.Max(range.Mid - range.Min, range.Max - range.Mid);
 
-				// 0..1 -> range
-				value = range.IsReversed
-					? range.Max + value * (2 - range.Range.Count()) // this is equivalent to the old code
-					: range.Min + value * range.Range.Count();
-
-				// finally, constrain to range again in case the original value was unexpectedly large, or the deadzone and scale made it so
+				// finally, constrain to range again in case the original value was unexpectedly large, or the deadzone and scale made it so, or the axis is lopsided
 				value = value.ConstrainWithin(range.FloatRange);
 
 				_axes[kvp.Key] = (int) value;

--- a/src/BizHawk.Client.Common/Controller.cs
+++ b/src/BizHawk.Client.Common/Controller.cs
@@ -73,9 +73,7 @@ namespace BizHawk.Client.Common
 				value *= Math.Max(range.Mid - range.Min, range.Max - range.Mid);
 
 				// finally, constrain to range again in case the original value was unexpectedly large, or the deadzone and scale made it so, or the axis is lopsided
-				value = value.ConstrainWithin(range.FloatRange);
-
-				_axes[kvp.Key] = (int) value;
+				_axes[kvp.Key] = ((int) value).ConstrainWithin(range.Range);
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -1267,7 +1267,8 @@ namespace BizHawk.Client.EmuHawk
 			string prevTyped = _axisTypedValue;
 
 			var range = ControllerType.Axes[_axisEditColumn];
-			var (rMin, rMax) = range.FloatRange;
+			float rMin = range.Min;
+			float rMax = range.Max;
 
 			// feos: typing past max digits overwrites existing value, not touching the sign
 			// but doesn't handle situations where the range is like -50 through 100, where minimum is negative and has less digits

--- a/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
+++ b/src/BizHawk.Emulation.Common/Base Implementations/Axes/AxisSpec.cs
@@ -15,8 +15,6 @@ namespace BizHawk.Emulation.Common
 		/// </summary>
 		public readonly AxisConstraint? Constraint;
 
-		public Range<float> FloatRange => ((float) Min).RangeTo(Max);
-
 		public readonly bool IsReversed;
 
 		public int Max => Range.EndInclusive;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/GBA/MGBAHawk.cs
@@ -271,6 +271,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.GBA
 			Name = "GBA Controller",
 			BoolButtons = { "Up", "Down", "Left", "Right", "Start", "Select", "B", "A", "L", "R", "Power" }
 		}.AddXYZTriple("Tilt {0}", (-32767).RangeTo(32767), 0)
-			.AddAxis("Light Sensor", 0.RangeTo(200), 100);
+			.AddAxis("Light Sensor", 0.RangeTo(255), 0);
 	}
 }


### PR DESCRIPTION
Binding host gamepad sticks to virtual sticks should work the same as before, bar typos. Binding host gamepad sticks and triggers to virtual triggers (or trigger-like axes e.g. light sensor) was changed. I think it's an improvement.

edit: Just spotted a division by zero bug, but it was present in the old code too so ¯\\\_(ツ)_/¯

merging closes #2323