### PR TITLE
Fix some TAStudio branch view issues

### DIFF
--- a/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
+++ b/src/BizHawk.Client.EmuHawk/CustomControls/InputRoll/InputRoll.cs
@@ -317,7 +317,7 @@ namespace BizHawk.Client.EmuHawk
 		public bool FullRowSelect { get; set; }
 
 		/// <summary>
-		/// Gets or sets a value indicating whether multiple items can to be selected
+		/// Gets or sets a value indicating whether multiple items can be selected
 		/// </summary>
 		[Category("Behavior")]
 		[DefaultValue(true)]
@@ -1569,7 +1569,7 @@ namespace BizHawk.Client.EmuHawk
 			CurrentCell = newCell;
 
 			if (PointedCellChanged != null &&
-				(_lastCell.Column != CurrentCell.Column || _lastCell.RowIndex != CurrentCell.RowIndex))
+				(_lastCell?.Column != CurrentCell.Column || _lastCell?.RowIndex != CurrentCell.RowIndex))
 			{
 				PointedCellChanged(this, new CellEventArgs(_lastCell, CurrentCell));
 			}

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -286,6 +286,7 @@ namespace BizHawk.Client.EmuHawk
 			toolTip1.SetToolTip(UndoBranchButton, "Undo Branch Update");
 			_branchUndo = BranchUndo.Update;
 
+			BranchView.ScrollToIndex(Branches.Current);
 			Branches.Replace(SelectedBranch, CreateBranch());
 			Tastudio.RefreshDialog();
 			SavedCallback?.Invoke(Branches.Current);
@@ -443,6 +444,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (Branches[slot] != null)
 				{
+					BranchView.DeselectAll();
 					Select(slot, true);
 				}
 				else

--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/BookmarksBranchesBox.cs
@@ -421,6 +421,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				if (Branches[slot] != null)
 				{
+					BranchView.DeselectAll();
 					Select(slot, true);
 				}
 				else


### PR DESCRIPTION
- rightclicking a branch when the contextmenu was already open would throw an exception and not work properly (I don't understand how 764f4ad81e744ce2b1949c6e97a46c0cb40debc8 tried to fix this very issue and somehow failed)
- branch view will now scroll to the updated branch when using hotkeys to update a branch as I feel like that makes sense
- fix #2645 (was broken in a2414f2b4ea41c18ad52b29e13f1a363b4ff425f)