### PR TITLE
Rename Alternate Sync

### DIFF
--- a/src/BizHawk.Client.EmuHawk/AVOut/VideoWriterChooserForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/VideoWriterChooserForm.Designer.cs
@@ -210,7 +210,7 @@
 			this.checkBoxASync.Name = "checkBoxASync";
 			this.checkBoxASync.Size = new System.Drawing.Size(95, 17);
 			this.checkBoxASync.TabIndex = 16;
-			this.checkBoxASync.Text = "Alternate Sync";
+			this.checkBoxASync.Text = "Sync to Audio";
 			this.checkBoxASync.UseVisualStyleBackColor = true;
 			// 
 			// panel1

--- a/src/BizHawk.Client.EmuHawk/AVOut/VideoWriterChooserForm.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/AVOut/VideoWriterChooserForm.Designer.cs
@@ -47,6 +47,7 @@
 			this.checkBoxASync = new System.Windows.Forms.CheckBox();
 			this.panel1 = new System.Windows.Forms.Panel();
 			this.lblResolutionWarning = new BizHawk.WinForms.Controls.LocLabelEx();
+			this.toolTip1 = new System.Windows.Forms.ToolTip();
 			this.tableLayoutPanel4.SuspendLayout();
 			this.panelSizeSelect.SuspendLayout();
 			this.panel1.SuspendLayout();
@@ -212,6 +213,7 @@
 			this.checkBoxASync.TabIndex = 16;
 			this.checkBoxASync.Text = "Sync to Audio";
 			this.checkBoxASync.UseVisualStyleBackColor = true;
+			toolTip1.SetToolTip(checkBoxASync, "Configures A/V Sync strategy for Variable Frame Rate movies. If checked, drops or repeats frames to match audio sync. If unchecked, stretches audio to match video sync, resulting in pitch issues");
 			// 
 			// panel1
 			// 
@@ -280,6 +282,7 @@
 		private System.Windows.Forms.Panel panelSizeSelect;
 		private System.Windows.Forms.CheckBox checkBoxPad;
 		private System.Windows.Forms.CheckBox checkBoxASync;
+		private System.Windows.Forms.ToolTip toolTip1;
 		private BizHawk.WinForms.Controls.LocLabelEx lblSize;
 		private System.Windows.Forms.Panel panel1;
 		private BizHawk.WinForms.Controls.LocLabelEx lblResolutionWarning;


### PR DESCRIPTION
Alternate sync syncs video frames to audio instead of stretching audio to fit video, so rename it to describe that.

closes #1398