### PR TITLE
add an option to capture the Lua without capturing the full OSD, when…

### DIFF
--- a/src/BizHawk.Client.Common/config/Config.cs
+++ b/src/BizHawk.Client.Common/config/Config.cs
@@ -92,6 +92,7 @@ namespace BizHawk.Client.Common
 		public bool SkipLagFrame { get; set; }
 		public bool SuppressAskSave { get; set; }
 		public bool AviCaptureOsd { get; set; }
+		public bool AviCaptureLua { get; set; }
 		public bool ScreenshotCaptureOsd { get; set; }
 		public bool FirstBoot { get; set; } = true;
 		public bool UpdateAutoCheckEnabled { get; set; }

--- a/src/BizHawk.Client.EmuHawk/DisplayManager/DisplayManager.cs
+++ b/src/BizHawk.Client.EmuHawk/DisplayManager/DisplayManager.cs
@@ -546,6 +546,23 @@ namespace BizHawk.Client.EmuHawk
 			UpdateSourceInternal(job);
 			return job.OffscreenBb;
 		}
+		/// <summary>
+		/// Does the display process to an offscreen buffer, suitable for a Lua-inclusive movie.
+		/// </summary>
+		public BitmapBuffer RenderOffscreenLua(IVideoProvider videoProvider)
+		{
+			var job = new JobInfo
+			{
+				VideoProvider = videoProvider,
+				Simulate = false,
+				ChainOutsize = new Size(videoProvider.BufferWidth, videoProvider.BufferHeight),
+				Offscreen = true,
+				IncludeOSD = false,
+				IncludeUserFilters = false,
+			};
+			UpdateSourceInternal(job);
+			return job.OffscreenBb;
+		}
 
 		private class FakeVideoProvider : IVideoProvider
 		{

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -136,7 +136,6 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
-			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -375,6 +374,7 @@ namespace BizHawk.Client.EmuHawk
 			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MainformMenu.SuspendLayout();
 			this.MainStatusBar.SuspendLayout();
 			this.MainFormContextMenu.SuspendLayout();
@@ -383,28 +383,28 @@ namespace BizHawk.Client.EmuHawk
 			// MainformMenu
 			// 
 			this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FileSubMenu,
-            this.EmulationSubMenu,
-            this.ViewSubMenu,
-            this.ConfigSubMenu,
-            this.ToolsSubMenu,
-            this.NESSubMenu,
-            this.TI83SubMenu,
-            this.A7800SubMenu,
-            this.GBSubMenu,
-            this.NDSSubMenu,
-            this.PSXSubMenu,
-            this.SNESSubMenu,
-            this.ColecoSubMenu,
-            this.N64SubMenu,
-            this.DGBSubMenu,
-            this.AppleSubMenu,
-            this.C64SubMenu,
-            this.IntvSubMenu,
-            this.zXSpectrumToolStripMenuItem,
-            this.GenericCoreSubMenu,
-            this.amstradCPCToolStripMenuItem,
-            this.HelpSubMenu});
+			this.FileSubMenu,
+			this.EmulationSubMenu,
+			this.ViewSubMenu,
+			this.ConfigSubMenu,
+			this.ToolsSubMenu,
+			this.NESSubMenu,
+			this.TI83SubMenu,
+			this.A7800SubMenu,
+			this.GBSubMenu,
+			this.NDSSubMenu,
+			this.PSXSubMenu,
+			this.SNESSubMenu,
+			this.ColecoSubMenu,
+			this.N64SubMenu,
+			this.DGBSubMenu,
+			this.AppleSubMenu,
+			this.C64SubMenu,
+			this.IntvSubMenu,
+			this.zXSpectrumToolStripMenuItem,
+			this.GenericCoreSubMenu,
+			this.amstradCPCToolStripMenuItem,
+			this.HelpSubMenu});
 			this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
 			this.MainformMenu.TabIndex = 0;
 			this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
@@ -413,21 +413,21 @@ namespace BizHawk.Client.EmuHawk
 			// FileSubMenu
 			// 
 			this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OpenRomMenuItem,
-            this.RecentRomSubMenu,
-            this.OpenAdvancedMenuItem,
-            this.CloseRomMenuItem,
-            this.toolStripMenuItem1,
-            this.SaveStateSubMenu,
-            this.LoadStateSubMenu,
-            this.SaveSlotSubMenu,
-            this.SaveRAMSubMenu,
-            this.toolStripMenuItem2,
-            this.MovieSubMenu,
-            this.AVSubMenu,
-            this.ScreenshotSubMenu,
-            this.toolStripSeparator4,
-            this.ExitMenuItem});
+			this.OpenRomMenuItem,
+			this.RecentRomSubMenu,
+			this.OpenAdvancedMenuItem,
+			this.CloseRomMenuItem,
+			this.toolStripMenuItem1,
+			this.SaveStateSubMenu,
+			this.LoadStateSubMenu,
+			this.SaveSlotSubMenu,
+			this.SaveRAMSubMenu,
+			this.toolStripMenuItem2,
+			this.MovieSubMenu,
+			this.AVSubMenu,
+			this.ScreenshotSubMenu,
+			this.toolStripSeparator4,
+			this.ExitMenuItem});
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
@@ -439,7 +439,7 @@ namespace BizHawk.Client.EmuHawk
 			// RecentRomSubMenu
 			// 
 			this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator3});
+			this.toolStripSeparator3});
 			this.RecentRomSubMenu.Text = "&Recent ROM";
 			this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
 			// 
@@ -456,18 +456,18 @@ namespace BizHawk.Client.EmuHawk
 			// SaveStateSubMenu
 			// 
 			this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SaveState1MenuItem,
-            this.SaveState2MenuItem,
-            this.SaveState3MenuItem,
-            this.SaveState4MenuItem,
-            this.SaveState5MenuItem,
-            this.SaveState6MenuItem,
-            this.SaveState7MenuItem,
-            this.SaveState8MenuItem,
-            this.SaveState9MenuItem,
-            this.SaveState0MenuItem,
-            this.toolStripSeparator6,
-            this.SaveNamedStateMenuItem});
+			this.SaveState1MenuItem,
+			this.SaveState2MenuItem,
+			this.SaveState3MenuItem,
+			this.SaveState4MenuItem,
+			this.SaveState5MenuItem,
+			this.SaveState6MenuItem,
+			this.SaveState7MenuItem,
+			this.SaveState8MenuItem,
+			this.SaveState9MenuItem,
+			this.SaveState0MenuItem,
+			this.toolStripSeparator6,
+			this.SaveNamedStateMenuItem});
 			this.SaveStateSubMenu.Text = "&Save State";
 			this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
 			// 
@@ -529,20 +529,20 @@ namespace BizHawk.Client.EmuHawk
 			// LoadStateSubMenu
 			// 
 			this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.LoadState1MenuItem,
-            this.LoadState2MenuItem,
-            this.LoadState3MenuItem,
-            this.LoadState4MenuItem,
-            this.LoadState5MenuItem,
-            this.LoadState6MenuItem,
-            this.LoadState7MenuItem,
-            this.LoadState8MenuItem,
-            this.LoadState9MenuItem,
-            this.LoadState0MenuItem,
-            this.toolStripSeparator7,
-            this.LoadNamedStateMenuItem,
-            this.toolStripSeparator21,
-            this.AutoloadLastSlotMenuItem});
+			this.LoadState1MenuItem,
+			this.LoadState2MenuItem,
+			this.LoadState3MenuItem,
+			this.LoadState4MenuItem,
+			this.LoadState5MenuItem,
+			this.LoadState6MenuItem,
+			this.LoadState7MenuItem,
+			this.LoadState8MenuItem,
+			this.LoadState9MenuItem,
+			this.LoadState0MenuItem,
+			this.toolStripSeparator7,
+			this.LoadNamedStateMenuItem,
+			this.toolStripSeparator21,
+			this.AutoloadLastSlotMenuItem});
 			this.LoadStateSubMenu.Text = "&Load State";
 			this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
 			// 
@@ -609,21 +609,21 @@ namespace BizHawk.Client.EmuHawk
 			// SaveSlotSubMenu
 			// 
 			this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SelectSlot0MenuItem,
-            this.SelectSlot1MenuItem,
-            this.SelectSlot2MenuItem,
-            this.SelectSlot3MenuItem,
-            this.SelectSlot4MenuItem,
-            this.SelectSlot5MenuItem,
-            this.SelectSlot6MenuItem,
-            this.SelectSlot7MenuItem,
-            this.SelectSlot8MenuItem,
-            this.SelectSlot9MenuItem,
-            this.PreviousSlotMenuItem,
-            this.NextSlotMenuItem,
-            this.toolStripSeparator5,
-            this.SaveToCurrentSlotMenuItem,
-            this.LoadCurrentSlotMenuItem});
+			this.SelectSlot0MenuItem,
+			this.SelectSlot1MenuItem,
+			this.SelectSlot2MenuItem,
+			this.SelectSlot3MenuItem,
+			this.SelectSlot4MenuItem,
+			this.SelectSlot5MenuItem,
+			this.SelectSlot6MenuItem,
+			this.SelectSlot7MenuItem,
+			this.SelectSlot8MenuItem,
+			this.SelectSlot9MenuItem,
+			this.PreviousSlotMenuItem,
+			this.NextSlotMenuItem,
+			this.toolStripSeparator5,
+			this.SaveToCurrentSlotMenuItem,
+			this.LoadCurrentSlotMenuItem});
 			this.SaveSlotSubMenu.Text = "Save S&lot";
 			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
 			// 
@@ -700,7 +700,7 @@ namespace BizHawk.Client.EmuHawk
 			// SaveRAMSubMenu
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FlushSaveRAMMenuItem});
+			this.FlushSaveRAMMenuItem});
 			this.SaveRAMSubMenu.Text = "Save &RAM";
 			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
 			// 
@@ -712,21 +712,21 @@ namespace BizHawk.Client.EmuHawk
 			// MovieSubMenu
 			// 
 			this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ReadonlyMenuItem,
-            this.toolStripSeparator15,
-            this.RecentMovieSubMenu,
-            this.RecordMovieMenuItem,
-            this.PlayMovieMenuItem,
-            this.StopMovieMenuItem,
-            this.PlayFromBeginningMenuItem,
-            this.ImportMoviesMenuItem,
-            this.SaveMovieMenuItem,
-            this.SaveMovieAsMenuItem,
-            this.StopMovieWithoutSavingMenuItem,
-            this.toolStripSeparator14,
-            this.AutomaticallyBackupMoviesMenuItem,
-            this.FullMovieLoadstatesMenuItem,
-            this.MovieEndSubMenu});
+			this.ReadonlyMenuItem,
+			this.toolStripSeparator15,
+			this.RecentMovieSubMenu,
+			this.RecordMovieMenuItem,
+			this.PlayMovieMenuItem,
+			this.StopMovieMenuItem,
+			this.PlayFromBeginningMenuItem,
+			this.ImportMoviesMenuItem,
+			this.SaveMovieMenuItem,
+			this.SaveMovieAsMenuItem,
+			this.StopMovieWithoutSavingMenuItem,
+			this.toolStripSeparator14,
+			this.AutomaticallyBackupMoviesMenuItem,
+			this.FullMovieLoadstatesMenuItem,
+			this.MovieEndSubMenu});
 			this.MovieSubMenu.Text = "&Movie";
 			this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
 			// 
@@ -738,7 +738,7 @@ namespace BizHawk.Client.EmuHawk
 			// RecentMovieSubMenu
 			// 
 			this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator16});
+			this.toolStripSeparator16});
 			this.RecentMovieSubMenu.Text = "Recent";
 			this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
 			// 
@@ -795,10 +795,10 @@ namespace BizHawk.Client.EmuHawk
 			// MovieEndSubMenu
 			// 
 			this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.MovieEndFinishMenuItem,
-            this.MovieEndRecordMenuItem,
-            this.MovieEndStopMenuItem,
-            this.MovieEndPauseMenuItem});
+			this.MovieEndFinishMenuItem,
+			this.MovieEndRecordMenuItem,
+			this.MovieEndStopMenuItem,
+			this.MovieEndPauseMenuItem});
 			this.MovieEndSubMenu.Text = "On Movie End";
 			this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
 			// 
@@ -825,13 +825,13 @@ namespace BizHawk.Client.EmuHawk
 			// AVSubMenu
 			// 
 			this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.RecordAVMenuItem,
-            this.ConfigAndRecordAVMenuItem,
-            this.StopAVIMenuItem,
-            this.toolStripSeparator19,
-            this.CaptureOSDMenuItem,
-            this.CaptureLuaMenuItem,
-            this.SynclessRecordingMenuItem});
+			this.RecordAVMenuItem,
+			this.ConfigAndRecordAVMenuItem,
+			this.StopAVIMenuItem,
+			this.toolStripSeparator19,
+			this.CaptureOSDMenuItem,
+			this.CaptureLuaMenuItem,
+			this.SynclessRecordingMenuItem});
 			this.AVSubMenu.Text = "&AVI/WAV";
 			this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
 			// 
@@ -870,12 +870,12 @@ namespace BizHawk.Client.EmuHawk
 			// ScreenshotSubMenu
 			// 
 			this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ScreenshotMenuItem,
-            this.ScreenshotAsMenuItem,
-            this.ScreenshotClipboardMenuItem,
-            this.ScreenshotClientClipboardMenuItem,
-            this.toolStripSeparator20,
-            this.ScreenshotCaptureOSDMenuItem1});
+			this.ScreenshotMenuItem,
+			this.ScreenshotAsMenuItem,
+			this.ScreenshotClipboardMenuItem,
+			this.ScreenshotClientClipboardMenuItem,
+			this.toolStripSeparator20,
+			this.ScreenshotCaptureOSDMenuItem1});
 			this.ScreenshotSubMenu.Text = "Scree&nshot";
 			this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
 			// 
@@ -913,11 +913,11 @@ namespace BizHawk.Client.EmuHawk
 			// EmulationSubMenu
 			// 
 			this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.PauseMenuItem,
-            this.RebootCoreMenuItem,
-            this.toolStripSeparator1,
-            this.SoftResetMenuItem,
-            this.HardResetMenuItem});
+			this.PauseMenuItem,
+			this.RebootCoreMenuItem,
+			this.toolStripSeparator1,
+			this.SoftResetMenuItem,
+			this.HardResetMenuItem});
 			this.EmulationSubMenu.Text = "&Emulation";
 			this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
 			// 
@@ -944,32 +944,32 @@ namespace BizHawk.Client.EmuHawk
 			// ViewSubMenu
 			// 
 			this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.WindowSizeSubMenu,
-            this.SwitchToFullscreenMenuItem,
-            this.toolStripSeparator2,
-            this.DisplayFPSMenuItem,
-            this.DisplayFrameCounterMenuItem,
-            this.DisplayLagCounterMenuItem,
-            this.DisplayInputMenuItem,
-            this.DisplayRerecordCountMenuItem,
-            this.DisplaySubtitlesMenuItem,
-            this.toolStripMenuItem4,
-            this.DisplayStatusBarMenuItem,
-            this.DisplayMessagesMenuItem,
-            this.toolStripSeparator8,
-            this.DisplayLogWindowMenuItem});
+			this.WindowSizeSubMenu,
+			this.SwitchToFullscreenMenuItem,
+			this.toolStripSeparator2,
+			this.DisplayFPSMenuItem,
+			this.DisplayFrameCounterMenuItem,
+			this.DisplayLagCounterMenuItem,
+			this.DisplayInputMenuItem,
+			this.DisplayRerecordCountMenuItem,
+			this.DisplaySubtitlesMenuItem,
+			this.toolStripMenuItem4,
+			this.DisplayStatusBarMenuItem,
+			this.DisplayMessagesMenuItem,
+			this.toolStripSeparator8,
+			this.DisplayLogWindowMenuItem});
 			this.ViewSubMenu.Text = "&View";
 			this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
 			// 
 			// WindowSizeSubMenu
 			// 
 			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.x1MenuItem,
-            this.x2MenuItem,
-            this.x3MenuItem,
-            this.x4MenuItem,
-            this.x5MenuItem,
-            this.mzMenuItem});
+			this.x1MenuItem,
+			this.x2MenuItem,
+			this.x3MenuItem,
+			this.x4MenuItem,
+			this.x5MenuItem,
+			this.mzMenuItem});
 			this.WindowSizeSubMenu.Text = "&Window Size";
 			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
 			// 
@@ -1056,27 +1056,27 @@ namespace BizHawk.Client.EmuHawk
 			// ConfigSubMenu
 			// 
 			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ControllersMenuItem,
-            this.HotkeysMenuItem,
-            this.DisplayConfigMenuItem,
-            this.SoundMenuItem,
-            this.PathsMenuItem,
-            this.FirmwaresMenuItem,
-            this.MessagesMenuItem,
-            this.AutofireMenuItem,
-            this.RewindOptionsMenuItem,
-            this.extensionsToolStripMenuItem,
-            this.ClientOptionsMenuItem,
-            this.ProfilesMenuItem,
-            this.toolStripSeparator9,
-            this.SpeedSkipSubMenu,
-            this.KeyPrioritySubMenu,
-            this.CoresSubMenu,
-            this.toolStripSeparator10,
-            this.SaveConfigMenuItem,
-            this.SaveConfigAsMenuItem,
-            this.LoadConfigMenuItem,
-            this.LoadConfigFromMenuItem});
+			this.ControllersMenuItem,
+			this.HotkeysMenuItem,
+			this.DisplayConfigMenuItem,
+			this.SoundMenuItem,
+			this.PathsMenuItem,
+			this.FirmwaresMenuItem,
+			this.MessagesMenuItem,
+			this.AutofireMenuItem,
+			this.RewindOptionsMenuItem,
+			this.extensionsToolStripMenuItem,
+			this.ClientOptionsMenuItem,
+			this.ProfilesMenuItem,
+			this.toolStripSeparator9,
+			this.SpeedSkipSubMenu,
+			this.KeyPrioritySubMenu,
+			this.CoresSubMenu,
+			this.toolStripSeparator10,
+			this.SaveConfigMenuItem,
+			this.SaveConfigAsMenuItem,
+			this.LoadConfigMenuItem,
+			this.LoadConfigFromMenuItem});
 			this.ConfigSubMenu.Text = "&Config";
 			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
 			// 
@@ -1143,23 +1143,23 @@ namespace BizHawk.Client.EmuHawk
 			// SpeedSkipSubMenu
 			// 
 			this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ClockThrottleMenuItem,
-            this.AudioThrottleMenuItem,
-            this.VsyncThrottleMenuItem,
-            this.toolStripSeparator27,
-            this.VsyncEnabledMenuItem,
-            this.toolStripMenuItem3,
-            this.miUnthrottled,
-            this.MinimizeSkippingMenuItem,
-            this.NeverSkipMenuItem,
-            this.toolStripMenuItem17,
-            this.toolStripMenuItem5,
-            this.Speed50MenuItem,
-            this.Speed75MenuItem,
-            this.Speed100MenuItem,
-            this.Speed150MenuItem,
-            this.Speed200MenuItem,
-            this.Speed400MenuItem});
+			this.ClockThrottleMenuItem,
+			this.AudioThrottleMenuItem,
+			this.VsyncThrottleMenuItem,
+			this.toolStripSeparator27,
+			this.VsyncEnabledMenuItem,
+			this.toolStripMenuItem3,
+			this.miUnthrottled,
+			this.MinimizeSkippingMenuItem,
+			this.NeverSkipMenuItem,
+			this.toolStripMenuItem17,
+			this.toolStripMenuItem5,
+			this.Speed50MenuItem,
+			this.Speed75MenuItem,
+			this.Speed100MenuItem,
+			this.Speed150MenuItem,
+			this.Speed200MenuItem,
+			this.Speed400MenuItem});
 			this.SpeedSkipSubMenu.Text = "Speed/Skip";
 			this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
 			// 
@@ -1201,15 +1201,15 @@ namespace BizHawk.Client.EmuHawk
 			// toolStripMenuItem17
 			// 
 			this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.Frameskip1MenuItem,
-            this.Frameskip2MenuItem,
-            this.Frameskip3MenuItem,
-            this.Frameskip4MenuItem,
-            this.Frameskip5MenuItem,
-            this.Frameskip6MenuItem,
-            this.Frameskip7MenuItem,
-            this.Frameskip8MenuItem,
-            this.Frameskip9MenuItem});
+			this.Frameskip1MenuItem,
+			this.Frameskip2MenuItem,
+			this.Frameskip3MenuItem,
+			this.Frameskip4MenuItem,
+			this.Frameskip5MenuItem,
+			this.Frameskip6MenuItem,
+			this.Frameskip7MenuItem,
+			this.Frameskip8MenuItem,
+			this.Frameskip9MenuItem});
 			this.toolStripMenuItem17.Text = "Skip 1..9";
 			// 
 			// Frameskip1MenuItem
@@ -1290,9 +1290,9 @@ namespace BizHawk.Client.EmuHawk
 			// KeyPrioritySubMenu
 			// 
 			this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.BothHkAndControllerMenuItem,
-            this.InputOverHkMenuItem,
-            this.HkOverInputMenuItem});
+			this.BothHkAndControllerMenuItem,
+			this.InputOverHkMenuItem,
+			this.HkOverInputMenuItem});
 			this.KeyPrioritySubMenu.Text = "Key Priority";
 			this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
 			// 
@@ -1338,26 +1338,26 @@ namespace BizHawk.Client.EmuHawk
 			// ToolsSubMenu
 			// 
 			this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ToolBoxMenuItem,
-            this.toolStripSeparator12,
-            this.RamWatchMenuItem,
-            this.RamSearchMenuItem,
-            this.LuaConsoleMenuItem,
-            this.TAStudioMenuItem,
-            this.HexEditorMenuItem,
-            this.TraceLoggerMenuItem,
-            this.DebuggerMenuItem,
-            this.CodeDataLoggerMenuItem,
-            this.MacroToolMenuItem,
-            this.VirtualPadMenuItem,
-            this.BasicBotMenuItem,
-            this.toolStripSeparator11,
-            this.CheatsMenuItem,
-            this.GameSharkConverterMenuItem,
-            this.toolStripSeparator29,
-            this.MultiDiskBundlerFileMenuItem,
-            this.ExternalToolMenuItem,
-            this.BatchRunnerMenuItem});
+			this.ToolBoxMenuItem,
+			this.toolStripSeparator12,
+			this.RamWatchMenuItem,
+			this.RamSearchMenuItem,
+			this.LuaConsoleMenuItem,
+			this.TAStudioMenuItem,
+			this.HexEditorMenuItem,
+			this.TraceLoggerMenuItem,
+			this.DebuggerMenuItem,
+			this.CodeDataLoggerMenuItem,
+			this.MacroToolMenuItem,
+			this.VirtualPadMenuItem,
+			this.BasicBotMenuItem,
+			this.toolStripSeparator11,
+			this.CheatsMenuItem,
+			this.GameSharkConverterMenuItem,
+			this.toolStripSeparator29,
+			this.MultiDiskBundlerFileMenuItem,
+			this.ExternalToolMenuItem,
+			this.BatchRunnerMenuItem});
 			this.ToolsSubMenu.Text = "&Tools";
 			this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
 			// 
@@ -1439,7 +1439,7 @@ namespace BizHawk.Client.EmuHawk
 			// ExternalToolMenuItem
 			// 
 			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.dummyExternalTool});
+			this.dummyExternalTool});
 			this.ExternalToolMenuItem.Text = "External Tool";
 			this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
 			// 
@@ -1456,19 +1456,19 @@ namespace BizHawk.Client.EmuHawk
 			// NESSubMenu
 			// 
 			this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.NESPPUViewerMenuItem,
-            this.NESNametableViewerMenuItem,
-            this.MusicRipperMenuItem,
-            this.toolStripSeparator17,
-            this.NesControllerSettingsMenuItem,
-            this.NESGraphicSettingsMenuItem,
-            this.NESSoundChannelsMenuItem,
-            this.VSSettingsMenuItem,
-            this.MovieSettingsMenuItem,
-            this.toolStripSeparator22,
-            this.FDSControlsMenuItem,
-            this.VSControlsMenuItem,
-            this.BarcodeReaderMenuItem});
+			this.NESPPUViewerMenuItem,
+			this.NESNametableViewerMenuItem,
+			this.MusicRipperMenuItem,
+			this.toolStripSeparator17,
+			this.NesControllerSettingsMenuItem,
+			this.NESGraphicSettingsMenuItem,
+			this.NESSoundChannelsMenuItem,
+			this.VSSettingsMenuItem,
+			this.MovieSettingsMenuItem,
+			this.toolStripSeparator22,
+			this.FDSControlsMenuItem,
+			this.VSControlsMenuItem,
+			this.BarcodeReaderMenuItem});
 			this.NESSubMenu.Text = "&NES";
 			this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
 			// 
@@ -1515,7 +1515,7 @@ namespace BizHawk.Client.EmuHawk
 			// FDSControlsMenuItem
 			// 
 			this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.FdsEjectDiskMenuItem});
+			this.FdsEjectDiskMenuItem});
 			this.FDSControlsMenuItem.Text = "FDS Controls";
 			this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
 			// 
@@ -1527,9 +1527,9 @@ namespace BizHawk.Client.EmuHawk
 			// VSControlsMenuItem
 			// 
 			this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.VSInsertCoinP1MenuItem,
-            this.VSInsertCoinP2MenuItem,
-            this.VSServiceSwitchMenuItem});
+			this.VSInsertCoinP1MenuItem,
+			this.VSInsertCoinP2MenuItem,
+			this.VSServiceSwitchMenuItem});
 			this.VSControlsMenuItem.Text = "VS Controls";
 			// 
 			// VSInsertCoinP1MenuItem
@@ -1555,11 +1555,11 @@ namespace BizHawk.Client.EmuHawk
 			// TI83SubMenu
 			// 
 			this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.KeypadMenuItem,
-            this.LoadTIFileMenuItem,
-            this.toolStripSeparator13,
-            this.AutoloadKeypadMenuItem,
-            this.paletteToolStripMenuItem});
+			this.KeypadMenuItem,
+			this.LoadTIFileMenuItem,
+			this.toolStripSeparator13,
+			this.AutoloadKeypadMenuItem,
+			this.paletteToolStripMenuItem});
 			this.TI83SubMenu.Text = "TI83";
 			this.TI83SubMenu.DropDownOpened += new System.EventHandler(this.Ti83SubMenu_DropDownOpened);
 			// 
@@ -1588,8 +1588,8 @@ namespace BizHawk.Client.EmuHawk
 			// A7800SubMenu
 			// 
 			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.A7800ControllerSettingsMenuItem,
-            this.A7800FilterSettingsMenuItem});
+			this.A7800ControllerSettingsMenuItem,
+			this.A7800FilterSettingsMenuItem});
 			this.A7800SubMenu.Text = "&A7800";
 			this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
 			// 
@@ -1606,10 +1606,10 @@ namespace BizHawk.Client.EmuHawk
 			// GBSubMenu
 			// 
 			this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.GBcoreSettingsToolStripMenuItem,
-            this.toolStripSeparator28,
-            this.GBGPUViewerMenuItem,
-            this.GBPrinterViewerMenuItem});
+			this.GBcoreSettingsToolStripMenuItem,
+			this.toolStripSeparator28,
+			this.GBGPUViewerMenuItem,
+			this.GBPrinterViewerMenuItem});
 			this.GBSubMenu.Text = "&GB";
 			// 
 			// GBcoreSettingsToolStripMenuItem
@@ -1630,8 +1630,8 @@ namespace BizHawk.Client.EmuHawk
 			// NDSSubMenu
 			// 
 			this.NDSSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.NdsSettingsMenuItem,
-            this.NdsSyncSettingsMenuItem});
+			this.NdsSettingsMenuItem,
+			this.NdsSyncSettingsMenuItem});
 			this.NDSSubMenu.Text = "NDS";
 			this.NDSSubMenu.DropDownOpened += new System.EventHandler(this.NDSSubMenu_DropDownOpened);
 			// 
@@ -1648,10 +1648,10 @@ namespace BizHawk.Client.EmuHawk
 			// PSXSubMenu
 			// 
 			this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.PSXControllerSettingsMenuItem,
-            this.PSXOptionsMenuItem,
-            this.PSXDiscControlsMenuItem,
-            this.PSXHashDiscsToolStripMenuItem});
+			this.PSXControllerSettingsMenuItem,
+			this.PSXOptionsMenuItem,
+			this.PSXDiscControlsMenuItem,
+			this.PSXHashDiscsToolStripMenuItem});
 			this.PSXSubMenu.Text = "PSX";
 			this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
 			// 
@@ -1678,10 +1678,10 @@ namespace BizHawk.Client.EmuHawk
 			// SNESSubMenu
 			// 
 			this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.SNESControllerConfigurationMenuItem,
-            this.toolStripSeparator18,
-            this.SnesGfxDebuggerMenuItem,
-            this.SnesOptionsMenuItem});
+			this.SNESControllerConfigurationMenuItem,
+			this.toolStripSeparator18,
+			this.SnesGfxDebuggerMenuItem,
+			this.SnesOptionsMenuItem});
 			this.SNESSubMenu.Text = "&SNES";
 			this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
 			// 
@@ -1703,10 +1703,10 @@ namespace BizHawk.Client.EmuHawk
 			// ColecoSubMenu
 			// 
 			this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ColecoControllerSettingsMenuItem,
-            this.toolStripSeparator35,
-            this.ColecoSkipBiosMenuItem,
-            this.ColecoUseSGMMenuItem});
+			this.ColecoControllerSettingsMenuItem,
+			this.toolStripSeparator35,
+			this.ColecoSkipBiosMenuItem,
+			this.ColecoUseSGMMenuItem});
 			this.ColecoSubMenu.Text = "&Coleco";
 			this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
 			// 
@@ -1728,12 +1728,12 @@ namespace BizHawk.Client.EmuHawk
 			// N64SubMenu
 			// 
 			this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.N64PluginSettingsMenuItem,
-            this.N64ControllerSettingsMenuItem,
-            this.toolStripSeparator23,
-            this.N64CircularAnalogRangeMenuItem,
-            this.MupenStyleLagMenuItem,
-            this.N64ExpansionSlotMenuItem});
+			this.N64PluginSettingsMenuItem,
+			this.N64ControllerSettingsMenuItem,
+			this.toolStripSeparator23,
+			this.N64CircularAnalogRangeMenuItem,
+			this.MupenStyleLagMenuItem,
+			this.N64ExpansionSlotMenuItem});
 			this.N64SubMenu.Text = "N64";
 			this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
 			// 
@@ -1765,7 +1765,7 @@ namespace BizHawk.Client.EmuHawk
 			// DGBSubMenu
 			// 
 			this.DGBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.DGBsettingsToolStripMenuItem});
+			this.DGBsettingsToolStripMenuItem});
 			this.DGBSubMenu.Text = "&GB Link";
 			// 
 			// DGBsettingsToolStripMenuItem
@@ -1776,15 +1776,15 @@ namespace BizHawk.Client.EmuHawk
 			// AppleSubMenu
 			// 
 			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.AppleDisksSubMenu,
-            this.settingsToolStripMenuItem1});
+			this.AppleDisksSubMenu,
+			this.settingsToolStripMenuItem1});
 			this.AppleSubMenu.Text = "Apple";
 			this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
 			// 
 			// AppleDisksSubMenu
 			// 
 			this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator31});
+			this.toolStripSeparator31});
 			this.AppleDisksSubMenu.Text = "Disks";
 			this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
 			// 
@@ -1796,15 +1796,15 @@ namespace BizHawk.Client.EmuHawk
 			// C64SubMenu
 			// 
 			this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.C64DisksSubMenu,
-            this.C64SettingsMenuItem});
+			this.C64DisksSubMenu,
+			this.C64SettingsMenuItem});
 			this.C64SubMenu.Text = "&C64";
 			this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
 			// 
 			// C64DisksSubMenu
 			// 
 			this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripSeparator36});
+			this.toolStripSeparator36});
 			this.C64DisksSubMenu.Text = "Disks";
 			this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
 			// 
@@ -1816,7 +1816,7 @@ namespace BizHawk.Client.EmuHawk
 			// IntvSubMenu
 			// 
 			this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.IntVControllerSettingsMenuItem});
+			this.IntVControllerSettingsMenuItem});
 			this.IntvSubMenu.Text = "&Intv";
 			this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
 			// 
@@ -1828,12 +1828,12 @@ namespace BizHawk.Client.EmuHawk
 			// zXSpectrumToolStripMenuItem
 			// 
 			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ZXSpectrumCoreEmulationSettingsMenuItem,
-            this.ZXSpectrumControllerConfigurationMenuItem,
-            this.ZXSpectrumAudioSettingsMenuItem,
-            this.ZXSpectrumNonSyncSettingsMenuItem,
-            this.ZXSpectrumPokeMemoryMenuItem,
-            this.ZXSpectrumMediaMenuItem});
+			this.ZXSpectrumCoreEmulationSettingsMenuItem,
+			this.ZXSpectrumControllerConfigurationMenuItem,
+			this.ZXSpectrumAudioSettingsMenuItem,
+			this.ZXSpectrumNonSyncSettingsMenuItem,
+			this.ZXSpectrumPokeMemoryMenuItem,
+			this.ZXSpectrumMediaMenuItem});
 			this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
 			// 
 			// ZXSpectrumCoreEmulationSettingsMenuItem
@@ -1864,16 +1864,16 @@ namespace BizHawk.Client.EmuHawk
 			// ZXSpectrumMediaMenuItem
 			// 
 			this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.ZXSpectrumTapesSubMenu,
-            this.ZXSpectrumDisksSubMenu,
-            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
+			this.ZXSpectrumTapesSubMenu,
+			this.ZXSpectrumDisksSubMenu,
+			this.ZXSpectrumExportSnapshotMenuItemMenuItem});
 			this.ZXSpectrumMediaMenuItem.Text = "Media";
 			this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
 			// 
 			// ZXSpectrumTapesSubMenu
 			// 
 			this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.zxt1ToolStripMenuItem});
+			this.zxt1ToolStripMenuItem});
 			this.ZXSpectrumTapesSubMenu.Text = "Tapes";
 			this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
 			// 
@@ -1884,7 +1884,7 @@ namespace BizHawk.Client.EmuHawk
 			// ZXSpectrumDisksSubMenu
 			// 
 			this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.zxt2ToolStripMenuItem});
+			this.zxt2ToolStripMenuItem});
 			this.ZXSpectrumDisksSubMenu.Text = "Disks";
 			this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
 			// 
@@ -1904,11 +1904,11 @@ namespace BizHawk.Client.EmuHawk
 			// amstradCPCToolStripMenuItem
 			// 
 			this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
-            this.AmstradCPCAudioSettingsToolStripMenuItem,
-            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
-            this.AmstradCPCPokeMemoryToolStripMenuItem,
-            this.AmstradCPCMediaToolStripMenuItem});
+			this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
+			this.AmstradCPCAudioSettingsToolStripMenuItem,
+			this.AmstradCPCNonSyncSettingsToolStripMenuItem,
+			this.AmstradCPCPokeMemoryToolStripMenuItem,
+			this.AmstradCPCMediaToolStripMenuItem});
 			this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
 			// 
 			// amstradCPCCoreEmulationSettingsToolStripMenuItem
@@ -1934,15 +1934,15 @@ namespace BizHawk.Client.EmuHawk
 			// AmstradCPCMediaToolStripMenuItem
 			// 
 			this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.AmstradCPCTapesSubMenu,
-            this.AmstradCPCDisksSubMenu});
+			this.AmstradCPCTapesSubMenu,
+			this.AmstradCPCDisksSubMenu});
 			this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
 			this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
 			// 
 			// AmstradCPCTapesSubMenu
 			// 
 			this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cpct1ToolStripMenuItem});
+			this.cpct1ToolStripMenuItem});
 			this.AmstradCPCTapesSubMenu.Text = "Tapes";
 			this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
 			// 
@@ -1953,7 +1953,7 @@ namespace BizHawk.Client.EmuHawk
 			// AmstradCPCDisksSubMenu
 			// 
 			this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.cpcd1ToolStripMenuItem});
+			this.cpcd1ToolStripMenuItem});
 			this.AmstradCPCDisksSubMenu.Text = "Disks";
 			this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
 			// 
@@ -1964,10 +1964,10 @@ namespace BizHawk.Client.EmuHawk
 			// HelpSubMenu
 			// 
 			this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OnlineHelpMenuItem,
-            this.ForumsMenuItem,
-            this.FeaturesMenuItem,
-            this.AboutMenuItem});
+			this.OnlineHelpMenuItem,
+			this.ForumsMenuItem,
+			this.FeaturesMenuItem,
+			this.AboutMenuItem});
 			this.HelpSubMenu.Text = "&Help";
 			this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
 			// 
@@ -1998,30 +1998,30 @@ namespace BizHawk.Client.EmuHawk
 			// MainStatusBar
 			// 
 			this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.DumpStatusButton,
-            this.EmuStatus,
-            this.PlayRecordStatusButton,
-            this.PauseStatusButton,
-            this.RebootStatusBarIcon,
-            this.AVIStatusLabel,
-            this.LedLightStatusLabel,
-            this.SaveSlotsStatusLabel,
-            this.Slot1StatusButton,
-            this.Slot2StatusButton,
-            this.Slot3StatusButton,
-            this.Slot4StatusButton,
-            this.Slot5StatusButton,
-            this.Slot6StatusButton,
-            this.Slot7StatusButton,
-            this.Slot8StatusButton,
-            this.Slot9StatusButton,
-            this.Slot0StatusButton,
-            this.CheatStatusButton,
-            this.KeyPriorityStatusLabel,
-            this.CoreNameStatusBarButton,
-            this.ProfileFirstBootLabel,
-            this.LinkConnectStatusBarButton,
-            this.UpdateNotification});
+			this.DumpStatusButton,
+			this.EmuStatus,
+			this.PlayRecordStatusButton,
+			this.PauseStatusButton,
+			this.RebootStatusBarIcon,
+			this.AVIStatusLabel,
+			this.LedLightStatusLabel,
+			this.SaveSlotsStatusLabel,
+			this.Slot1StatusButton,
+			this.Slot2StatusButton,
+			this.Slot3StatusButton,
+			this.Slot4StatusButton,
+			this.Slot5StatusButton,
+			this.Slot6StatusButton,
+			this.Slot7StatusButton,
+			this.Slot8StatusButton,
+			this.Slot9StatusButton,
+			this.Slot0StatusButton,
+			this.CheatStatusButton,
+			this.KeyPriorityStatusLabel,
+			this.CoreNameStatusBarButton,
+			this.ProfileFirstBootLabel,
+			this.LinkConnectStatusBarButton,
+			this.UpdateNotification});
 			this.MainStatusBar.Location = new System.Drawing.Point(0, 386);
 			this.MainStatusBar.Name = "MainStatusBar";
 			this.MainStatusBar.ShowItemToolTips = true;
@@ -2184,31 +2184,31 @@ namespace BizHawk.Client.EmuHawk
 			// MainFormContextMenu
 			// 
 			this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.OpenRomContextMenuItem,
-            this.LoadLastRomContextMenuItem,
-            this.StopAVContextMenuItem,
-            this.ContextSeparator_AfterROM,
-            this.RecordMovieContextMenuItem,
-            this.PlayMovieContextMenuItem,
-            this.RestartMovieContextMenuItem,
-            this.StopMovieContextMenuItem,
-            this.LoadLastMovieContextMenuItem,
-            this.BackupMovieContextMenuItem,
-            this.StopNoSaveContextMenuItem,
-            this.ViewSubtitlesContextMenuItem,
-            this.AddSubtitleContextMenuItem,
-            this.ViewCommentsContextMenuItem,
-            this.SaveMovieContextMenuItem,
-            this.SaveMovieAsContextMenuItem,
-            this.ContextSeparator_AfterMovie,
-            this.UndoSavestateContextMenuItem,
-            this.ContextSeparator_AfterUndo,
-            this.ConfigContextMenuItem,
-            this.ScreenshotContextMenuItem,
-            this.CloseRomContextMenuItem,
-            this.ClearSRAMContextMenuItem,
-            this.ShowMenuContextMenuSeparator,
-            this.ShowMenuContextMenuItem});
+			this.OpenRomContextMenuItem,
+			this.LoadLastRomContextMenuItem,
+			this.StopAVContextMenuItem,
+			this.ContextSeparator_AfterROM,
+			this.RecordMovieContextMenuItem,
+			this.PlayMovieContextMenuItem,
+			this.RestartMovieContextMenuItem,
+			this.StopMovieContextMenuItem,
+			this.LoadLastMovieContextMenuItem,
+			this.BackupMovieContextMenuItem,
+			this.StopNoSaveContextMenuItem,
+			this.ViewSubtitlesContextMenuItem,
+			this.AddSubtitleContextMenuItem,
+			this.ViewCommentsContextMenuItem,
+			this.SaveMovieContextMenuItem,
+			this.SaveMovieAsContextMenuItem,
+			this.ContextSeparator_AfterMovie,
+			this.UndoSavestateContextMenuItem,
+			this.ContextSeparator_AfterUndo,
+			this.ConfigContextMenuItem,
+			this.ScreenshotContextMenuItem,
+			this.CloseRomContextMenuItem,
+			this.ClearSRAMContextMenuItem,
+			this.ShowMenuContextMenuSeparator,
+			this.ShowMenuContextMenuItem});
 			this.MainFormContextMenu.Name = "contextMenuStrip1";
 			this.MainFormContextMenu.Size = new System.Drawing.Size(217, 490);
 			this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
@@ -2297,20 +2297,20 @@ namespace BizHawk.Client.EmuHawk
 			// ConfigContextMenuItem
 			// 
 			this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem6,
-            this.toolStripMenuItem7,
-            this.toolStripMenuItem8,
-            this.toolStripMenuItem9,
-            this.toolStripMenuItem10,
-            this.toolStripMenuItem11,
-            this.toolStripMenuItem12,
-            this.toolStripMenuItem13,
-            this.toolStripMenuItem14,
-            this.toolStripMenuItem15,
-            this.customizeToolStripMenuItem,
-            this.toolStripSeparator30,
-            this.toolStripMenuItem66,
-            this.toolStripMenuItem67});
+			this.toolStripMenuItem6,
+			this.toolStripMenuItem7,
+			this.toolStripMenuItem8,
+			this.toolStripMenuItem9,
+			this.toolStripMenuItem10,
+			this.toolStripMenuItem11,
+			this.toolStripMenuItem12,
+			this.toolStripMenuItem13,
+			this.toolStripMenuItem14,
+			this.toolStripMenuItem15,
+			this.customizeToolStripMenuItem,
+			this.toolStripSeparator30,
+			this.toolStripMenuItem66,
+			this.toolStripMenuItem67});
 			this.ConfigContextMenuItem.Text = "Config";
 			// 
 			// toolStripMenuItem6

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -100,6 +100,7 @@ namespace BizHawk.Client.EmuHawk
 			this.StopAVIMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.toolStripSeparator19 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.CaptureOSDMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.CaptureLuaMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.SynclessRecordingMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScreenshotSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ScreenshotMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -135,6 +136,7 @@ namespace BizHawk.Client.EmuHawk
 			this.toolStripMenuItem4 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayStatusBarMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.DisplayMessagesMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
+			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.DisplayLogWindowMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ConfigSubMenu = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.ControllersMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
@@ -373,7 +375,6 @@ namespace BizHawk.Client.EmuHawk
 			this.ShowMenuContextMenuSeparator = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.ShowMenuContextMenuItem = new BizHawk.WinForms.Controls.ToolStripMenuItemEx();
 			this.timerMouseIdle = new System.Windows.Forms.Timer(this.components);
-			this.toolStripSeparator8 = new BizHawk.WinForms.Controls.ToolStripSeparatorEx();
 			this.MainformMenu.SuspendLayout();
 			this.MainStatusBar.SuspendLayout();
 			this.MainFormContextMenu.SuspendLayout();
@@ -382,28 +383,28 @@ namespace BizHawk.Client.EmuHawk
 			// MainformMenu
 			// 
 			this.MainformMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FileSubMenu,
-			this.EmulationSubMenu,
-			this.ViewSubMenu,
-			this.ConfigSubMenu,
-			this.ToolsSubMenu,
-			this.NESSubMenu,
-			this.TI83SubMenu,
-			this.A7800SubMenu,
-			this.GBSubMenu,
-			this.NDSSubMenu,
-			this.PSXSubMenu,
-			this.SNESSubMenu,
-			this.ColecoSubMenu,
-			this.N64SubMenu,
-			this.DGBSubMenu,
-			this.AppleSubMenu,
-			this.C64SubMenu,
-			this.IntvSubMenu,
-			this.zXSpectrumToolStripMenuItem,
-			this.GenericCoreSubMenu,
-			this.amstradCPCToolStripMenuItem,
-			this.HelpSubMenu});
+            this.FileSubMenu,
+            this.EmulationSubMenu,
+            this.ViewSubMenu,
+            this.ConfigSubMenu,
+            this.ToolsSubMenu,
+            this.NESSubMenu,
+            this.TI83SubMenu,
+            this.A7800SubMenu,
+            this.GBSubMenu,
+            this.NDSSubMenu,
+            this.PSXSubMenu,
+            this.SNESSubMenu,
+            this.ColecoSubMenu,
+            this.N64SubMenu,
+            this.DGBSubMenu,
+            this.AppleSubMenu,
+            this.C64SubMenu,
+            this.IntvSubMenu,
+            this.zXSpectrumToolStripMenuItem,
+            this.GenericCoreSubMenu,
+            this.amstradCPCToolStripMenuItem,
+            this.HelpSubMenu});
 			this.MainformMenu.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
 			this.MainformMenu.TabIndex = 0;
 			this.MainformMenu.MenuActivate += new System.EventHandler(this.MainformMenu_MenuActivate);
@@ -412,21 +413,21 @@ namespace BizHawk.Client.EmuHawk
 			// FileSubMenu
 			// 
 			this.FileSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OpenRomMenuItem,
-			this.RecentRomSubMenu,
-			this.OpenAdvancedMenuItem,
-			this.CloseRomMenuItem,
-			this.toolStripMenuItem1,
-			this.SaveStateSubMenu,
-			this.LoadStateSubMenu,
-			this.SaveSlotSubMenu,
-			this.SaveRAMSubMenu,
-			this.toolStripMenuItem2,
-			this.MovieSubMenu,
-			this.AVSubMenu,
-			this.ScreenshotSubMenu,
-			this.toolStripSeparator4,
-			this.ExitMenuItem});
+            this.OpenRomMenuItem,
+            this.RecentRomSubMenu,
+            this.OpenAdvancedMenuItem,
+            this.CloseRomMenuItem,
+            this.toolStripMenuItem1,
+            this.SaveStateSubMenu,
+            this.LoadStateSubMenu,
+            this.SaveSlotSubMenu,
+            this.SaveRAMSubMenu,
+            this.toolStripMenuItem2,
+            this.MovieSubMenu,
+            this.AVSubMenu,
+            this.ScreenshotSubMenu,
+            this.toolStripSeparator4,
+            this.ExitMenuItem});
 			this.FileSubMenu.Text = "&File";
 			this.FileSubMenu.DropDownOpened += new System.EventHandler(this.FileSubMenu_DropDownOpened);
 			// 
@@ -438,7 +439,7 @@ namespace BizHawk.Client.EmuHawk
 			// RecentRomSubMenu
 			// 
 			this.RecentRomSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator3});
+            this.toolStripSeparator3});
 			this.RecentRomSubMenu.Text = "&Recent ROM";
 			this.RecentRomSubMenu.DropDownOpened += new System.EventHandler(this.RecentRomMenuItem_DropDownOpened);
 			// 
@@ -455,18 +456,18 @@ namespace BizHawk.Client.EmuHawk
 			// SaveStateSubMenu
 			// 
 			this.SaveStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SaveState1MenuItem,
-			this.SaveState2MenuItem,
-			this.SaveState3MenuItem,
-			this.SaveState4MenuItem,
-			this.SaveState5MenuItem,
-			this.SaveState6MenuItem,
-			this.SaveState7MenuItem,
-			this.SaveState8MenuItem,
-			this.SaveState9MenuItem,
-			this.SaveState0MenuItem,
-			this.toolStripSeparator6,
-			this.SaveNamedStateMenuItem});
+            this.SaveState1MenuItem,
+            this.SaveState2MenuItem,
+            this.SaveState3MenuItem,
+            this.SaveState4MenuItem,
+            this.SaveState5MenuItem,
+            this.SaveState6MenuItem,
+            this.SaveState7MenuItem,
+            this.SaveState8MenuItem,
+            this.SaveState9MenuItem,
+            this.SaveState0MenuItem,
+            this.toolStripSeparator6,
+            this.SaveNamedStateMenuItem});
 			this.SaveStateSubMenu.Text = "&Save State";
 			this.SaveStateSubMenu.DropDownOpened += new System.EventHandler(this.SaveStateSubMenu_DropDownOpened);
 			// 
@@ -528,20 +529,20 @@ namespace BizHawk.Client.EmuHawk
 			// LoadStateSubMenu
 			// 
 			this.LoadStateSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.LoadState1MenuItem,
-			this.LoadState2MenuItem,
-			this.LoadState3MenuItem,
-			this.LoadState4MenuItem,
-			this.LoadState5MenuItem,
-			this.LoadState6MenuItem,
-			this.LoadState7MenuItem,
-			this.LoadState8MenuItem,
-			this.LoadState9MenuItem,
-			this.LoadState0MenuItem,
-			this.toolStripSeparator7,
-			this.LoadNamedStateMenuItem,
-			this.toolStripSeparator21,
-			this.AutoloadLastSlotMenuItem});
+            this.LoadState1MenuItem,
+            this.LoadState2MenuItem,
+            this.LoadState3MenuItem,
+            this.LoadState4MenuItem,
+            this.LoadState5MenuItem,
+            this.LoadState6MenuItem,
+            this.LoadState7MenuItem,
+            this.LoadState8MenuItem,
+            this.LoadState9MenuItem,
+            this.LoadState0MenuItem,
+            this.toolStripSeparator7,
+            this.LoadNamedStateMenuItem,
+            this.toolStripSeparator21,
+            this.AutoloadLastSlotMenuItem});
 			this.LoadStateSubMenu.Text = "&Load State";
 			this.LoadStateSubMenu.DropDownOpened += new System.EventHandler(this.LoadStateSubMenu_DropDownOpened);
 			// 
@@ -608,21 +609,21 @@ namespace BizHawk.Client.EmuHawk
 			// SaveSlotSubMenu
 			// 
 			this.SaveSlotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SelectSlot0MenuItem,
-			this.SelectSlot1MenuItem,
-			this.SelectSlot2MenuItem,
-			this.SelectSlot3MenuItem,
-			this.SelectSlot4MenuItem,
-			this.SelectSlot5MenuItem,
-			this.SelectSlot6MenuItem,
-			this.SelectSlot7MenuItem,
-			this.SelectSlot8MenuItem,
-			this.SelectSlot9MenuItem,
-			this.PreviousSlotMenuItem,
-			this.NextSlotMenuItem,
-			this.toolStripSeparator5,
-			this.SaveToCurrentSlotMenuItem,
-			this.LoadCurrentSlotMenuItem});
+            this.SelectSlot0MenuItem,
+            this.SelectSlot1MenuItem,
+            this.SelectSlot2MenuItem,
+            this.SelectSlot3MenuItem,
+            this.SelectSlot4MenuItem,
+            this.SelectSlot5MenuItem,
+            this.SelectSlot6MenuItem,
+            this.SelectSlot7MenuItem,
+            this.SelectSlot8MenuItem,
+            this.SelectSlot9MenuItem,
+            this.PreviousSlotMenuItem,
+            this.NextSlotMenuItem,
+            this.toolStripSeparator5,
+            this.SaveToCurrentSlotMenuItem,
+            this.LoadCurrentSlotMenuItem});
 			this.SaveSlotSubMenu.Text = "Save S&lot";
 			this.SaveSlotSubMenu.DropDownOpened += new System.EventHandler(this.SaveSlotSubMenu_DropDownOpened);
 			// 
@@ -699,7 +700,7 @@ namespace BizHawk.Client.EmuHawk
 			// SaveRAMSubMenu
 			// 
 			this.SaveRAMSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FlushSaveRAMMenuItem});
+            this.FlushSaveRAMMenuItem});
 			this.SaveRAMSubMenu.Text = "Save &RAM";
 			this.SaveRAMSubMenu.DropDownOpened += new System.EventHandler(this.SaveRamSubMenu_DropDownOpened);
 			// 
@@ -711,21 +712,21 @@ namespace BizHawk.Client.EmuHawk
 			// MovieSubMenu
 			// 
 			this.MovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ReadonlyMenuItem,
-			this.toolStripSeparator15,
-			this.RecentMovieSubMenu,
-			this.RecordMovieMenuItem,
-			this.PlayMovieMenuItem,
-			this.StopMovieMenuItem,
-			this.PlayFromBeginningMenuItem,
-			this.ImportMoviesMenuItem,
-			this.SaveMovieMenuItem,
-			this.SaveMovieAsMenuItem,
-			this.StopMovieWithoutSavingMenuItem,
-			this.toolStripSeparator14,
-			this.AutomaticallyBackupMoviesMenuItem,
-			this.FullMovieLoadstatesMenuItem,
-			this.MovieEndSubMenu});
+            this.ReadonlyMenuItem,
+            this.toolStripSeparator15,
+            this.RecentMovieSubMenu,
+            this.RecordMovieMenuItem,
+            this.PlayMovieMenuItem,
+            this.StopMovieMenuItem,
+            this.PlayFromBeginningMenuItem,
+            this.ImportMoviesMenuItem,
+            this.SaveMovieMenuItem,
+            this.SaveMovieAsMenuItem,
+            this.StopMovieWithoutSavingMenuItem,
+            this.toolStripSeparator14,
+            this.AutomaticallyBackupMoviesMenuItem,
+            this.FullMovieLoadstatesMenuItem,
+            this.MovieEndSubMenu});
 			this.MovieSubMenu.Text = "&Movie";
 			this.MovieSubMenu.DropDownOpened += new System.EventHandler(this.MovieSubMenu_DropDownOpened);
 			// 
@@ -737,7 +738,7 @@ namespace BizHawk.Client.EmuHawk
 			// RecentMovieSubMenu
 			// 
 			this.RecentMovieSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator16});
+            this.toolStripSeparator16});
 			this.RecentMovieSubMenu.Text = "Recent";
 			this.RecentMovieSubMenu.DropDownOpened += new System.EventHandler(this.RecentMovieSubMenu_DropDownOpened);
 			// 
@@ -794,10 +795,10 @@ namespace BizHawk.Client.EmuHawk
 			// MovieEndSubMenu
 			// 
 			this.MovieEndSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.MovieEndFinishMenuItem,
-			this.MovieEndRecordMenuItem,
-			this.MovieEndStopMenuItem,
-			this.MovieEndPauseMenuItem});
+            this.MovieEndFinishMenuItem,
+            this.MovieEndRecordMenuItem,
+            this.MovieEndStopMenuItem,
+            this.MovieEndPauseMenuItem});
 			this.MovieEndSubMenu.Text = "On Movie End";
 			this.MovieEndSubMenu.DropDownOpened += new System.EventHandler(this.MovieEndSubMenu_DropDownOpened);
 			// 
@@ -824,12 +825,13 @@ namespace BizHawk.Client.EmuHawk
 			// AVSubMenu
 			// 
 			this.AVSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.RecordAVMenuItem,
-			this.ConfigAndRecordAVMenuItem,
-			this.StopAVIMenuItem,
-			this.toolStripSeparator19,
-			this.CaptureOSDMenuItem,
-			this.SynclessRecordingMenuItem});
+            this.RecordAVMenuItem,
+            this.ConfigAndRecordAVMenuItem,
+            this.StopAVIMenuItem,
+            this.toolStripSeparator19,
+            this.CaptureOSDMenuItem,
+            this.CaptureLuaMenuItem,
+            this.SynclessRecordingMenuItem});
 			this.AVSubMenu.Text = "&AVI/WAV";
 			this.AVSubMenu.DropDownOpened += new System.EventHandler(this.AVSubMenu_DropDownOpened);
 			// 
@@ -853,6 +855,13 @@ namespace BizHawk.Client.EmuHawk
 			this.CaptureOSDMenuItem.Text = "Capture OSD";
 			this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
 			// 
+			// CaptureLuaMenuItem
+			// 
+			this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
+			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(225, 22);
+			this.CaptureLuaMenuItem.Text = "Capture Lua";
+			this.CaptureLuaMenuItem.Click += new System.EventHandler(this.CaptureLuaMenuItem_Click);
+			// 
 			// SynclessRecordingMenuItem
 			// 
 			this.SynclessRecordingMenuItem.Text = "S&yncless Recording Tools";
@@ -861,12 +870,12 @@ namespace BizHawk.Client.EmuHawk
 			// ScreenshotSubMenu
 			// 
 			this.ScreenshotSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ScreenshotMenuItem,
-			this.ScreenshotAsMenuItem,
-			this.ScreenshotClipboardMenuItem,
-			this.ScreenshotClientClipboardMenuItem,
-			this.toolStripSeparator20,
-			this.ScreenshotCaptureOSDMenuItem1});
+            this.ScreenshotMenuItem,
+            this.ScreenshotAsMenuItem,
+            this.ScreenshotClipboardMenuItem,
+            this.ScreenshotClientClipboardMenuItem,
+            this.toolStripSeparator20,
+            this.ScreenshotCaptureOSDMenuItem1});
 			this.ScreenshotSubMenu.Text = "Scree&nshot";
 			this.ScreenshotSubMenu.DropDownOpening += new System.EventHandler(this.ScreenshotSubMenu_DropDownOpening);
 			// 
@@ -904,11 +913,11 @@ namespace BizHawk.Client.EmuHawk
 			// EmulationSubMenu
 			// 
 			this.EmulationSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.PauseMenuItem,
-			this.RebootCoreMenuItem,
-			this.toolStripSeparator1,
-			this.SoftResetMenuItem,
-			this.HardResetMenuItem});
+            this.PauseMenuItem,
+            this.RebootCoreMenuItem,
+            this.toolStripSeparator1,
+            this.SoftResetMenuItem,
+            this.HardResetMenuItem});
 			this.EmulationSubMenu.Text = "&Emulation";
 			this.EmulationSubMenu.DropDownOpened += new System.EventHandler(this.EmulationMenuItem_DropDownOpened);
 			// 
@@ -935,32 +944,32 @@ namespace BizHawk.Client.EmuHawk
 			// ViewSubMenu
 			// 
 			this.ViewSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.WindowSizeSubMenu,
-			this.SwitchToFullscreenMenuItem,
-			this.toolStripSeparator2,
-			this.DisplayFPSMenuItem,
-			this.DisplayFrameCounterMenuItem,
-			this.DisplayLagCounterMenuItem,
-			this.DisplayInputMenuItem,
-			this.DisplayRerecordCountMenuItem,
-			this.DisplaySubtitlesMenuItem,
-			this.toolStripMenuItem4,
-			this.DisplayStatusBarMenuItem,
-			this.DisplayMessagesMenuItem,
-			this.toolStripSeparator8,
-			this.DisplayLogWindowMenuItem});
+            this.WindowSizeSubMenu,
+            this.SwitchToFullscreenMenuItem,
+            this.toolStripSeparator2,
+            this.DisplayFPSMenuItem,
+            this.DisplayFrameCounterMenuItem,
+            this.DisplayLagCounterMenuItem,
+            this.DisplayInputMenuItem,
+            this.DisplayRerecordCountMenuItem,
+            this.DisplaySubtitlesMenuItem,
+            this.toolStripMenuItem4,
+            this.DisplayStatusBarMenuItem,
+            this.DisplayMessagesMenuItem,
+            this.toolStripSeparator8,
+            this.DisplayLogWindowMenuItem});
 			this.ViewSubMenu.Text = "&View";
 			this.ViewSubMenu.DropDownOpened += new System.EventHandler(this.ViewSubMenu_DropDownOpened);
 			// 
 			// WindowSizeSubMenu
 			// 
 			this.WindowSizeSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.x1MenuItem,
-			this.x2MenuItem,
-			this.x3MenuItem,
-			this.x4MenuItem,
-			this.x5MenuItem,
-			this.mzMenuItem});
+            this.x1MenuItem,
+            this.x2MenuItem,
+            this.x3MenuItem,
+            this.x4MenuItem,
+            this.x5MenuItem,
+            this.mzMenuItem});
 			this.WindowSizeSubMenu.Text = "&Window Size";
 			this.WindowSizeSubMenu.DropDownOpened += new System.EventHandler(this.WindowSizeSubMenu_DropDownOpened);
 			// 
@@ -1047,27 +1056,27 @@ namespace BizHawk.Client.EmuHawk
 			// ConfigSubMenu
 			// 
 			this.ConfigSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ControllersMenuItem,
-			this.HotkeysMenuItem,
-			this.DisplayConfigMenuItem,
-			this.SoundMenuItem,
-			this.PathsMenuItem,
-			this.FirmwaresMenuItem,
-			this.MessagesMenuItem,
-			this.AutofireMenuItem,
-			this.RewindOptionsMenuItem,
-			this.extensionsToolStripMenuItem,
-			this.ClientOptionsMenuItem,
-			this.ProfilesMenuItem,
-			this.toolStripSeparator9,
-			this.SpeedSkipSubMenu,
-			this.KeyPrioritySubMenu,
-			this.CoresSubMenu,
-			this.toolStripSeparator10,
-			this.SaveConfigMenuItem,
-			this.SaveConfigAsMenuItem,
-			this.LoadConfigMenuItem,
-			this.LoadConfigFromMenuItem});
+            this.ControllersMenuItem,
+            this.HotkeysMenuItem,
+            this.DisplayConfigMenuItem,
+            this.SoundMenuItem,
+            this.PathsMenuItem,
+            this.FirmwaresMenuItem,
+            this.MessagesMenuItem,
+            this.AutofireMenuItem,
+            this.RewindOptionsMenuItem,
+            this.extensionsToolStripMenuItem,
+            this.ClientOptionsMenuItem,
+            this.ProfilesMenuItem,
+            this.toolStripSeparator9,
+            this.SpeedSkipSubMenu,
+            this.KeyPrioritySubMenu,
+            this.CoresSubMenu,
+            this.toolStripSeparator10,
+            this.SaveConfigMenuItem,
+            this.SaveConfigAsMenuItem,
+            this.LoadConfigMenuItem,
+            this.LoadConfigFromMenuItem});
 			this.ConfigSubMenu.Text = "&Config";
 			this.ConfigSubMenu.DropDownOpened += new System.EventHandler(this.ConfigSubMenu_DropDownOpened);
 			// 
@@ -1134,23 +1143,23 @@ namespace BizHawk.Client.EmuHawk
 			// SpeedSkipSubMenu
 			// 
 			this.SpeedSkipSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ClockThrottleMenuItem,
-			this.AudioThrottleMenuItem,
-			this.VsyncThrottleMenuItem,
-			this.toolStripSeparator27,
-			this.VsyncEnabledMenuItem,
-			this.toolStripMenuItem3,
-			this.miUnthrottled,
-			this.MinimizeSkippingMenuItem,
-			this.NeverSkipMenuItem,
-			this.toolStripMenuItem17,
-			this.toolStripMenuItem5,
-			this.Speed50MenuItem,
-			this.Speed75MenuItem,
-			this.Speed100MenuItem,
-			this.Speed150MenuItem,
-			this.Speed200MenuItem,
-			this.Speed400MenuItem});
+            this.ClockThrottleMenuItem,
+            this.AudioThrottleMenuItem,
+            this.VsyncThrottleMenuItem,
+            this.toolStripSeparator27,
+            this.VsyncEnabledMenuItem,
+            this.toolStripMenuItem3,
+            this.miUnthrottled,
+            this.MinimizeSkippingMenuItem,
+            this.NeverSkipMenuItem,
+            this.toolStripMenuItem17,
+            this.toolStripMenuItem5,
+            this.Speed50MenuItem,
+            this.Speed75MenuItem,
+            this.Speed100MenuItem,
+            this.Speed150MenuItem,
+            this.Speed200MenuItem,
+            this.Speed400MenuItem});
 			this.SpeedSkipSubMenu.Text = "Speed/Skip";
 			this.SpeedSkipSubMenu.DropDownOpened += new System.EventHandler(this.FrameSkipMenuItem_DropDownOpened);
 			// 
@@ -1192,15 +1201,15 @@ namespace BizHawk.Client.EmuHawk
 			// toolStripMenuItem17
 			// 
 			this.toolStripMenuItem17.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.Frameskip1MenuItem,
-			this.Frameskip2MenuItem,
-			this.Frameskip3MenuItem,
-			this.Frameskip4MenuItem,
-			this.Frameskip5MenuItem,
-			this.Frameskip6MenuItem,
-			this.Frameskip7MenuItem,
-			this.Frameskip8MenuItem,
-			this.Frameskip9MenuItem});
+            this.Frameskip1MenuItem,
+            this.Frameskip2MenuItem,
+            this.Frameskip3MenuItem,
+            this.Frameskip4MenuItem,
+            this.Frameskip5MenuItem,
+            this.Frameskip6MenuItem,
+            this.Frameskip7MenuItem,
+            this.Frameskip8MenuItem,
+            this.Frameskip9MenuItem});
 			this.toolStripMenuItem17.Text = "Skip 1..9";
 			// 
 			// Frameskip1MenuItem
@@ -1281,9 +1290,9 @@ namespace BizHawk.Client.EmuHawk
 			// KeyPrioritySubMenu
 			// 
 			this.KeyPrioritySubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.BothHkAndControllerMenuItem,
-			this.InputOverHkMenuItem,
-			this.HkOverInputMenuItem});
+            this.BothHkAndControllerMenuItem,
+            this.InputOverHkMenuItem,
+            this.HkOverInputMenuItem});
 			this.KeyPrioritySubMenu.Text = "Key Priority";
 			this.KeyPrioritySubMenu.DropDownOpened += new System.EventHandler(this.KeyPriorityMenuItem_DropDownOpened);
 			// 
@@ -1329,26 +1338,26 @@ namespace BizHawk.Client.EmuHawk
 			// ToolsSubMenu
 			// 
 			this.ToolsSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ToolBoxMenuItem,
-			this.toolStripSeparator12,
-			this.RamWatchMenuItem,
-			this.RamSearchMenuItem,
-			this.LuaConsoleMenuItem,
-			this.TAStudioMenuItem,
-			this.HexEditorMenuItem,
-			this.TraceLoggerMenuItem,
-			this.DebuggerMenuItem,
-			this.CodeDataLoggerMenuItem,
-			this.MacroToolMenuItem,
-			this.VirtualPadMenuItem,
-			this.BasicBotMenuItem,
-			this.toolStripSeparator11,
-			this.CheatsMenuItem,
-			this.GameSharkConverterMenuItem,
-			this.toolStripSeparator29,
-			this.MultiDiskBundlerFileMenuItem,
-			this.ExternalToolMenuItem,
-			this.BatchRunnerMenuItem});
+            this.ToolBoxMenuItem,
+            this.toolStripSeparator12,
+            this.RamWatchMenuItem,
+            this.RamSearchMenuItem,
+            this.LuaConsoleMenuItem,
+            this.TAStudioMenuItem,
+            this.HexEditorMenuItem,
+            this.TraceLoggerMenuItem,
+            this.DebuggerMenuItem,
+            this.CodeDataLoggerMenuItem,
+            this.MacroToolMenuItem,
+            this.VirtualPadMenuItem,
+            this.BasicBotMenuItem,
+            this.toolStripSeparator11,
+            this.CheatsMenuItem,
+            this.GameSharkConverterMenuItem,
+            this.toolStripSeparator29,
+            this.MultiDiskBundlerFileMenuItem,
+            this.ExternalToolMenuItem,
+            this.BatchRunnerMenuItem});
 			this.ToolsSubMenu.Text = "&Tools";
 			this.ToolsSubMenu.DropDownOpened += new System.EventHandler(this.ToolsSubMenu_DropDownOpened);
 			// 
@@ -1430,7 +1439,7 @@ namespace BizHawk.Client.EmuHawk
 			// ExternalToolMenuItem
 			// 
 			this.ExternalToolMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.dummyExternalTool});
+            this.dummyExternalTool});
 			this.ExternalToolMenuItem.Text = "External Tool";
 			this.ExternalToolMenuItem.DropDownOpening += new System.EventHandler(this.ExternalToolMenuItem_DropDownOpening);
 			// 
@@ -1447,19 +1456,19 @@ namespace BizHawk.Client.EmuHawk
 			// NESSubMenu
 			// 
 			this.NESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.NESPPUViewerMenuItem,
-			this.NESNametableViewerMenuItem,
-			this.MusicRipperMenuItem,
-			this.toolStripSeparator17,
-			this.NesControllerSettingsMenuItem,
-			this.NESGraphicSettingsMenuItem,
-			this.NESSoundChannelsMenuItem,
-			this.VSSettingsMenuItem,
-			this.MovieSettingsMenuItem,
-			this.toolStripSeparator22,
-			this.FDSControlsMenuItem,
-			this.VSControlsMenuItem,
-			this.BarcodeReaderMenuItem});
+            this.NESPPUViewerMenuItem,
+            this.NESNametableViewerMenuItem,
+            this.MusicRipperMenuItem,
+            this.toolStripSeparator17,
+            this.NesControllerSettingsMenuItem,
+            this.NESGraphicSettingsMenuItem,
+            this.NESSoundChannelsMenuItem,
+            this.VSSettingsMenuItem,
+            this.MovieSettingsMenuItem,
+            this.toolStripSeparator22,
+            this.FDSControlsMenuItem,
+            this.VSControlsMenuItem,
+            this.BarcodeReaderMenuItem});
 			this.NESSubMenu.Text = "&NES";
 			this.NESSubMenu.DropDownOpened += new System.EventHandler(this.NesSubMenu_DropDownOpened);
 			// 
@@ -1506,7 +1515,7 @@ namespace BizHawk.Client.EmuHawk
 			// FDSControlsMenuItem
 			// 
 			this.FDSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.FdsEjectDiskMenuItem});
+            this.FdsEjectDiskMenuItem});
 			this.FDSControlsMenuItem.Text = "FDS Controls";
 			this.FDSControlsMenuItem.DropDownOpened += new System.EventHandler(this.FdsControlsMenuItem_DropDownOpened);
 			// 
@@ -1518,9 +1527,9 @@ namespace BizHawk.Client.EmuHawk
 			// VSControlsMenuItem
 			// 
 			this.VSControlsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.VSInsertCoinP1MenuItem,
-			this.VSInsertCoinP2MenuItem,
-			this.VSServiceSwitchMenuItem});
+            this.VSInsertCoinP1MenuItem,
+            this.VSInsertCoinP2MenuItem,
+            this.VSServiceSwitchMenuItem});
 			this.VSControlsMenuItem.Text = "VS Controls";
 			// 
 			// VSInsertCoinP1MenuItem
@@ -1546,11 +1555,11 @@ namespace BizHawk.Client.EmuHawk
 			// TI83SubMenu
 			// 
 			this.TI83SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.KeypadMenuItem,
-			this.LoadTIFileMenuItem,
-			this.toolStripSeparator13,
-			this.AutoloadKeypadMenuItem,
-			this.paletteToolStripMenuItem});
+            this.KeypadMenuItem,
+            this.LoadTIFileMenuItem,
+            this.toolStripSeparator13,
+            this.AutoloadKeypadMenuItem,
+            this.paletteToolStripMenuItem});
 			this.TI83SubMenu.Text = "TI83";
 			this.TI83SubMenu.DropDownOpened += new System.EventHandler(this.Ti83SubMenu_DropDownOpened);
 			// 
@@ -1579,8 +1588,8 @@ namespace BizHawk.Client.EmuHawk
 			// A7800SubMenu
 			// 
 			this.A7800SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.A7800ControllerSettingsMenuItem,
-			this.A7800FilterSettingsMenuItem});
+            this.A7800ControllerSettingsMenuItem,
+            this.A7800FilterSettingsMenuItem});
 			this.A7800SubMenu.Text = "&A7800";
 			this.A7800SubMenu.DropDownOpened += new System.EventHandler(this.A7800SubMenu_DropDownOpened);
 			// 
@@ -1597,10 +1606,10 @@ namespace BizHawk.Client.EmuHawk
 			// GBSubMenu
 			// 
 			this.GBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.GBcoreSettingsToolStripMenuItem,
-			this.toolStripSeparator28,
-			this.GBGPUViewerMenuItem,
-			this.GBPrinterViewerMenuItem});
+            this.GBcoreSettingsToolStripMenuItem,
+            this.toolStripSeparator28,
+            this.GBGPUViewerMenuItem,
+            this.GBPrinterViewerMenuItem});
 			this.GBSubMenu.Text = "&GB";
 			// 
 			// GBcoreSettingsToolStripMenuItem
@@ -1621,8 +1630,8 @@ namespace BizHawk.Client.EmuHawk
 			// NDSSubMenu
 			// 
 			this.NDSSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.NdsSettingsMenuItem,
-			this.NdsSyncSettingsMenuItem});
+            this.NdsSettingsMenuItem,
+            this.NdsSyncSettingsMenuItem});
 			this.NDSSubMenu.Text = "NDS";
 			this.NDSSubMenu.DropDownOpened += new System.EventHandler(this.NDSSubMenu_DropDownOpened);
 			// 
@@ -1639,10 +1648,10 @@ namespace BizHawk.Client.EmuHawk
 			// PSXSubMenu
 			// 
 			this.PSXSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.PSXControllerSettingsMenuItem,
-			this.PSXOptionsMenuItem,
-			this.PSXDiscControlsMenuItem,
-			this.PSXHashDiscsToolStripMenuItem});
+            this.PSXControllerSettingsMenuItem,
+            this.PSXOptionsMenuItem,
+            this.PSXDiscControlsMenuItem,
+            this.PSXHashDiscsToolStripMenuItem});
 			this.PSXSubMenu.Text = "PSX";
 			this.PSXSubMenu.DropDownOpened += new System.EventHandler(this.PsxSubMenu_DropDownOpened);
 			// 
@@ -1669,10 +1678,10 @@ namespace BizHawk.Client.EmuHawk
 			// SNESSubMenu
 			// 
 			this.SNESSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.SNESControllerConfigurationMenuItem,
-			this.toolStripSeparator18,
-			this.SnesGfxDebuggerMenuItem,
-			this.SnesOptionsMenuItem});
+            this.SNESControllerConfigurationMenuItem,
+            this.toolStripSeparator18,
+            this.SnesGfxDebuggerMenuItem,
+            this.SnesOptionsMenuItem});
 			this.SNESSubMenu.Text = "&SNES";
 			this.SNESSubMenu.DropDownOpened += new System.EventHandler(this.SnesSubMenu_DropDownOpened);
 			// 
@@ -1694,10 +1703,10 @@ namespace BizHawk.Client.EmuHawk
 			// ColecoSubMenu
 			// 
 			this.ColecoSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ColecoControllerSettingsMenuItem,
-			this.toolStripSeparator35,
-			this.ColecoSkipBiosMenuItem,
-			this.ColecoUseSGMMenuItem});
+            this.ColecoControllerSettingsMenuItem,
+            this.toolStripSeparator35,
+            this.ColecoSkipBiosMenuItem,
+            this.ColecoUseSGMMenuItem});
 			this.ColecoSubMenu.Text = "&Coleco";
 			this.ColecoSubMenu.DropDownOpened += new System.EventHandler(this.ColecoSubMenu_DropDownOpened);
 			// 
@@ -1719,12 +1728,12 @@ namespace BizHawk.Client.EmuHawk
 			// N64SubMenu
 			// 
 			this.N64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.N64PluginSettingsMenuItem,
-			this.N64ControllerSettingsMenuItem,
-			this.toolStripSeparator23,
-			this.N64CircularAnalogRangeMenuItem,
-			this.MupenStyleLagMenuItem,
-			this.N64ExpansionSlotMenuItem});
+            this.N64PluginSettingsMenuItem,
+            this.N64ControllerSettingsMenuItem,
+            this.toolStripSeparator23,
+            this.N64CircularAnalogRangeMenuItem,
+            this.MupenStyleLagMenuItem,
+            this.N64ExpansionSlotMenuItem});
 			this.N64SubMenu.Text = "N64";
 			this.N64SubMenu.DropDownOpened += new System.EventHandler(this.N64SubMenu_DropDownOpened);
 			// 
@@ -1756,7 +1765,7 @@ namespace BizHawk.Client.EmuHawk
 			// DGBSubMenu
 			// 
 			this.DGBSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.DGBsettingsToolStripMenuItem});
+            this.DGBsettingsToolStripMenuItem});
 			this.DGBSubMenu.Text = "&GB Link";
 			// 
 			// DGBsettingsToolStripMenuItem
@@ -1767,15 +1776,15 @@ namespace BizHawk.Client.EmuHawk
 			// AppleSubMenu
 			// 
 			this.AppleSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AppleDisksSubMenu,
-			this.settingsToolStripMenuItem1});
+            this.AppleDisksSubMenu,
+            this.settingsToolStripMenuItem1});
 			this.AppleSubMenu.Text = "Apple";
 			this.AppleSubMenu.DropDownOpened += new System.EventHandler(this.AppleSubMenu_DropDownOpened);
 			// 
 			// AppleDisksSubMenu
 			// 
 			this.AppleDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator31});
+            this.toolStripSeparator31});
 			this.AppleDisksSubMenu.Text = "Disks";
 			this.AppleDisksSubMenu.DropDownOpened += new System.EventHandler(this.AppleDisksSubMenu_DropDownOpened);
 			// 
@@ -1787,15 +1796,15 @@ namespace BizHawk.Client.EmuHawk
 			// C64SubMenu
 			// 
 			this.C64SubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.C64DisksSubMenu,
-			this.C64SettingsMenuItem});
+            this.C64DisksSubMenu,
+            this.C64SettingsMenuItem});
 			this.C64SubMenu.Text = "&C64";
 			this.C64SubMenu.DropDownOpened += new System.EventHandler(this.C64SubMenu_DropDownOpened);
 			// 
 			// C64DisksSubMenu
 			// 
 			this.C64DisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripSeparator36});
+            this.toolStripSeparator36});
 			this.C64DisksSubMenu.Text = "Disks";
 			this.C64DisksSubMenu.DropDownOpened += new System.EventHandler(this.C64DisksSubMenu_DropDownOpened);
 			// 
@@ -1807,7 +1816,7 @@ namespace BizHawk.Client.EmuHawk
 			// IntvSubMenu
 			// 
 			this.IntvSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.IntVControllerSettingsMenuItem});
+            this.IntVControllerSettingsMenuItem});
 			this.IntvSubMenu.Text = "&Intv";
 			this.IntvSubMenu.DropDownOpened += new System.EventHandler(this.IntVSubMenu_DropDownOpened);
 			// 
@@ -1819,12 +1828,12 @@ namespace BizHawk.Client.EmuHawk
 			// zXSpectrumToolStripMenuItem
 			// 
 			this.zXSpectrumToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ZXSpectrumCoreEmulationSettingsMenuItem,
-			this.ZXSpectrumControllerConfigurationMenuItem,
-			this.ZXSpectrumAudioSettingsMenuItem,
-			this.ZXSpectrumNonSyncSettingsMenuItem,
-			this.ZXSpectrumPokeMemoryMenuItem,
-			this.ZXSpectrumMediaMenuItem});
+            this.ZXSpectrumCoreEmulationSettingsMenuItem,
+            this.ZXSpectrumControllerConfigurationMenuItem,
+            this.ZXSpectrumAudioSettingsMenuItem,
+            this.ZXSpectrumNonSyncSettingsMenuItem,
+            this.ZXSpectrumPokeMemoryMenuItem,
+            this.ZXSpectrumMediaMenuItem});
 			this.zXSpectrumToolStripMenuItem.Text = "ZX Spectrum";
 			// 
 			// ZXSpectrumCoreEmulationSettingsMenuItem
@@ -1855,16 +1864,16 @@ namespace BizHawk.Client.EmuHawk
 			// ZXSpectrumMediaMenuItem
 			// 
 			this.ZXSpectrumMediaMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.ZXSpectrumTapesSubMenu,
-			this.ZXSpectrumDisksSubMenu,
-			this.ZXSpectrumExportSnapshotMenuItemMenuItem});
+            this.ZXSpectrumTapesSubMenu,
+            this.ZXSpectrumDisksSubMenu,
+            this.ZXSpectrumExportSnapshotMenuItemMenuItem});
 			this.ZXSpectrumMediaMenuItem.Text = "Media";
 			this.ZXSpectrumMediaMenuItem.DropDownOpened += new System.EventHandler(this.ZXSpectrumMediaMenuItem_DropDownOpened);
 			// 
 			// ZXSpectrumTapesSubMenu
 			// 
 			this.ZXSpectrumTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.zxt1ToolStripMenuItem});
+            this.zxt1ToolStripMenuItem});
 			this.ZXSpectrumTapesSubMenu.Text = "Tapes";
 			this.ZXSpectrumTapesSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumTapesSubMenu_DropDownOpened);
 			// 
@@ -1875,7 +1884,7 @@ namespace BizHawk.Client.EmuHawk
 			// ZXSpectrumDisksSubMenu
 			// 
 			this.ZXSpectrumDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.zxt2ToolStripMenuItem});
+            this.zxt2ToolStripMenuItem});
 			this.ZXSpectrumDisksSubMenu.Text = "Disks";
 			this.ZXSpectrumDisksSubMenu.DropDownOpened += new System.EventHandler(this.ZXSpectrumDisksSubMenu_DropDownOpened);
 			// 
@@ -1895,11 +1904,11 @@ namespace BizHawk.Client.EmuHawk
 			// amstradCPCToolStripMenuItem
 			// 
 			this.amstradCPCToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
-			this.AmstradCPCAudioSettingsToolStripMenuItem,
-			this.AmstradCPCNonSyncSettingsToolStripMenuItem,
-			this.AmstradCPCPokeMemoryToolStripMenuItem,
-			this.AmstradCPCMediaToolStripMenuItem});
+            this.amstradCPCCoreEmulationSettingsToolStripMenuItem,
+            this.AmstradCPCAudioSettingsToolStripMenuItem,
+            this.AmstradCPCNonSyncSettingsToolStripMenuItem,
+            this.AmstradCPCPokeMemoryToolStripMenuItem,
+            this.AmstradCPCMediaToolStripMenuItem});
 			this.amstradCPCToolStripMenuItem.Text = "Amstrad CPC";
 			// 
 			// amstradCPCCoreEmulationSettingsToolStripMenuItem
@@ -1925,15 +1934,15 @@ namespace BizHawk.Client.EmuHawk
 			// AmstradCPCMediaToolStripMenuItem
 			// 
 			this.AmstradCPCMediaToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.AmstradCPCTapesSubMenu,
-			this.AmstradCPCDisksSubMenu});
+            this.AmstradCPCTapesSubMenu,
+            this.AmstradCPCDisksSubMenu});
 			this.AmstradCPCMediaToolStripMenuItem.Text = "Media";
 			this.AmstradCPCMediaToolStripMenuItem.DropDownOpened += new System.EventHandler(this.AmstradCpcMediaMenuItem_DropDownOpened);
 			// 
 			// AmstradCPCTapesSubMenu
 			// 
 			this.AmstradCPCTapesSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.cpct1ToolStripMenuItem});
+            this.cpct1ToolStripMenuItem});
 			this.AmstradCPCTapesSubMenu.Text = "Tapes";
 			this.AmstradCPCTapesSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcTapesSubMenu_DropDownOpened);
 			// 
@@ -1944,7 +1953,7 @@ namespace BizHawk.Client.EmuHawk
 			// AmstradCPCDisksSubMenu
 			// 
 			this.AmstradCPCDisksSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.cpcd1ToolStripMenuItem});
+            this.cpcd1ToolStripMenuItem});
 			this.AmstradCPCDisksSubMenu.Text = "Disks";
 			this.AmstradCPCDisksSubMenu.DropDownOpened += new System.EventHandler(this.AmstradCpcDisksSubMenu_DropDownOpened);
 			// 
@@ -1955,10 +1964,10 @@ namespace BizHawk.Client.EmuHawk
 			// HelpSubMenu
 			// 
 			this.HelpSubMenu.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OnlineHelpMenuItem,
-			this.ForumsMenuItem,
-			this.FeaturesMenuItem,
-			this.AboutMenuItem});
+            this.OnlineHelpMenuItem,
+            this.ForumsMenuItem,
+            this.FeaturesMenuItem,
+            this.AboutMenuItem});
 			this.HelpSubMenu.Text = "&Help";
 			this.HelpSubMenu.DropDownOpened += new System.EventHandler(this.HelpSubMenu_DropDownOpened);
 			// 
@@ -1989,30 +1998,30 @@ namespace BizHawk.Client.EmuHawk
 			// MainStatusBar
 			// 
 			this.MainStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.DumpStatusButton,
-			this.EmuStatus,
-			this.PlayRecordStatusButton,
-			this.PauseStatusButton,
-			this.RebootStatusBarIcon,
-			this.AVIStatusLabel,
-			this.LedLightStatusLabel,
-			this.SaveSlotsStatusLabel,
-			this.Slot1StatusButton,
-			this.Slot2StatusButton,
-			this.Slot3StatusButton,
-			this.Slot4StatusButton,
-			this.Slot5StatusButton,
-			this.Slot6StatusButton,
-			this.Slot7StatusButton,
-			this.Slot8StatusButton,
-			this.Slot9StatusButton,
-			this.Slot0StatusButton,
-			this.CheatStatusButton,
-			this.KeyPriorityStatusLabel,
-			this.CoreNameStatusBarButton,
-			this.ProfileFirstBootLabel,
-			this.LinkConnectStatusBarButton,
-			this.UpdateNotification});
+            this.DumpStatusButton,
+            this.EmuStatus,
+            this.PlayRecordStatusButton,
+            this.PauseStatusButton,
+            this.RebootStatusBarIcon,
+            this.AVIStatusLabel,
+            this.LedLightStatusLabel,
+            this.SaveSlotsStatusLabel,
+            this.Slot1StatusButton,
+            this.Slot2StatusButton,
+            this.Slot3StatusButton,
+            this.Slot4StatusButton,
+            this.Slot5StatusButton,
+            this.Slot6StatusButton,
+            this.Slot7StatusButton,
+            this.Slot8StatusButton,
+            this.Slot9StatusButton,
+            this.Slot0StatusButton,
+            this.CheatStatusButton,
+            this.KeyPriorityStatusLabel,
+            this.CoreNameStatusBarButton,
+            this.ProfileFirstBootLabel,
+            this.LinkConnectStatusBarButton,
+            this.UpdateNotification});
 			this.MainStatusBar.Location = new System.Drawing.Point(0, 386);
 			this.MainStatusBar.Name = "MainStatusBar";
 			this.MainStatusBar.ShowItemToolTips = true;
@@ -2175,31 +2184,31 @@ namespace BizHawk.Client.EmuHawk
 			// MainFormContextMenu
 			// 
 			this.MainFormContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.OpenRomContextMenuItem,
-			this.LoadLastRomContextMenuItem,
-			this.StopAVContextMenuItem,
-			this.ContextSeparator_AfterROM,
-			this.RecordMovieContextMenuItem,
-			this.PlayMovieContextMenuItem,
-			this.RestartMovieContextMenuItem,
-			this.StopMovieContextMenuItem,
-			this.LoadLastMovieContextMenuItem,
-			this.BackupMovieContextMenuItem,
-			this.StopNoSaveContextMenuItem,
-			this.ViewSubtitlesContextMenuItem,
-			this.AddSubtitleContextMenuItem,
-			this.ViewCommentsContextMenuItem,
-			this.SaveMovieContextMenuItem,
-			this.SaveMovieAsContextMenuItem,
-			this.ContextSeparator_AfterMovie,
-			this.UndoSavestateContextMenuItem,
-			this.ContextSeparator_AfterUndo,
-			this.ConfigContextMenuItem,
-			this.ScreenshotContextMenuItem,
-			this.CloseRomContextMenuItem,
-			this.ClearSRAMContextMenuItem,
-			this.ShowMenuContextMenuSeparator,
-			this.ShowMenuContextMenuItem});
+            this.OpenRomContextMenuItem,
+            this.LoadLastRomContextMenuItem,
+            this.StopAVContextMenuItem,
+            this.ContextSeparator_AfterROM,
+            this.RecordMovieContextMenuItem,
+            this.PlayMovieContextMenuItem,
+            this.RestartMovieContextMenuItem,
+            this.StopMovieContextMenuItem,
+            this.LoadLastMovieContextMenuItem,
+            this.BackupMovieContextMenuItem,
+            this.StopNoSaveContextMenuItem,
+            this.ViewSubtitlesContextMenuItem,
+            this.AddSubtitleContextMenuItem,
+            this.ViewCommentsContextMenuItem,
+            this.SaveMovieContextMenuItem,
+            this.SaveMovieAsContextMenuItem,
+            this.ContextSeparator_AfterMovie,
+            this.UndoSavestateContextMenuItem,
+            this.ContextSeparator_AfterUndo,
+            this.ConfigContextMenuItem,
+            this.ScreenshotContextMenuItem,
+            this.CloseRomContextMenuItem,
+            this.ClearSRAMContextMenuItem,
+            this.ShowMenuContextMenuSeparator,
+            this.ShowMenuContextMenuItem});
 			this.MainFormContextMenu.Name = "contextMenuStrip1";
 			this.MainFormContextMenu.Size = new System.Drawing.Size(217, 490);
 			this.MainFormContextMenu.Closing += new System.Windows.Forms.ToolStripDropDownClosingEventHandler(this.MainFormContextMenu_Closing);
@@ -2288,20 +2297,20 @@ namespace BizHawk.Client.EmuHawk
 			// ConfigContextMenuItem
 			// 
 			this.ConfigContextMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-			this.toolStripMenuItem6,
-			this.toolStripMenuItem7,
-			this.toolStripMenuItem8,
-			this.toolStripMenuItem9,
-			this.toolStripMenuItem10,
-			this.toolStripMenuItem11,
-			this.toolStripMenuItem12,
-			this.toolStripMenuItem13,
-			this.toolStripMenuItem14,
-			this.toolStripMenuItem15,
-			this.customizeToolStripMenuItem,
-			this.toolStripSeparator30,
-			this.toolStripMenuItem66,
-			this.toolStripMenuItem67});
+            this.toolStripMenuItem6,
+            this.toolStripMenuItem7,
+            this.toolStripMenuItem8,
+            this.toolStripMenuItem9,
+            this.toolStripMenuItem10,
+            this.toolStripMenuItem11,
+            this.toolStripMenuItem12,
+            this.toolStripMenuItem13,
+            this.toolStripMenuItem14,
+            this.toolStripMenuItem15,
+            this.customizeToolStripMenuItem,
+            this.toolStripSeparator30,
+            this.toolStripMenuItem66,
+            this.toolStripMenuItem67});
 			this.ConfigContextMenuItem.Text = "Config";
 			// 
 			// toolStripMenuItem6
@@ -2778,5 +2787,6 @@ namespace BizHawk.Client.EmuHawk
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NdsSyncSettingsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripMenuItemEx NdsSettingsMenuItem;
 		private BizHawk.WinForms.Controls.ToolStripSeparatorEx toolStripSeparator8;
+		private System.Windows.Forms.ToolStripMenuItem CaptureLuaMenuItem;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Designer.cs
@@ -852,11 +852,13 @@ namespace BizHawk.Client.EmuHawk
 			// 
 			// CaptureOSDMenuItem
 			// 
+			this.CaptureOSDMenuItem.CheckOnClick = true;
 			this.CaptureOSDMenuItem.Text = "Capture OSD";
 			this.CaptureOSDMenuItem.Click += new System.EventHandler(this.CaptureOSDMenuItem_Click);
 			// 
 			// CaptureLuaMenuItem
 			// 
+			this.CaptureLuaMenuItem.CheckOnClick = true;
 			this.CaptureLuaMenuItem.Name = "CaptureLuaMenuItem";
 			this.CaptureLuaMenuItem.Size = new System.Drawing.Size(225, 22);
 			this.CaptureLuaMenuItem.Text = "Capture Lua";

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -215,7 +215,7 @@ namespace BizHawk.Client.EmuHawk
 			ConfigAndRecordAVMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Record A/V"].Bindings;
 			StopAVIMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Stop A/V"].Bindings;
 			CaptureOSDMenuItem.Checked = Config.AviCaptureOsd;
-			CaptureLuaMenuItem.Checked = Config.AviCaptureOsd || Config.AviCaptureLua;
+			CaptureLuaMenuItem.Checked = Config.AviCaptureLua || Config.AviCaptureOsd; // or with osd is for better compatibility with old config files
 
 			RecordAVMenuItem.Enabled = !string.IsNullOrEmpty(Config.VideoWriter) && _currAviWriter == null;
 
@@ -538,15 +538,17 @@ namespace BizHawk.Client.EmuHawk
 
 		private void CaptureOSDMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.AviCaptureOsd ^= true;
-			if (Config.AviCaptureOsd)
+			bool c = ((ToolStripMenuItem)sender).Checked;
+			Config.AviCaptureOsd = c;
+			if (c) // Logic to capture OSD w/o Lua does not currently exist, so disallow that.
 				Config.AviCaptureLua = true;
 		}
 
 		private void CaptureLuaMenuItem_Click(object sender, EventArgs e)
 		{
-			Config.AviCaptureLua = !CaptureLuaMenuItem.Checked;
-			if (!Config.AviCaptureLua)
+			bool c = ((ToolStripMenuItem)sender).Checked;
+			Config.AviCaptureLua = c;
+			if (!c) // Logic to capture OSD w/o Lua does not currently exist, so disallow that.
 				Config.AviCaptureOsd = false;
 		}
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -215,6 +215,7 @@ namespace BizHawk.Client.EmuHawk
 			ConfigAndRecordAVMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Record A/V"].Bindings;
 			StopAVIMenuItem.ShortcutKeyDisplayString = Config.HotkeyBindings["Stop A/V"].Bindings;
 			CaptureOSDMenuItem.Checked = Config.AviCaptureOsd;
+			CaptureLuaMenuItem.Checked = Config.AviCaptureOsd || Config.AviCaptureLua;
 
 			RecordAVMenuItem.Enabled = !string.IsNullOrEmpty(Config.VideoWriter) && _currAviWriter == null;
 
@@ -538,6 +539,15 @@ namespace BizHawk.Client.EmuHawk
 		private void CaptureOSDMenuItem_Click(object sender, EventArgs e)
 		{
 			Config.AviCaptureOsd ^= true;
+			if (Config.AviCaptureOsd)
+				Config.AviCaptureLua = true;
+		}
+
+		private void CaptureLuaMenuItem_Click(object sender, EventArgs e)
+		{
+			Config.AviCaptureLua = !CaptureLuaMenuItem.Checked;
+			if (!Config.AviCaptureLua)
+				Config.AviCaptureOsd = false;
 		}
 
 		private void ScreenshotMenuItem_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -2507,6 +2507,12 @@ namespace BizHawk.Client.EmuHawk
 			bb.DiscardAlpha();
 			return bb;
 		}
+		public BitmapBuffer CaptureLua()
+		{
+			var bb = DisplayManager.RenderOffscreenLua(_currentVideoProvider);
+			bb.DiscardAlpha();
+			return bb;
+		}
 
 		private void IncreaseWindowSize()
 		{
@@ -3416,6 +3422,11 @@ namespace BizHawk.Client.EmuHawk
 						if (Config.AviCaptureOsd)
 						{
 							output = new BitmapBufferVideoProvider(CaptureOSD());
+							disposableOutput = (IDisposable) output;
+						}
+						else if (Config.AviCaptureLua)
+						{
+							output = new BitmapBufferVideoProvider(CaptureLua());
 							disposableOutput = (IDisposable) output;
 						}
 						else


### PR DESCRIPTION
It's a bit sloppy, do we want this? Should be easy to extend this to screenshots if so.