### PR TITLE
POC of better delegate types for WinForms control event handlers

### DIFF
--- a/src/BizHawk.Client.EmuHawk/config/AutofireConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AutofireConfig.Designer.cs
@@ -33,7 +33,7 @@
 			this.btnDialogOK.Name = "btnDialogOK";
 			this.btnDialogOK.Size = new System.Drawing.Size(75, 23);
 			this.btnDialogOK.Text = "&OK";
-			this.btnDialogOK.Click += new System.EventHandler(this.btnDialogOK_Click);
+			this.btnDialogOK.Click += new BizHawk.WinForms.Controls.ButtonClickEventHandler<BizHawk.WinForms.Controls.ButtonExBase>(this.btnDialogOK_Click);
 			// 
 			// btnDialogCancel
 			// 
@@ -41,7 +41,7 @@
 			this.btnDialogCancel.Name = "btnDialogCancel";
 			this.btnDialogCancel.Size = new System.Drawing.Size(75, 23);
 			this.btnDialogCancel.Text = "&Cancel";
-			this.btnDialogCancel.Click += new System.EventHandler(this.btnDialogCancel_Click);
+			this.btnDialogCancel.Click += new BizHawk.WinForms.Controls.ButtonClickEventHandler<BizHawk.WinForms.Controls.ButtonExBase>(this.btnDialogCancel_Click);
 			// 
 			// nudPatternOn
 			// 

--- a/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/AutofireConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using BizHawk.Client.Common;
+using BizHawk.WinForms.Controls;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -53,7 +54,7 @@ namespace BizHawk.Client.EmuHawk
 			cbConsiderLag.Checked = _config.AutofireLagFrames;
 		}
 
-		private void btnDialogOK_Click(object sender, EventArgs e)
+		private void btnDialogOK_Click(ButtonExBase sender, EventArgs e)
 		{
 			_autoFireController.On = _config.AutofireOn = (int)nudPatternOn.Value;
 			_autoFireController.Off = _config.AutofireOff = (int)nudPatternOff.Value;
@@ -63,7 +64,7 @@ namespace BizHawk.Client.EmuHawk
 			Close();
 		}
 
-		private void btnDialogCancel_Click(object sender, EventArgs e)
+		private void btnDialogCancel_Click(ButtonExBase sender, EventArgs e)
 		{
 			Close();
 		}

--- a/src/BizHawk.Client.EmuHawk/config/Messages/MessageRow.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/Messages/MessageRow.Designer.cs
@@ -36,7 +36,7 @@
             // 
             this.RowRadio.Name = "RowRadio";
             this.RowRadio.Text = "Frame Counter";
-            this.RowRadio.CheckedChanged += new System.EventHandler(this.RowRadio_CheckedChanged);
+            this.RowRadio.CheckedChanged += new BizHawk.WinForms.Controls.CBOrRBCheckedChangedEventHandler<BizHawk.WinForms.Controls.ICheckBoxOrRadioEx>(this.RowRadio_CheckedChanged);
             // 
             // LocationLabel
             // 

--- a/src/BizHawk.Client.EmuHawk/config/Messages/MessageRow.cs
+++ b/src/BizHawk.Client.EmuHawk/config/Messages/MessageRow.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 
 using BizHawk.Client.Common;
+using BizHawk.WinForms.Controls;
 
 namespace BizHawk.Client.EmuHawk
 {
@@ -44,9 +45,9 @@ namespace BizHawk.Client.EmuHawk
 			LocationLabel.Text = MessagePosition.ToCoordinateStr();
 		}
 
-		private void RowRadio_CheckedChanged(object sender, EventArgs e)
+		private void RowRadio_CheckedChanged(ICheckBoxOrRadioEx sender, EventArgs e)
 		{
-			if (!_programmaticallyUpdating && RowRadio.Checked)
+			if (!_programmaticallyUpdating && sender.Checked)
 			{
 				_selectedCallback.Invoke(MessagePosition);
 			}

--- a/src/BizHawk.WinForms.Controls/ButtonEx/ButtonClickEventHandler.cs
+++ b/src/BizHawk.WinForms.Controls/ButtonEx/ButtonClickEventHandler.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace BizHawk.WinForms.Controls
+{
+	public delegate void ButtonClickEventHandler<in TButton>(TButton sender, EventArgs args)
+		where TButton : ButtonExBase;
+}

--- a/src/BizHawk.WinForms.Controls/ButtonEx/ButtonExBase.cs
+++ b/src/BizHawk.WinForms.Controls/ButtonEx/ButtonExBase.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
 
@@ -5,6 +7,8 @@ namespace BizHawk.WinForms.Controls
 {
 	public abstract class ButtonExBase : Button
 	{
+		private readonly IDictionary<ButtonClickEventHandler<ButtonExBase>, EventHandler> _clickDelegates = new Dictionary<ButtonClickEventHandler<ButtonExBase>, EventHandler>();
+
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public new int TabIndex => base.TabIndex;
@@ -12,5 +16,23 @@ namespace BizHawk.WinForms.Controls
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public new bool UseVisualStyleBackColor => base.UseVisualStyleBackColor;
+
+		public new event ButtonClickEventHandler<ButtonExBase> Click
+		{
+			add
+			{
+				if (!_clickDelegates.TryGetValue(value, out var d))
+				{
+					d = (sender, args) => value((ButtonExBase) sender, args);
+					_clickDelegates[value] = d;
+				}
+				base.Click += d;
+			}
+			remove
+			{
+				base.Click -= _clickDelegates[value];
+				_clickDelegates.Remove(value);
+			}
+		}
 	}
 }

--- a/src/BizHawk.WinForms.Controls/CheckBoxEx/CBOrRBCheckedChangedEventHandler.cs
+++ b/src/BizHawk.WinForms.Controls/CheckBoxEx/CBOrRBCheckedChangedEventHandler.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace BizHawk.WinForms.Controls
+{
+	public delegate void CBOrRBCheckedChangedEventHandler<in TCheckBox>(TCheckBox sender, EventArgs args)
+		where TCheckBox : ICheckBoxOrRadioEx;
+}

--- a/src/BizHawk.WinForms.Controls/CheckBoxEx/CheckBoxExBase.cs
+++ b/src/BizHawk.WinForms.Controls/CheckBoxEx/CheckBoxExBase.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
 
@@ -5,6 +7,8 @@ namespace BizHawk.WinForms.Controls
 {
 	public abstract class CheckBoxExBase : CheckBox, ICheckBoxOrRadioEx
 	{
+		private readonly IDictionary<CBOrRBCheckedChangedEventHandler<ICheckBoxOrRadioEx>, EventHandler> _cChangedDelegates = new Dictionary<CBOrRBCheckedChangedEventHandler<ICheckBoxOrRadioEx>, EventHandler>();
+
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public new int TabIndex => base.TabIndex;
@@ -12,5 +16,23 @@ namespace BizHawk.WinForms.Controls
 		[Browsable(false)]
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public new bool UseVisualStyleBackColor => base.UseVisualStyleBackColor;
+
+		public new event CBOrRBCheckedChangedEventHandler<ICheckBoxOrRadioEx> CheckedChanged
+		{
+			add
+			{
+				if (!_cChangedDelegates.TryGetValue(value, out var d))
+				{
+					d = (sender, args) => value((ICheckBoxOrRadioEx) sender, args);
+					_cChangedDelegates[value] = d;
+				}
+				base.CheckedChanged += d;
+			}
+			remove
+			{
+				base.CheckedChanged -= _cChangedDelegates[value];
+				_cChangedDelegates.Remove(value);
+			}
+		}
 	}
 }

--- a/src/BizHawk.WinForms.Controls/ICheckBoxOrRadioEx.cs
+++ b/src/BizHawk.WinForms.Controls/ICheckBoxOrRadioEx.cs
@@ -3,5 +3,7 @@ namespace BizHawk.WinForms.Controls
 	public interface ICheckBoxOrRadioEx
 	{
 		bool Checked { get; set; }
+
+		event CBOrRBCheckedChangedEventHandler<ICheckBoxOrRadioEx> CheckedChanged;
 	}
 }


### PR DESCRIPTION
These don't remove a lot of boilerplate, which the `*Ex` controls have been focused on so far, their purpose is to improve type-safety by passing the "sender" control to handlers as the expected type instead of as `object`.