### PR TITLE
TAStudio: Fix deletion crashing when deleting invalid indexes

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -114,7 +114,8 @@ namespace BizHawk.Client.Common
 			{
 				// Separate the given frames into contiguous blocks
 				// and process each block independently
-				List<int> framesToDelete = frames.OrderBy(fr => fr).ToList();
+				List<int> framesToDelete = frames.Where(fr => fr >= 0 && fr < InputLogLength)
+					.OrderBy(fr => fr).ToList();
 				// f is the current index for framesToDelete
 				int f = 0;
 				int numDeleted = 0;

--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.Editing.cs
@@ -114,8 +114,10 @@ namespace BizHawk.Client.Common
 			{
 				// Separate the given frames into contiguous blocks
 				// and process each block independently
-				List<int> framesToDelete = frames.Where(fr => fr >= 0 && fr < InputLogLength)
-					.OrderBy(fr => fr).ToList();
+				List<int> framesToDelete = frames
+					.Where(fr => fr >= 0 && fr < InputLogLength)
+					.OrderBy(fr => fr)
+					.ToList();
 				// f is the current index for framesToDelete
 				int f = 0;
 				int numDeleted = 0;


### PR DESCRIPTION
The problem occurs when trying to delete a selection where some of the frames were valid, but the last displayed line (which is currently an extra non-input frame) was in the selection.