### PR TITLE
Cleanup initialisation of GlobalWin.GL

### DIFF
--- a/src/BizHawk.Bizware.BizwareGL/OpenTKConfigurator.cs
+++ b/src/BizHawk.Bizware.BizwareGL/OpenTKConfigurator.cs
@@ -1,0 +1,22 @@
+using System;
+
+using OpenTK;
+
+namespace BizHawk.Bizware.BizwareGL
+{
+	public static class OpenTKConfigurator
+	{
+		static OpenTKConfigurator()
+		{
+			// make sure OpenTK initializes without getting wrecked on the SDL check and throwing an exception to annoy our MDA's
+			var toolkitOptions = ToolkitOptions.Default;
+			toolkitOptions.Backend = PlatformBackend.PreferNative;
+			Toolkit.Init(toolkitOptions);
+			// NOTE: this throws EGL exceptions anyway. I'm going to ignore it and whine about it later
+			// still seeing the exception in VS as of 2.5.3 dev... --yoshi
+		}
+
+		/// <summary>no-op; this class' static ctor is guaranteed to be called exactly once if this is called at least once</summary>
+		public static void EnsureConfigurated() {}
+	}
+}

--- a/src/BizHawk.Bizware.DirectX/IGL_SlimDX9.cs
+++ b/src/BizHawk.Bizware.DirectX/IGL_SlimDX9.cs
@@ -38,6 +38,8 @@ namespace BizHawk.Bizware.DirectX
 				_d3d = new Direct3D();
 			}
 
+			OpenTKConfigurator.EnsureConfigurated();
+
 			// make an 'offscreen context' so we can at least do things without having to create a window
 			_offscreenNativeWindow = new NativeWindow { ClientSize = new Size(8, 8) };
 

--- a/src/BizHawk.Client.EmuHawk/GlobalWin.cs
+++ b/src/BizHawk.Client.EmuHawk/GlobalWin.cs
@@ -16,11 +16,6 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		public static IGL GL;
 
-		/// <summary>
-		/// The IGL_TK to be used for specifically opengl operations (accessing textures from opengl-based cores)
-		/// </summary>
-		public static IGL_TK IGL_GL;
-
 		public static Sound Sound;
 
 		public static Config Config { get; set; }

--- a/src/BizHawk.Client.EmuHawk/GraphicsImplementations/IGL_TK.cs
+++ b/src/BizHawk.Client.EmuHawk/GraphicsImplementations/IGL_TK.cs
@@ -34,15 +34,6 @@ namespace BizHawk.Client.EmuHawk
 		private Pipeline _currPipeline;
 		private RenderTarget _currRenderTarget;
 
-		static IGL_TK()
-		{
-			//make sure OpenTK initializes without getting wrecked on the SDL check and throwing an exception to annoy our MDA's
-			var toolkitOptions = global::OpenTK.ToolkitOptions.Default;
-			toolkitOptions.Backend = PlatformBackend.PreferNative;
-			global::OpenTK.Toolkit.Init(toolkitOptions);
-			//NOTE: this throws EGL exceptions anyway. I'm going to ignore it and whine about it later
-		}
-
 		public string API => "OPENGL";
 
 		public int Version
@@ -66,6 +57,8 @@ namespace BizHawk.Client.EmuHawk
 
 		public IGL_TK(int majorVersion, int minorVersion, bool forwardCompatible)
 		{
+			OpenTKConfigurator.EnsureConfigurated();
+
 			//make an 'offscreen context' so we can at least do things without having to create a window
 			OffscreenNativeWindow = new NativeWindow { ClientSize = new sd.Size(8, 8) };
 			GraphicsContext = new GraphicsContext(GraphicsMode.Default, OffscreenNativeWindow.WindowInfo, majorVersion, minorVersion, forwardCompatible ? GraphicsContextFlags.ForwardCompatible : GraphicsContextFlags.Default);

--- a/src/BizHawk.Client.EmuHawk/Program.cs
+++ b/src/BizHawk.Client.EmuHawk/Program.cs
@@ -142,10 +142,6 @@ namespace BizHawk.Client.EmuHawk
 				GlobalWin.Config.DispMethod = EDispMethod.GdiPlus;
 			}
 
-			// create IGL context. we do this whether or not the user has selected OpenGL, so that we can run opengl-based emulator cores
-			GlobalWin.IGL_GL = new IGL_TK(2, 0, false);
-
-			//now create the "GL" context for the display method. we can reuse the IGL_TK context if opengl display method is chosen
 		REDO_DISPMETHOD:
 			if (GlobalWin.Config.DispMethod == EDispMethod.GdiPlus)
 			{
@@ -168,15 +164,19 @@ namespace BizHawk.Client.EmuHawk
 			}
 			else
 			{
-				GlobalWin.GL = GlobalWin.IGL_GL;
+				var glOpenTK = new IGL_TK(2, 0, false);
 
 				// check the opengl version and don't even try to boot this crap up if its too old
-				if (GlobalWin.IGL_GL.Version < 200)
+				if (glOpenTK.Version < 200)
 				{
+					((IDisposable) glOpenTK).Dispose();
+
 					// fallback
 					GlobalWin.Config.DispMethod = EDispMethod.GdiPlus;
 					goto REDO_DISPMETHOD;
 				}
+
+				GlobalWin.GL = glOpenTK;
 			}
 
 			// try creating a GUI Renderer. If that doesn't succeed. we fallback


### PR DESCRIPTION
Mupen is still able to load on my Win10 machine with the D3D display method selected.