### PR TITLE
StateManager - increase performance when there are a lot of states, fixes issue #2428

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using  BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common
@@ -11,7 +12,7 @@ namespace BizHawk.Client.Common
 		private static readonly byte[] NonState = new byte[0];
 
 		private readonly Func<int, bool> _reserveCallback;
-		internal readonly List<int> StateCache = new List<int>();
+		internal readonly SortedList<int> StateCache = new SortedList<int>();
 		private ZwinderBuffer _current;
 		private ZwinderBuffer _recent;
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -469,7 +469,7 @@ namespace BizHawk.Client.Common
 			var b1 = InvalidateNormal(frame);
 			var b2 = InvalidateGaps(frame);
 			var b3 = InvalidateReserved(frame);
-			StateCache.RemoveAll(s => s > frame);
+			StateCache.RemoveAfter(frame);
 			return b1 || b2 || b3;
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Client.Common
 		private static readonly byte[] NonState = new byte[0];
 
 		private readonly Func<int, bool> _reserveCallback;
-		internal readonly SortedSet<int> StateCache = new SortedSet<int>();
+		internal readonly List<int> StateCache = new List<int>();
 		private ZwinderBuffer _current;
 		private ZwinderBuffer _recent;
 
@@ -45,7 +45,7 @@ namespace BizHawk.Client.Common
 			if (!_reserved.ContainsKey(0))
 			{
 				_reserved.Add(0, frameZeroState);
-				StateCache.Add(0);
+				AddStateCache(0);
 			}
 		}
 
@@ -149,7 +149,9 @@ namespace BizHawk.Client.Common
 		{
 			StateCache.Clear();
 			foreach (StateInfo state in AllStates())
-				StateCache.Add(state.Frame);
+			{
+				AddStateCache(state.Frame);
+			}
 		}
 
 		public int Count => _current.Count + _recent.Count + _gapFiller.Count + _reserved.Count;
@@ -227,7 +229,7 @@ namespace BizHawk.Client.Common
 			var ms = new MemoryStream();
 			source.SaveStateBinary(new BinaryWriter(ms));
 			_reserved.Add(frame, ms.ToArray());
-			StateCache.Add(frame);
+			AddStateCache(frame);
 		}
 
 		private void AddToReserved(ZwinderBuffer.StateInformation state)
@@ -241,7 +243,15 @@ namespace BizHawk.Client.Common
 			var ms = new MemoryStream(bb);
 			state.GetReadStream().CopyTo(ms);
 			_reserved.Add(state.Frame, bb);
-			StateCache.Add(state.Frame);
+			AddStateCache(state.Frame);
+		}
+
+		private void AddStateCache(int frame)
+		{
+			if (!StateCache.Contains(frame))
+			{
+				StateCache.Add(frame);
+			}
 		}
 
 		public void EvictReserved(int frame)
@@ -285,7 +295,7 @@ namespace BizHawk.Client.Common
 				s =>
 				{
 					source.SaveStateBinary(new BinaryWriter(s));
-					StateCache.Add(frame);
+					AddStateCache(frame);
 				},
 				index =>
 				{
@@ -303,7 +313,7 @@ namespace BizHawk.Client.Common
 						s =>
 						{
 							state.GetReadStream().CopyTo(s);
-							StateCache.Add(state.Frame);
+							AddStateCache(state.Frame);
 						},
 						index2 => 
 						{
@@ -369,7 +379,7 @@ namespace BizHawk.Client.Common
 			_gapFiller.Capture(
 				frame, s =>
 				{
-					StateCache.Add(frame);
+					AddStateCache(frame);
 					source.SaveStateBinary(new BinaryWriter(s));
 				},
 				index => StateCache.Remove(index));
@@ -381,7 +391,7 @@ namespace BizHawk.Client.Common
 			_recent.InvalidateEnd(0);
 			_gapFiller.InvalidateEnd(0);
 			StateCache.Clear();
-			StateCache.Add(0);
+			AddStateCache(0);
 			_reserved = _reserved
 				.Where(kvp => kvp.Key == 0)
 				.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
@@ -409,7 +419,7 @@ namespace BizHawk.Client.Common
 				if (state.Frame > frame)
 				{
 					var last = GapStates().First();
-					StateCache.RemoveWhere(s => s >= state.Frame && s <= last.Frame); // TODO: be consistent, other invalidate methods do not touch cache and it is addressed in the public InvalidateAfter
+					StateCache.RemoveAll(s => s >= state.Frame && s <= last.Frame); // TODO: be consistent, other invalidate methods do not touch cache and it is addressed in the public InvalidateAfter
 
 					_gapFiller.InvalidateEnd(i);
 					return true;
@@ -458,7 +468,7 @@ namespace BizHawk.Client.Common
 			var b1 = InvalidateNormal(frame);
 			var b2 = InvalidateGaps(frame);
 			var b3 = InvalidateReserved(frame);
-			StateCache.RemoveWhere(s => s > frame);
+			StateCache.RemoveAll(s => s > frame);
 			return b1 || b2 || b3;
 		}
 

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using  BizHawk.Common;
+using BizHawk.Common;
 using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.Common

--- a/src/BizHawk.Common/CustomCollections.cs
+++ b/src/BizHawk.Common/CustomCollections.cs
@@ -36,6 +36,54 @@ namespace BizHawk.Common
 		public IEnumerator<KeyValuePair<TKey, List<TValue>>> GetKVPEnumerator() => dictionary.GetEnumerator();
 	}
 
+	public class SortedList<T> : ICollection<T>
+		where T : IComparable<T>
+	{
+		private readonly List<T> _list;
+
+		public int Count => _list.Count;
+
+		public bool IsReadOnly { get; } = false;
+
+		public SortedList() => _list = new List<T>();
+
+		public SortedList(IEnumerable<T> collection)
+		{
+			_list = new List<T>(collection);
+			_list.Sort();
+		}
+
+		public T this[int index] => _list[index];
+
+		public void Add(T item)
+		{
+			var i = _list.BinarySearch(item);
+			_list.Insert(i < 0 ? ~i : i, item);
+		}
+
+		public void Clear() => _list.Clear();
+
+		public bool Contains(T item) => _list.BinarySearch(item) >= 0; // can't use `!= -1`, BinarySearch can return multiple negative values
+
+		public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+
+		public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+		public bool Remove(T item)
+		{
+#if true
+			var i = _list.BinarySearch(item);
+			if (i < 0) return false;
+			_list.RemoveAt(i);
+			return true;
+#else //TODO is this any slower?
+			return _list.Remove(item);
+#endif
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
 	/// <summary>A dictionary whose index getter creates an entry if the requested key isn't part of the collection, making it always safe to use the returned value. The new entry's value will be the result of the default constructor of <typeparamref name="TValue"/>.</summary>
 	[Serializable]
 	public class WorkingDictionary<TKey, TValue> : Dictionary<TKey, TValue>

--- a/src/BizHawk.Common/CustomCollections.cs
+++ b/src/BizHawk.Common/CustomCollections.cs
@@ -39,11 +39,11 @@ namespace BizHawk.Common
 	public class SortedList<T> : ICollection<T>
 		where T : IComparable<T>
 	{
-		private readonly List<T> _list;
+		protected readonly List<T> _list;
 
-		public int Count => _list.Count;
+		public virtual int Count => _list.Count;
 
-		public bool IsReadOnly { get; } = false;
+		public virtual bool IsReadOnly { get; } = false;
 
 		public SortedList() => _list = new List<T>();
 
@@ -53,23 +53,31 @@ namespace BizHawk.Common
 			_list.Sort();
 		}
 
-		public T this[int index] => _list[index];
+		public virtual T this[int index] => _list[index];
 
-		public void Add(T item)
+		public virtual void Add(T item)
 		{
 			var i = _list.BinarySearch(item);
 			_list.Insert(i < 0 ? ~i : i, item);
 		}
 
-		public void Clear() => _list.Clear();
+		public virtual int BinarySearch(T item) => _list.BinarySearch(item);
 
-		public bool Contains(T item) => _list.BinarySearch(item) >= 0; // can't use `!= -1`, BinarySearch can return multiple negative values
+		public virtual void Clear() => _list.Clear();
 
-		public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+		public virtual bool Contains(T item) => !(_list.BinarySearch(item) < 0); // can't use `!= -1`, BinarySearch can return multiple negative values
 
-		public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+		public virtual void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
 
-		public bool Remove(T item)
+		public virtual IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+		public virtual int IndexOf(T item)
+		{
+			var i = _list.BinarySearch(item);
+			return i < 0 ? -1 : i;
+		}
+
+		public virtual bool Remove(T item)
 		{
 #if true
 			var i = _list.BinarySearch(item);
@@ -80,6 +88,10 @@ namespace BizHawk.Common
 			return _list.Remove(item);
 #endif
 		}
+
+		public virtual int RemoveAll(Predicate<T> match) => _list.RemoveAll(match);
+
+		public virtual void RemoveAt(int index) => _list.RemoveAt(index);
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}

--- a/src/BizHawk.Common/CustomCollections.cs
+++ b/src/BizHawk.Common/CustomCollections.cs
@@ -89,9 +89,32 @@ namespace BizHawk.Common
 #endif
 		}
 
+
 		public virtual int RemoveAll(Predicate<T> match) => _list.RemoveAll(match);
 
 		public virtual void RemoveAt(int index) => _list.RemoveAt(index);
+
+		/// <summary>Remove all items after the specific item (but not the given item).</summary>
+		public virtual void RemoveAfter(T item)
+		{
+			var startIndex = _list.BinarySearch(item);
+			if (startIndex < 0)
+			{
+				// If BinarySearch doesn't find the item, 
+				// it returns the bitwise complement of the index of the next element
+				// that is larger than item
+				startIndex = ~startIndex;
+			}
+			else
+			{
+				// All items *after* the item
+				startIndex = startIndex + 1;
+			}
+			if (startIndex < _list.Count)
+			{
+				_list.RemoveRange(startIndex, _list.Count - startIndex);
+			}
+		}
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}

--- a/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
+++ b/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+
+using BizHawk.Common;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BizHawk.Tests.Common.CustomCollections
+{
+	[TestClass]
+	public class CustomCollectionTests
+	{
+		[TestMethod]
+		public void TestSortedListAddRemove()
+		{
+			var list = new SortedList<int>(new[] { 1, 3, 4, 7, 8, 9, 11 }); // this causes one sort, collection initializer syntax wouldn't
+			list.Add(5); // `Insert` when `BinarySearch` returns negative
+			list.Add(8); // `Insert` when `BinarySearch` returns non-negative
+			list.Remove(3); // `Remove` when `BinarySearch` returns non-negative
+			Assert.IsTrue(list.ToArray().SequenceEqual(new[] { 1, 4, 5, 7, 8, 8, 9, 11 }));
+			Assert.IsFalse(list.Remove(10)); // `Remove` when `BinarySearch` returns negative
+		}
+
+		[TestMethod]
+		public void TestSortedListContains()
+		{
+			var list = new SortedList<int>(new[] { 1, 3, 4, 7, 8, 9, 11 });
+			Assert.IsFalse(list.Contains(6)); // `Contains` when `BinarySearch` returns negative
+			Assert.IsTrue(list.Contains(11)); // `Contains` when `BinarySearch` returns non-negative
+		}
+	}
+}

--- a/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
+++ b/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
@@ -28,25 +28,12 @@ namespace BizHawk.Tests.Common.CustomCollections
 			Assert.IsTrue(list.Contains(11)); // `Contains` when `BinarySearch` returns non-negative
 		}
 
-		[TestMethod]
-		public void TestSortedListRemoveAfter_Between()
-		{
-			RemoveAfterTestcase(new[] {1, 5, 9, 10, 11, 12}, new[] {1, 5, 9}, 9);
-		}
 
 		[TestMethod]
-		public void TestSortedListRemoveAfter_None()
-		{
-			RemoveAfterTestcase(new[] { 2, 3 }, new[] { 2, 3 }, 5);
-		}
-
-		[TestMethod]
-		public void TestSortedListRemoveAfter_All()
-		{
-			RemoveAfterTestcase(new[] { 4, 7 }, new int[] { }, 0);
-		}
-
-		private void RemoveAfterTestcase(int[] before, int[] after, int removeItem)
+		[DataRow(new[] {1, 5, 9, 10, 11, 12}, new[] {1, 5, 9}, 9)]
+		[DataRow(new[] { 2, 3 }, new[] { 2, 3 }, 5)]
+		[DataRow(new[] { 4, 7 }, new int[] { }, 0)]
+		public void TestSortedListRemoveAfter(int[] before, int[] after, int removeItem)
 		{
 			var sortlist = new SortedList<int>(before);
 			sortlist.RemoveAfter(removeItem);

--- a/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
+++ b/src/BizHawk.Tests/Common/CustomCollections/CustomCollectionTests.cs
@@ -27,5 +27,30 @@ namespace BizHawk.Tests.Common.CustomCollections
 			Assert.IsFalse(list.Contains(6)); // `Contains` when `BinarySearch` returns negative
 			Assert.IsTrue(list.Contains(11)); // `Contains` when `BinarySearch` returns non-negative
 		}
+
+		[TestMethod]
+		public void TestSortedListRemoveAfter_Between()
+		{
+			RemoveAfterTestcase(new[] {1, 5, 9, 10, 11, 12}, new[] {1, 5, 9}, 9);
+		}
+
+		[TestMethod]
+		public void TestSortedListRemoveAfter_None()
+		{
+			RemoveAfterTestcase(new[] { 2, 3 }, new[] { 2, 3 }, 5);
+		}
+
+		[TestMethod]
+		public void TestSortedListRemoveAfter_All()
+		{
+			RemoveAfterTestcase(new[] { 4, 7 }, new int[] { }, 0);
+		}
+
+		private void RemoveAfterTestcase(int[] before, int[] after, int removeItem)
+		{
+			var sortlist = new SortedList<int>(before);
+			sortlist.RemoveAfter(removeItem);
+			Assert.IsTrue(sortlist.ToArray().SequenceEqual(after));
+		}
 	}
 }


### PR DESCRIPTION
The data structure for the StateCache was the culprit here.  The datastructure meant calls to Invalidate got slow at large numbers, even if no frames are determined to need to be invalidated, (the RemoveWhere() is still costly), causing painting to be laggy.

Using a custom SortedInt<int> allows for quick removals as well as fast duplicate check + additions.

Maybe a better structure could be conceived down the road but this seems to address the primary performance bottlenecks