### PR TITLE
Fix #2640 due to library differences

### DIFF
--- a/src/BizHawk.Client.Common/savestates/ZipStateLoader.cs
+++ b/src/BizHawk.Client.Common/savestates/ZipStateLoader.cs
@@ -55,7 +55,7 @@ namespace BizHawk.Client.Common
 			_entriesByName = new Dictionary<string, ZipArchiveEntry>();
 			foreach (var z in _zip.Entries)
 			{
-				string name = z.Name;
+				string name = z.FullName;
 				int i;
 				if ((i = name.LastIndexOf('.')) != -1)
 				{
@@ -80,7 +80,7 @@ namespace BizHawk.Client.Common
 					return null;
 				}
 			}
-			
+
 			try
 			{
 				ret._zip = new ZipArchive(new FileStream(filename, FileMode.Open, FileAccess.Read), ZipArchiveMode.Read);
@@ -113,12 +113,12 @@ namespace BizHawk.Client.Common
 
 				return true;
 			}
-			
+
 			if (abort)
 			{
 				throw new Exception($"Essential zip section not found: {lump.ReadName}");
 			}
-			
+
 			return false;
 		}
 


### PR DESCRIPTION
- closes #2640 

SharpZipLib's `ZipEntry.Name` is actually equivalent to `ZipArchiveEntry.FullName`. `.Name` returns only the filename without directories.

*I really hope there aren't more of these subtle differences sprinkled across the code*
