### PR TITLE
Refactor DisplaySurface locking as used by ApiHawk (and Lua)

### DIFF
--- a/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Classes/GuiApi.cs
@@ -92,11 +92,11 @@ namespace BizHawk.Client.Common
 			{
 				case DisplaySurfaceID.EmuCore:
 					if (_GUISurface != null) throw new InvalidOperationException("attempt to lock surface without unlocking previous");
-					_GUISurface = _displayManager.LockLuaSurface(surfaceID.GetName(), clear: true);
+					_GUISurface = _displayManager.LockApiHawkSurface(surfaceID, clear: true);
 					break;
 				case DisplaySurfaceID.Client:
 					if (_clientSurface != null) throw new InvalidOperationException("attempt to lock surface without unlocking previous");
-					_clientSurface = _displayManager.LockLuaSurface(surfaceID.GetName(), clear: true);
+					_clientSurface = _displayManager.LockApiHawkSurface(surfaceID, clear: true);
 					break;
 				default:
 					throw new ArgumentException(message: "not a valid enum member", paramName: nameof(surfaceID));
@@ -108,11 +108,11 @@ namespace BizHawk.Client.Common
 			switch (surfaceID)
 			{
 				case DisplaySurfaceID.EmuCore:
-					if (_GUISurface != null) _displayManager.UnlockLuaSurface(_GUISurface);
+					if (_GUISurface != null) _displayManager.UnlockApiHawkSurface(_GUISurface);
 					_GUISurface = null;
 					break;
 				case DisplaySurfaceID.Client:
-					if (_clientSurface != null) _displayManager.UnlockLuaSurface(_clientSurface);
+					if (_clientSurface != null) _displayManager.UnlockApiHawkSurface(_clientSurface);
 					_clientSurface = null;
 					break;
 				default:

--- a/src/BizHawk.Client.Common/Api/DisplaySurfaceID.cs
+++ b/src/BizHawk.Client.Common/Api/DisplaySurfaceID.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using System;
+
+namespace BizHawk.Client.Common
+{
+	public enum DisplaySurfaceID : int
+	{
+		EmuCore = 0,
+		Client = 1,
+	}
+
+	/// <remarks>should probably centralise these enum extensions and not-extensions somewhere... --yoshi</remarks>
+	public static class DisplaySurfaceIDParser
+	{
+		public static DisplaySurfaceID? Parse(string? str) => str?.ToLowerInvariant() switch
+		{
+			null => null, // this makes it easy to cascade the "remembered" value
+			"client" => DisplaySurfaceID.Client,
+			"emu" => DisplaySurfaceID.EmuCore,
+			"emucore" => DisplaySurfaceID.EmuCore,
+			"native" => DisplaySurfaceID.Client,
+			_ => throw new ArgumentException(message: $"{str} is not the name of a display surface", paramName: nameof(str))
+		};
+
+		public static string GetName(this DisplaySurfaceID surfaceID) => surfaceID switch
+		{
+			DisplaySurfaceID.EmuCore => "emucore",
+			DisplaySurfaceID.Client => "client",
+			_ => throw new ArgumentException(message: "not a valid enum member", paramName: nameof(surfaceID))
+		};
+	}
+}

--- a/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
@@ -9,8 +9,16 @@ namespace BizHawk.Client.Common
 		void ToggleCompositingMode();
 		ImageAttributes GetAttributes();
 		void SetAttributes(ImageAttributes a);
+
+		void WithEmuSurface(Action drawingCallsFunc);
+
+		[Obsolete]
 		void DrawNew(string name, bool clear = true);
+
+		[Obsolete]
 		void DrawFinish();
+
+		[Obsolete]
 		bool HasGUISurface { get; }
 
 		void SetPadding(int all);

--- a/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
+++ b/src/BizHawk.Client.Common/Api/Interfaces/IGuiApi.cs
@@ -10,7 +10,7 @@ namespace BizHawk.Client.Common
 		ImageAttributes GetAttributes();
 		void SetAttributes(ImageAttributes a);
 
-		void WithEmuSurface(Action drawingCallsFunc);
+		void WithSurface(DisplaySurfaceID surfaceID, Action drawingCallsFunc);
 
 		[Obsolete]
 		void DrawNew(string name, bool clear = true);
@@ -27,32 +27,31 @@ namespace BizHawk.Client.Common
 		(int Left, int Top, int Right, int Bottom) GetPadding();
 
 		void AddMessage(string message);
-		void ClearGraphics();
+		void ClearGraphics(DisplaySurfaceID? surfaceID = null);
 		void ClearText();
 		void SetDefaultForegroundColor(Color color);
 		void SetDefaultBackgroundColor(Color color);
 		Color? GetDefaultTextBackground();
 		void SetDefaultTextBackground(Color color);
 		void SetDefaultPixelFont(string fontfamily);
-		void DrawBezier(Point p1, Point p2, Point p3, Point p4, Color? color = null);
-		void DrawBeziers(Point[] points, Color? color = null);
-		void DrawBox(int x, int y, int x2, int y2, Color? line = null, Color? background = null);
-		void DrawEllipse(int x, int y, int width, int height, Color? line = null, Color? background = null);
-		void DrawIcon(string path, int x, int y, int? width = null, int? height = null);
-		void DrawImage(Image img, int x, int y, int? width = null, int? height = null, bool cache = true);
-		void DrawImage(string path, int x, int y, int? width = null, int? height = null, bool cache = true);
+		void DrawBezier(Point p1, Point p2, Point p3, Point p4, Color? color = null, DisplaySurfaceID? surfaceID = null);
+		void DrawBeziers(Point[] points, Color? color = null, DisplaySurfaceID? surfaceID = null);
+		void DrawBox(int x, int y, int x2, int y2, Color? line = null, Color? background = null, DisplaySurfaceID? surfaceID = null);
+		void DrawEllipse(int x, int y, int width, int height, Color? line = null, Color? background = null, DisplaySurfaceID? surfaceID = null);
+		void DrawIcon(string path, int x, int y, int? width = null, int? height = null, DisplaySurfaceID? surfaceID = null);
+		void DrawImage(Image img, int x, int y, int? width = null, int? height = null, bool cache = true, DisplaySurfaceID? surfaceID = null);
+		void DrawImage(string path, int x, int y, int? width = null, int? height = null, bool cache = true, DisplaySurfaceID? surfaceID = null);
 		void ClearImageCache();
-		void DrawImageRegion(Image img, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null);
-		void DrawImageRegion(string path, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null);
-		void DrawLine(int x1, int y1, int x2, int y2, Color? color = null);
-		void DrawAxis(int x, int y, int size, Color? color = null);
-		void DrawPie(int x, int y, int width, int height, int startangle, int sweepangle, Color? line = null, Color? background = null);
-		void DrawPixel(int x, int y, Color? color = null);
-		void DrawPolygon(Point[] points, Color? line = null, Color? background = null);
-		void DrawRectangle(int x, int y, int width, int height, Color? line = null, Color? background = null);
-		void DrawString(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, int? fontsize = null,
-							  string fontfamily = null, string fontstyle = null, string horizalign = null, string vertalign = null);
-		void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, string fontfamily = null);
+		void DrawImageRegion(Image img, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null, DisplaySurfaceID? surfaceID = null);
+		void DrawImageRegion(string path, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null, DisplaySurfaceID? surfaceID = null);
+		void DrawLine(int x1, int y1, int x2, int y2, Color? color = null, DisplaySurfaceID? surfaceID = null);
+		void DrawAxis(int x, int y, int size, Color? color = null, DisplaySurfaceID? surfaceID = null);
+		void DrawPie(int x, int y, int width, int height, int startangle, int sweepangle, Color? line = null, Color? background = null, DisplaySurfaceID? surfaceID = null);
+		void DrawPixel(int x, int y, Color? color = null, DisplaySurfaceID? surfaceID = null);
+		void DrawPolygon(Point[] points, Color? line = null, Color? background = null, DisplaySurfaceID? surfaceID = null);
+		void DrawRectangle(int x, int y, int width, int height, Color? line = null, Color? background = null, DisplaySurfaceID? surfaceID = null);
+		void DrawString(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, int? fontsize = null, string fontfamily = null, string fontstyle = null, string horizalign = null, string vertalign = null, DisplaySurfaceID? surfaceID = null);
+		void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, string fontfamily = null, DisplaySurfaceID? surfaceID = null);
 		void Text(int x, int y, string message, Color? forecolor = null, string anchor = null);
 	}
 }

--- a/src/BizHawk.Client.Common/DisplayManager/Filters/Gui.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/Filters/Gui.cs
@@ -675,6 +675,7 @@ namespace BizHawk.Client.Common.Filters
 		}
 	}
 
+	/// <remarks>More accurately, ApiHawkLayer, since the <c>gui</c> Lua library is delegated.</remarks>
 	public class LuaLayer : BaseFilter
 	{
 		public override void Initialize()

--- a/src/BizHawk.Client.Common/DisplayManager/IDisplayManagerForApi.cs
+++ b/src/BizHawk.Client.Common/DisplayManager/IDisplayManagerForApi.cs
@@ -9,12 +9,12 @@ namespace BizHawk.Client.Common
 
 		OSDManager OSD { get; }
 
-		/// <summary>locks the lua surface called <paramref name="name"/></summary>
+		/// <summary>locks the surface with ID <paramref name="surfaceID"/></summary>
 		/// <exception cref="InvalidOperationException">already locked, or unknown surface</exception>
-		DisplaySurface LockLuaSurface(string name, bool clear = true);
+		DisplaySurface LockApiHawkSurface(DisplaySurfaceID surfaceID, bool clear = true);
 
-		/// <summary>unlocks this DisplaySurface which had better have been locked as a lua surface</summary>
+		/// <summary>unlocks the given <paramref name="surface"/>, which must be a locked surface produced by <see cref="LockApiHawkSurface"/></summary>
 		/// <exception cref="InvalidOperationException">already unlocked</exception>
-		void UnlockLuaSurface(DisplaySurface surface);
+		void UnlockApiHawkSurface(DisplaySurface surface);
 	}
 }

--- a/src/BizHawk.Client.Common/lua/CommonLibs/GuiLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/GuiLuaLibrary.cs
@@ -8,12 +8,16 @@ namespace BizHawk.Client.Common
 {
 	public sealed class GuiLuaLibrary : LuaLibraryBase, IDisposable
 	{
+		private DisplaySurfaceID _rememberedSurfaceID = DisplaySurfaceID.EmuCore;
+
 		public Func<int, int, int?, int?, LuaTable> CreateLuaCanvasCallback { get; set; }
 
 		public GuiLuaLibrary(IPlatformLuaLibEnv luaLibsImpl, ApiContainer apiContainer, Action<string> logOutputCallback)
 			: base(luaLibsImpl, apiContainer, logOutputCallback) {}
 
 		public override string Name => "gui";
+
+		private DisplaySurfaceID UseOrFallback(string surfaceName) => DisplaySurfaceIDParser.Parse(surfaceName) ?? _rememberedSurfaceID;
 
 #pragma warning disable CS0612
 		[LuaDeprecatedMethod]
@@ -31,7 +35,7 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("gui.clearGraphics( );")]
 		[LuaMethod("clearGraphics", "clears all lua drawn graphics from the screen")]
-		public void ClearGraphics() => APIs.Gui.ClearGraphics();
+		public void ClearGraphics(string surfaceName = null) => APIs.Gui.ClearGraphics(surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.cleartext( );")]
 		[LuaMethod("cleartext", "clears all text created by gui.text()")]
@@ -55,7 +59,7 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("gui.drawBezier( { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 0x000000FF );")]
 		[LuaMethod("drawBezier", "Draws a Bezier curve using the table of coordinates provided in the given color")]
-		public void DrawBezier(LuaTable points, Color color)
+		public void DrawBezier(LuaTable points, Color color, string surfaceName = null)
 		{
 			try
 			{
@@ -71,7 +75,7 @@ namespace BizHawk.Client.Common
 						break;
 					}
 				}
-				APIs.Gui.DrawBezier(pointsArr[0], pointsArr[1], pointsArr[2], pointsArr[3], color);
+				APIs.Gui.DrawBezier(pointsArr[0], pointsArr[1], pointsArr[2], pointsArr[3], color, surfaceID: UseOrFallback(surfaceName));
 			}
 			catch (Exception)
 			{
@@ -81,19 +85,19 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("gui.drawBox( 16, 32, 162, 322, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawBox", "Draws a rectangle on screen from x1/y1 to x2/y2. Same as drawRectangle except it receives two points intead of a point and width/height")]
-		public void DrawBox(int x, int y, int x2, int y2, Color? line = null, Color? background = null) => APIs.Gui.DrawBox(x, y, x2, y2, line, background);
+		public void DrawBox(int x, int y, int x2, int y2, Color? line = null, Color? background = null, string surfaceName = null) => APIs.Gui.DrawBox(x, y, x2, y2, line, background, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawEllipse( 16, 32, 77, 99, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawEllipse", "Draws an ellipse at the given coordinates and the given width and height. Line is the color of the ellipse. Background is the optional fill color")]
-		public void DrawEllipse(int x, int y, int width, int height, Color? line = null, Color? background = null) => APIs.Gui.DrawEllipse(x, y, width, height, line, background);
+		public void DrawEllipse(int x, int y, int width, int height, Color? line = null, Color? background = null, string surfaceName = null) => APIs.Gui.DrawEllipse(x, y, width, height, line, background, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawIcon( \"C:\\sample.ico\", 16, 32, 18, 24 );")]
 		[LuaMethod("drawIcon", "draws an Icon (.ico) file from the given path at the given coordinate. width and height are optional. If specified, it will resize the image accordingly")]
-		public void DrawIcon(string path, int x, int y, int? width = null, int? height = null) => APIs.Gui.DrawIcon(path, x, y, width, height);
+		public void DrawIcon(string path, int x, int y, int? width = null, int? height = null, string surfaceName = null) => APIs.Gui.DrawIcon(path, x, y, width, height, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawImage( \"C:\\sample.bmp\", 16, 32, 18, 24, false );")]
 		[LuaMethod("drawImage", "draws an image file from the given path at the given coordinate. width and height are optional. If specified, it will resize the image accordingly")]
-		public void DrawImage(string path, int x, int y, int? width = null, int? height = null, bool cache = true) => APIs.Gui.DrawImage(path, x, y, width, height, cache);
+		public void DrawImage(string path, int x, int y, int? width = null, int? height = null, bool cache = true, string surfaceName = null) => APIs.Gui.DrawImage(path, x, y, width, height, cache, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.clearImageCache( );")]
 		[LuaMethod("clearImageCache", "clears the image cache that is built up by using gui.drawImage, also releases the file handle for cached images")]
@@ -101,27 +105,27 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("gui.drawImageRegion( \"C:\\sample.png\", 11, 22, 33, 44, 21, 43, 34, 45 );")]
 		[LuaMethod("drawImageRegion", "draws a given region of an image file from the given path at the given coordinate, and optionally with the given size")]
-		public void DrawImageRegion(string path, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null) => APIs.Gui.DrawImageRegion(path, source_x, source_y, source_width, source_height, dest_x, dest_y, dest_width, dest_height);
+		public void DrawImageRegion(string path, int source_x, int source_y, int source_width, int source_height, int dest_x, int dest_y, int? dest_width = null, int? dest_height = null, string surfaceName = null) => APIs.Gui.DrawImageRegion(path, source_x, source_y, source_width, source_height, dest_x, dest_y, dest_width, dest_height, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawLine( 161, 321, 162, 322, 0xFFFFFFFF );")]
 		[LuaMethod("drawLine", "Draws a line from the first coordinate pair to the 2nd. Color is optional (if not specified it will be drawn black)")]
-		public void DrawLine(int x1, int y1, int x2, int y2, Color? color = null) => APIs.Gui.DrawLine(x1, y1, x2, y2, color);
+		public void DrawLine(int x1, int y1, int x2, int y2, Color? color = null, string surfaceName = null) => APIs.Gui.DrawLine(x1, y1, x2, y2, color, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawAxis( 16, 32, 15, 0xFFFFFFFF );")]
 		[LuaMethod("drawAxis", "Draws an axis of the specified size at the coordinate pair.)")]
-		public void DrawAxis(int x, int y, int size, Color? color = null) => APIs.Gui.DrawAxis(x, y, size, color);
+		public void DrawAxis(int x, int y, int size, Color? color = null, string surfaceName = null) => APIs.Gui.DrawAxis(x, y, size, color, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawPie( 16, 32, 77, 99, 180, 90, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawPie", "draws a Pie shape at the given coordinates and the given width and height")]
-		public void DrawPie(int x, int y, int width, int height, int startangle, int sweepangle, Color? line = null, Color? background = null) => APIs.Gui.DrawPie(x, y, width, height, startangle, sweepangle, line, background);
+		public void DrawPie(int x, int y, int width, int height, int startangle, int sweepangle, Color? line = null, Color? background = null, string surfaceName = null) => APIs.Gui.DrawPie(x, y, width, height, startangle, sweepangle, line, background, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawPixel( 16, 32, 0xFFFFFFFF );")]
 		[LuaMethod("drawPixel", "Draws a single pixel at the given coordinates in the given color. Color is optional (if not specified it will be drawn black)")]
-		public void DrawPixel(int x, int y, Color? color = null) => APIs.Gui.DrawPixel(x, y, color);
+		public void DrawPixel(int x, int y, Color? color = null, string surfaceName = null) => APIs.Gui.DrawPixel(x, y, color, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawPolygon( { { 5, 10 }, { 10, 10 }, { 10, 20 }, { 5, 20 } }, 10, 30, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawPolygon", "Draws a polygon using the table of coordinates specified in points. This should be a table of tables(each of size 2). If x or y is passed, the polygon will be translated by the passed coordinate pair. Line is the color of the polygon. Background is the optional fill color")]
-		public void DrawPolygon(LuaTable points, int? offsetX = null, int? offsetY = null, Color? line = null, Color? background = null)
+		public void DrawPolygon(LuaTable points, int? offsetX = null, int? offsetY = null, Color? line = null, Color? background = null, string surfaceName = null)
 		{
 			var pointsList = _th.EnumerateValues<LuaTable>(points)
 				.Select(table => _th.EnumerateValues<double>(table).ToList()).ToList();
@@ -134,7 +138,7 @@ namespace BizHawk.Client.Common
 					pointsArr[i] = new Point(LuaInt(point[0]) + (offsetX ?? 0), LuaInt(point[1]) + (offsetY ?? 0));
 					i++;
 				}
-				APIs.Gui.DrawPolygon(pointsArr, line, background);
+				APIs.Gui.DrawPolygon(pointsArr, line, background, surfaceID: UseOrFallback(surfaceName));
 			}
 			catch (Exception)
 			{
@@ -144,7 +148,7 @@ namespace BizHawk.Client.Common
 
 		[LuaMethodExample("gui.drawRectangle( 16, 32, 77, 99, 0x007F00FF, 0x7F7F7FFF );")]
 		[LuaMethod("drawRectangle", "Draws a rectangle at the given coordinate and the given width and height. Line is the color of the box. Background is the optional fill color")]
-		public void DrawRectangle(int x, int y, int width, int height, Color? line = null, Color? background = null) => APIs.Gui.DrawRectangle(x, y, width, height, line, background);
+		public void DrawRectangle(int x, int y, int width, int height, Color? line = null, Color? background = null, string surfaceName = null) => APIs.Gui.DrawRectangle(x, y, width, height, line, background, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.drawString( 16, 32, \"Some message\", 0x7F0000FF, 0x00007FFF, 8, \"Arial Narrow\", \"bold\", \"center\", \"middle\" );")]
 		[LuaMethod("drawString", "Alias of gui.drawText()")]
@@ -158,18 +162,19 @@ namespace BizHawk.Client.Common
 			string fontfamily = null,
 			string fontstyle = null,
 			string horizalign = null,
-			string vertalign = null)
+			string vertalign = null,
+			string surfaceName = null)
 		{
-			DrawText(x, y, message, forecolor, backcolor, fontsize, fontfamily, fontstyle, horizalign, vertalign);
+			DrawText(x, y, message, forecolor, backcolor, fontsize, fontfamily, fontstyle, horizalign, vertalign, surfaceName: surfaceName);
 		}
 
 		[LuaMethodExample("gui.drawText( 16, 32, \"Some message\", 0x7F0000FF, 0x00007FFF, 8, \"Arial Narrow\", \"bold\", \"center\", \"middle\" );")]
 		[LuaMethod("drawText", "Draws the given message in the emulator screen space (like all draw functions) at the given x,y coordinates and the given color. The default color is white. A fontfamily can be specified and is monospace generic if none is specified (font family options are the same as the .NET FontFamily class). The fontsize default is 12. The default font style is regular. Font style options are regular, bold, italic, strikethrough, underline. Horizontal alignment options are left (default), center, or right. Vertical alignment options are bottom (default), middle, or top. Alignment options specify which ends of the text will be drawn at the x and y coordinates. For pixel-perfect font look, make sure to disable aspect ratio correction.")]
-		public void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, int? fontsize = null, string fontfamily = null, string fontstyle = null, string horizalign = null, string vertalign = null) => APIs.Gui.DrawString(x, y, message, forecolor, backcolor, fontsize, fontfamily, fontstyle, horizalign, vertalign);
+		public void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, int? fontsize = null, string fontfamily = null, string fontstyle = null, string horizalign = null, string vertalign = null, string surfaceName = null) => APIs.Gui.DrawString(x, y, message, forecolor, backcolor, fontsize, fontfamily, fontstyle, horizalign, vertalign, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.pixelText( 16, 32, \"Some message\", 0x7F0000FF, 0x00007FFF, \"Arial Narrow\" );")]
 		[LuaMethod("pixelText", "Draws the given message in the emulator screen space (like all draw functions) at the given x,y coordinates and the given color. The default color is white. Two font families are available, \"fceux\" and \"gens\" (or  \"0\" and \"1\" respectively), both are monospace and have the same size as in the emulators they've been taken from. If no font family is specified, it uses \"gens\" font, unless that's overridden via gui.defaultPixelFont()")]
-		public void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, string fontfamily = null) => APIs.Gui.DrawText(x, y, message, forecolor, backcolor ?? APIs.Gui.GetDefaultTextBackground().Value, fontfamily);
+		public void DrawText(int x, int y, string message, Color? forecolor = null, Color? backcolor = null, string fontfamily = null, string surfaceName = null) => APIs.Gui.DrawText(x, y, message, forecolor, backcolor ?? APIs.Gui.GetDefaultTextBackground().Value, fontfamily, surfaceID: UseOrFallback(surfaceName));
 
 		[LuaMethodExample("gui.text( 16, 32, \"Some message\", 0x7F0000FF, \"bottomleft\" );")]
 		[LuaMethod("text", "Displays the given text on the screen at the given coordinates. Optional Foreground color. The optional anchor flag anchors the text to one of the four corners. Anchor flag parameters: topleft, topright, bottomleft, bottomright")]
@@ -178,6 +183,18 @@ namespace BizHawk.Client.Common
 		[LuaMethodExample("local nlguicre = gui.createcanvas( 77, 99, 2, 48 );")]
 		[LuaMethod("createcanvas", "Creates a canvas of the given size and, if specified, the given coordinates.")]
 		public LuaTable Text(int width, int height, int? x = null, int? y = null) => CreateLuaCanvasCallback(width, height, x, y);
+
+		[LuaMethodExample("gui.use_surface( \"client\" );")]
+		[LuaMethod("use_surface", "Stores the name of a surface to draw on, so you don't need to pass it to every draw function. The default is \"emucore\", and the other valid value is \"client\".")]
+		public void UseSurface(string surfaceName)
+		{
+			if (surfaceName == null)
+			{
+				Log("Surface name cannot be nil. Pass \"emucore\" to `gui.use_surface` to restore the default.");
+				return;
+			}
+			_rememberedSurfaceID = DisplaySurfaceIDParser.Parse(surfaceName).Value; // iff param is not null, returns not null or throws
+		}
 
 		public void Dispose() => APIs.Gui.Dispose();
 	}

--- a/src/BizHawk.Client.Common/lua/CommonLibs/GuiLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/GuiLuaLibrary.cs
@@ -15,17 +15,15 @@ namespace BizHawk.Client.Common
 
 		public override string Name => "gui";
 
-		public bool HasLuaSurface => APIs.Gui.HasGUISurface;
-
-		public bool SurfaceIsNull => !APIs.Gui.HasGUISurface;
-
-		[LuaMethodExample("gui.DrawNew( \"native\", false );")]
+#pragma warning disable CS0612
+		[LuaDeprecatedMethod]
 		[LuaMethod("DrawNew", "Changes drawing target to the specified lua surface name. This may clobber any previous drawing to this surface (pass false if you don't want it to)")]
 		public void DrawNew(string name, bool? clear = true) => APIs.Gui.DrawNew(name, clear ?? true);
 
-		[LuaMethodExample("gui.DrawFinish( );")]
+		[LuaDeprecatedMethod]
 		[LuaMethod("DrawFinish", "Finishes drawing to the current lua surface and causes it to get displayed.")]
 		public void DrawFinish() => APIs.Gui.DrawFinish();
+#pragma warning restore CS0612
 
 		[LuaMethodExample("gui.addmessage( \"Some message\" );")]
 		[LuaMethod("addmessage", "Adds a message to the OSD's message area")]

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -134,11 +134,7 @@ namespace BizHawk.Client.EmuHawk
 						MainForm.FrameBufferResized();
 					}
 
-					if (LuaImp is Win32LuaLibraries luaLibsImpl)
-					{
-						luaLibsImpl.GuiLibrary?.DrawFinish();
-						luaLibsImpl.Close();
-					}
+					(LuaImp as Win32LuaLibraries)?.Close();
 					DisplayManager.OSD.ClearGuiText();
 				}
 				else
@@ -219,11 +215,6 @@ namespace BizHawk.Client.EmuHawk
 					// Even if the lua console is self-rebooting from client.reboot_core() we still want to re-inject dependencies
 					luaLibsImpl.Restart(Emulator.ServiceProvider, Config, Emulator, Game);
 					return;
-				}
-
-				if (luaLibsImpl.GuiLibrary != null && luaLibsImpl.GuiLibrary.HasLuaSurface)
-				{
-					luaLibsImpl.GuiLibrary.DrawFinish();
 				}
 
 				runningScripts = luaLibsImpl.ScriptList.Where(lf => lf.Enabled).ToList();
@@ -572,7 +563,6 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			luaLibsImpl.CallFrameBeforeEvent();
-			luaLibsImpl.StartLuaDrawing();
 		}
 
 		protected override void UpdateAfter()
@@ -584,7 +574,6 @@ namespace BizHawk.Client.EmuHawk
 
 			luaLibsImpl.CallFrameAfterEvent();
 			ResumeScripts(true);
-			luaLibsImpl.EndLuaDrawing();
 		}
 
 		protected override void FastUpdateBefore()
@@ -615,11 +604,6 @@ namespace BizHawk.Client.EmuHawk
 				|| (MainForm.IsTurboing && !Config.RunLuaDuringTurbo))
 			{
 				return;
-			}
-
-			if (luaLibsImpl.GuiLibrary?.SurfaceIsNull == true)
-			{
-				luaLibsImpl.GuiLibrary.DrawNew("emu");
 			}
 
 			foreach (var lf in luaLibsImpl.ScriptList.Where(l => l.Enabled && l.Thread != null && !l.Paused))
@@ -955,7 +939,7 @@ namespace BizHawk.Client.EmuHawk
 					item.State = LuaFile.RunState.Disabled;
 				});
 
-				ReDraw();
+				// there used to be a call here which did a redraw of the Gui/OSD, which included a call to `Tools.UpdateToolsAfter` --yoshi
 			}
 			catch (IOException)
 			{
@@ -965,17 +949,6 @@ namespace BizHawk.Client.EmuHawk
 			{
 				DialogController.ShowMessageBox(ex.ToString());
 			}
-		}
-
-		private void ReDraw()
-		{
-			// Shenanigans
-			// We want any gui.text messages from a script to immediately update even when paused
-			DisplayManager.OSD.ClearGuiText();
-			Tools.UpdateToolsAfter();
-			if (!(LuaImp is Win32LuaLibraries luaLibsImpl)) return;
-			luaLibsImpl.EndLuaDrawing();
-			luaLibsImpl.StartLuaDrawing();
 		}
 
 		private void PauseScriptMenuItem_Click(object sender, EventArgs e)
@@ -1581,7 +1554,7 @@ namespace BizHawk.Client.EmuHawk
 				luaLibsImpl.RegisteredFunctions.RemoveForFile(file, Emulator);
 				luaLibsImpl.CallExitEvent(file);
 				file.Stop();
-				ReDraw();
+				// there used to be a call here which did a redraw of the Gui/OSD, which included a call to `Tools.UpdateToolsAfter` --yoshi
 			}
 		}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/LuaConsole.cs
@@ -120,7 +120,7 @@ namespace BizHawk.Client.EmuHawk
 				{
 					Settings.Columns = LuaListView.AllColumns;
 					
-					DisplayManager.ClearLuaSurfaces();
+					DisplayManager.ClearApiHawkSurfaces();
 
 					if (DisplayManager.ClientExtraPadding != (0, 0, 0, 0))
 					{
@@ -1511,7 +1511,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void EraseToolbarItem_Click(object sender, EventArgs e)
 		{
-			DisplayManager.ClearLuaSurfaces();
+			DisplayManager.ClearApiHawkSurfaces();
 		}
 
 		// Stupid designer


### PR DESCRIPTION
As before, `gui.draw*` draw to the "emu" surface without needing `gui.DrawNew("emu")`. There's a new function `gui.use_surface` to replace `gui.DrawNew("native")`. `gui.DrawFinish` is a no-op. I seem to be the only one who cares about ApiHawk so I won't bother explaining that.

I've tested the first commit on Windows, but not the second. The third is purely cosmetic and can be dropped.