### PR TITLE
Simplify Gambatte's sync settings for selecting GBA

### DIFF
--- a/src/BizHawk.Client.EmuHawk/config/ProfileConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/ProfileConfig.cs
@@ -224,7 +224,6 @@ namespace BizHawk.Client.EmuHawk
 			_config.PreferredCores["GBC"] = CoreNames.Gambatte;
 			var s = GetSyncSettings<Gameboy, Gameboy.GambatteSyncSettings>();
 			s.EnableBIOS = true;
-			s.GBACGB = false;
 			PutSyncSettings<Gameboy>(s);
 			
 		}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISettable.cs
@@ -97,18 +97,14 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 			{
 				Auto,
 				GB,
-				GBC
+				GBC,
+				GBA
 			}
 
 			[DisplayName("Console Mode")]
-			[Description("Pick which console to run, 'Auto' chooses from ROM header, 'GB' and 'GBC' chooses the respective system")]
+			[Description("Pick which console to run, 'Auto' chooses from ROM header; 'GB', 'GBC', and 'GBA' chooses the respective system")]
 			[DefaultValue(ConsoleModeType.Auto)]
 			public ConsoleModeType ConsoleMode { get; set; }
-
-			[DisplayName("CGB in GBA")]
-			[Description("Emulate GBA hardware running a CGB game, instead of CGB hardware.  Relevant only for titles that detect the presense of a GBA, such as Shantae.")]
-			[DefaultValue(false)]
-			public bool GBACGB { get; set; }
 
 			[DisplayName("Multicart Compatibility")]
 			[Description("Use special compatibility hacks for certain multicart games.  Relevant only for specific multicarts.")]

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.cs
@@ -64,15 +64,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 						break;
 					case GambatteSyncSettings.ConsoleModeType.GBC:
 						break;
+					case GambatteSyncSettings.ConsoleModeType.GBA:
+						flags |= LibGambatte.LoadFlags.GBA_CGB;
+						break;
 					default:
 						if (game.System == "GB")
 							flags |= LibGambatte.LoadFlags.FORCE_DMG;
 						break;
-				}
-
-				if (_syncSettings.GBACGB)
-				{
-					flags |= LibGambatte.LoadFlags.GBA_CGB;
 				}
 
 				if (_syncSettings.MulticartCompat)
@@ -97,7 +95,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 				else
 				{
 					biosSystemId = "GBC";
-					biosId = _syncSettings.GBACGB ? "AGB" : "World";
+					biosId = _syncSettings.ConsoleMode == GambatteSyncSettings.ConsoleModeType.GBA ? "AGB" : "World";
 					IsCgb = true;
 				}
 


### PR DESCRIPTION
Having GBA be a console mode is more straightforward for users to understand and a more logical way of arranging options. GBA is literally a console mode, not an additional modifier to a console mode.