### PR TITLE
Added Pop_OS support for library paths

### DIFF
--- a/Assets/EmuHawkMono.sh
+++ b/Assets/EmuHawkMono.sh
@@ -9,7 +9,7 @@ winepath=""
 if [ "$(command -v lsb_release)" ]; then
 	case "$(lsb_release -i | cut -c17- | tr -d "\n")" in
 		"Arch"|"ManjaroLinux") libpath="/usr/lib";;
-		"Debian"|"LinuxMint"|"Ubuntu") libpath="/usr/lib/x86_64-linux-gnu"; export MONO_WINFORMS_XIM_STYLE=disabled;; # see https://bugzilla.xamarin.com/show_bug.cgi?id=28047#c9
+		"Debian"|"LinuxMint"|"Ubuntu"|"Pop") libpath="/usr/lib/x86_64-linux-gnu"; export MONO_WINFORMS_XIM_STYLE=disabled;; # see https://bugzilla.xamarin.com/show_bug.cgi?id=28047#c9
 	esac
 else
 	printf "Distro does not provide LSB release info API! (You've met with a terrible fate, haven't you?)\n"


### PR DESCRIPTION
Pop_OS is a Linux distro based on Ubuntu. I added it to the Unix launch shell script in order to remove an error message I received.