### PR TITLE
Fix for state gap when frame advancing and painting input

### DIFF
--- a/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
+++ b/src/BizHawk.Client.EmuHawk/IMainFormForTools.cs
@@ -78,6 +78,8 @@ namespace BizHawk.Client.EmuHawk
 
 		void PauseEmulator();
 
+		bool BlockFrameAdvance { get; set; }
+
 		/// <remarks>only referenced from <see cref="TAStudio"/></remarks>
 		void RelinquishControl(IControlMainform master);
 

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -768,6 +768,17 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		private bool _block_frame_advance;
+		public bool BlockFrameAdvance
+		{
+			get => _block_frame_advance;
+
+			set
+			{
+				_block_frame_advance = value;
+			}
+		}
+
 		public event Action<bool> OnPauseChanged;
 
 		public string CurrentlyOpenRom { get; private set; } // todo - delete me and use only args instead
@@ -2916,7 +2927,8 @@ namespace BizHawk.Client.EmuHawk
 
 			float atten = 0;
 
-			if (runFrame || force)
+			// BlockFrameAdvance (true when input it being editted in TAStudio) supercedes all other frame advance conditions
+			if ((runFrame || force) && !BlockFrameAdvance)
 			{
 				var isFastForwarding = InputManager.ClientControls["Fast Forward"] || IsTurboing || InvisibleEmulation;
 				var isFastForwardingOrRewinding = isFastForwarding || isRewinding || _unthrottled;

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -768,16 +768,7 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		private bool _block_frame_advance;
-		public bool BlockFrameAdvance
-		{
-			get => _block_frame_advance;
-
-			set
-			{
-				_block_frame_advance = value;
-			}
-		}
+		public bool BlockFrameAdvance { get; set; }
 
 		public event Action<bool> OnPauseChanged;
 

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.ListView.cs
@@ -619,6 +619,11 @@ namespace BizHawk.Client.EmuHawk
 					_playbackInterrupted = !MainForm.EmulatorPaused;
 					MainForm.PauseEmulator();
 
+					// Pausing the emulator is insufficient to actually stop frame advancing as the frame advance hotkey can
+					// still take effect. This can lead to desyncs by simultaneously changing input and frame advancing.
+					// So we want to block all frame advance operations while the user is changing input in the piano roll
+					MainForm.BlockFrameAdvance = true;
+
 					if (ControllerType.BoolButtons.Contains(buttonName))
 					{
 						_patternPaint = false;
@@ -810,6 +815,8 @@ namespace BizHawk.Client.EmuHawk
 			{
 				CurrentTasMovie.ChangeLog?.EndBatch();
 			}
+
+			MainForm.BlockFrameAdvance = false;
 		}
 
 		private void TasView_MouseUp(object sender, MouseEventArgs e)


### PR DESCRIPTION
Painting inputs in the piano roll can cause gaps in the greenzone and desyncs in movies if done while frame advance is happening. This PR prevents frame advance from any source while inputs are being painted.