### PR TITLE
Markers/branch multi-selection

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -944,6 +944,11 @@ namespace BizHawk.Client.EmuHawk
 
 		public bool AnyRowsSelected => _selectedItems.Any(cell => cell.RowIndex.HasValue);
 
+		/// <summary>
+		/// Rows are selected and the selection is in focus.
+		/// </summary>
+		public bool SelectionFocused => AnyRowsSelected && Focused;
+
 		public IEnumerable<ToolStripItem> GenerateContextMenuItems()
 		{
 			if (Rotatable)

--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/RollColumn.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/RollColumn.cs
@@ -8,7 +8,9 @@
 		public int Right { get; set; }
 		public string Name { get; set; }
 		public string Text { get; set; }
-		public ColumnType Type { get; set; }
+		
+		// Is this the default we want? ColumnType.Text is the most common.
+		public ColumnType Type { get; set; } = ColumnType.Boolean;
 		public bool Visible { get; set; } = true;
 
 		/// <summary>

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -76,19 +76,22 @@ namespace BizHawk.Client.EmuHawk
 				{
 					Name = BranchNumberColumnName,
 					Text = "#",
-					UnscaledWidth = 30
+					UnscaledWidth = 30,
+					Type = ColumnType.Text
 				},
 				new RollColumn
 				{
 					Name = FrameColumnName,
 					Text = "Frame",
-					UnscaledWidth = 64
+					UnscaledWidth = 64,
+					Type = ColumnType.Text
 				},
 				new RollColumn
 				{
 					Name = UserTextColumnName,
 					Text = "UserText",
-					UnscaledWidth = 90
+					UnscaledWidth = 90,
+					Type = ColumnType.Text
 				}
 			});
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/MarkerControl.cs
@@ -43,13 +43,15 @@ namespace BizHawk.Client.EmuHawk
 				{
 					Name = "FrameColumn",
 					Text = "Frame",
-					UnscaledWidth = 52
+					UnscaledWidth = 52,
+					Type = ColumnType.Text
 				},
 				new RollColumn
 				{
 					Name = "LabelColumn",
 					Text = "",
-					UnscaledWidth = 125
+					UnscaledWidth = 125,
+					Type = ColumnType.Text
 				}
 			});
 		}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.MenuItems.cs
@@ -205,7 +205,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void SaveSelectionToMacroMenuItem_Click(object sender, EventArgs e)
 		{
-			if (!TasView.AnyRowsSelected)
+			if (!TasView.SelectionFocused)
 			{
 				return;
 			}
@@ -230,7 +230,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PlaceMacroAtSelectionMenuItem_Click(object sender, EventArgs e)
 		{
-			if (!TasView.AnyRowsSelected)
+			if (!TasView.SelectionFocused)
 			{
 				return;
 			}
@@ -392,7 +392,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void SelectBetweenMarkersMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var prevMarker = CurrentTasMovie.Markers.PreviousOrCurrent(TasView.LastSelectedIndex ?? 0);
 				var nextMarker = CurrentTasMovie.Markers.Next(TasView.LastSelectedIndex ?? 0);
@@ -424,7 +424,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CopyMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				_tasClipboard.Clear();
 				var list = TasView.SelectedRows.ToArray();
@@ -450,7 +450,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PasteMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				// TODO: if highlighting 2 rows and pasting 3, only paste 2 of them
 				// FCEUX Taseditor doesn't do this, but I think it is the expected behavior in editor programs
@@ -493,7 +493,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PasteInsertMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				// copy paste from PasteMenuItem_Click!
 				IDataObject data = Clipboard.GetDataObject();
@@ -534,7 +534,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CutMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var needsToRollback = TasView.FirstSelectedIndex < Emulator.Frame;
 				var rollBackFrame = TasView.FirstSelectedIndex ?? 0;
@@ -572,7 +572,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ClearFramesMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var firstWithInput = FirstNonEmptySelectedFrame;
 				bool needsToRollback = firstWithInput.HasValue && firstWithInput < Emulator.Frame;
@@ -598,7 +598,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DeleteFramesMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var needsToRollback = TasView.FirstSelectedIndex < Emulator.Frame;
 				var rollBackFrame = TasView.FirstSelectedIndex ?? 0;
@@ -640,7 +640,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			for (int i = 0; i < timesToClone; i++)
 			{
-				if (TasView.AnyRowsSelected)
+				if (TasView.SelectionFocused)
 				{
 					var framesToInsert = TasView.SelectedRows;
 					var insertionFrame = Math.Min((TasView.LastSelectedIndex ?? 0) + 1, CurrentTasMovie.InputLogLength);
@@ -665,7 +665,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void InsertFrameMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var insertionFrame = TasView.FirstSelectedIndex ?? 0;
 				var needsToRollback = TasView.FirstSelectedIndex < Emulator.Frame;
@@ -684,7 +684,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void InsertNumFramesMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				int insertionFrame = TasView.FirstSelectedIndex ?? 0;
 				using var framesPrompt = new FramesPrompt();
@@ -697,7 +697,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void TruncateMenuItem_Click(object sender, EventArgs e)
 		{
-			if (TasView.AnyRowsSelected)
+			if (TasView.SelectionFocused)
 			{
 				var rollbackFrame = TasView.LastSelectedIndex ?? 0;
 				var needsToRollback = TasView.FirstSelectedIndex < Emulator.Frame;

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -702,7 +702,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void DummyLoadMacro(string path)
 		{
-			if (!TasView.AnyRowsSelected)
+			if (!TasView.SelectionFocused)
 			{
 				return;
 			}


### PR DESCRIPTION
See also: #2215

The previous work intended to implement multi-select for 2.5 doesn't quite work right, so I'm trying to fix it here.

Known issues:

- [x] The current implementation for multiselect really doesn't play nicely with the way users expect branches to behave (#2405) -- 3575446
- [x] Selecting branches or markers doesn't deselect the input roll, meaning you can still clear the input roll when selecting markers. (EDIT: this was slightly misphrased: more accurately, input roll hotkeys still apply even when the TasView isn't the currently focused component).