### PR TITLE
Probably fix SNES core crash on load with CDL enabled, or formerly enabled

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/SNES/LibsnesCore.IStatable.cs
@@ -19,6 +19,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.SNES
 			IsLagFrame = reader.ReadBoolean();
 			LagCount = reader.ReadInt32();
 			Frame = reader.ReadInt32();
+			Api.QUERY_set_cdl(_currCdl);
 		}
 	}
 }


### PR DESCRIPTION
The crash @g0me3 sent me was very simple to debug:  `cdlInfo.blocks` contains absolute garbage.  It appears that these are foreign pointers brought into the core, in which case they must be refangled on every state load.