### PR TITLE
ZwinderStateManager: Use the gap buffer for forced capture to avoid c…

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.cs
@@ -192,10 +192,8 @@ namespace BizHawk.Client.Common
 
 			LagLog[Emulator.Frame] = _inputPollable.IsLagFrame;
 
-			if (!TasStateManager.HasState(Emulator.Frame))
-			{
-				TasStateManager.Capture(Emulator.Frame, Emulator.AsStatable(), Emulator.Frame == LastEditedFrame - 1);
-			}
+			// We will forbibly capture a state for the last edited frame (requested by #916 for case of "platforms with analog stick")
+			TasStateManager.Capture(Emulator.Frame, Emulator.AsStatable(), Emulator.Frame == LastEditedFrame - 1);
 		}
 
 		

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManager.cs
@@ -291,13 +291,10 @@ namespace BizHawk.Client.Common
 
 			// We do not want to consider reserved states for a notion of Last
 			// reserved states can include future states in the case of branch states
-			if (frame <= LastRing)
+			if ((frame <= LastRing && NeedsGap(frame)) || force)
 			{
-				if (NeedsGap(frame))
-				{
-					CaptureGap(frame, source);
-				}
-
+				// We use the gap buffer for forced capture to avoid crowding the "current" buffer and thus reducing it's actual span of covered frames.
+				CaptureGap(frame, source);
 				return;
 			}
 


### PR DESCRIPTION
With the new state manager, forcing a capture of the most recently edited state subverts the "target frame length" setting by putting extra states in the current buffer.
Example: 
Edit frame 4, play back a few frames; now "current" has a state at frame 4.
Edit frame 5, play back a few frames; now "current" has a state at frame 5.
Edit frame 6, play back a few frames; now "current" has a state at frame 6.
and so on

This commit aims to fix that issue by putting those states in the gap buffer. I find it highly unlikely that users will much care about previous gap states during the time they are actively editing, so this is a simple and easy solution. (Compared to the originally suggested behavior of just having one state reserved for this purpose, with each new edited frame invalidating the previous "last edited frame" state. #916 )