### PR TITLE
Refactor ZWinderBuffer to allow use of arbitrary backing Streams

### DIFF
--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -8,7 +8,7 @@
 		bool UseCompression { get; }
 
 		/// <summary>
-		/// Max amount of buffer space to use in MB
+		/// Buffer space to use in MB
 		/// </summary>
 		long BufferSize { get; }
 
@@ -16,6 +16,14 @@
 		/// Desired frame length (number of emulated frames you can go back before running out of buffer)
 		/// </summary>
 		int TargetFrameLength { get; }
+
+		public enum BackingStoreType
+		{
+			Memory,
+			TempFile,
+		}
+
+		public BackingStoreType BackingStore { get; }
 	}
 
 	public class RewindConfig : IRewindSettings
@@ -24,5 +32,6 @@
 		public bool Enabled { get; set; } = true;
 		public long BufferSize { get; set; } = 512; // in mb
 		public int TargetFrameLength { get; set; } = 600;
+		public IRewindSettings.BackingStoreType BackingStore { get; set; } = IRewindSettings.BackingStoreType.Memory;
 	}
 }

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.Common
 				case IRewindSettings.BackingStoreType.TempFile:
 				{
 					var filename = TempFileManager.GetTempFilename("ZwinderBuffer");
-					var filestream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite);
+					var filestream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose);
 					filestream.SetLength(Size);
 					_backingStore = filestream;
 					_disposables.Add(filestream);

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -42,7 +42,7 @@ namespace BizHawk.Client.Common
 				case IRewindSettings.BackingStoreType.TempFile:
 				{
 					var filename = TempFileManager.GetTempFilename("ZwinderBuffer");
-					var filestream = new FileStream(filename, FileMode.Truncate, FileAccess.ReadWrite);
+					var filestream = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite);
 					filestream.SetLength(Size);
 					_backingStore = filestream;
 					_disposables.Add(filestream);


### PR DESCRIPTION
A future commit may expose this functionality for use in ZWinderStateManager.

Should we expose this directly to the user, so the rewinder can be disk based?

