### PR TITLE
Support branches in all "old" .tasproj files

### DIFF
--- a/src/BizHawk.Client.Common/savestates/ZipStateLoader.cs
+++ b/src/BizHawk.Client.Common/savestates/ZipStateLoader.cs
@@ -62,7 +62,7 @@ namespace BizHawk.Client.Common
 					name = name.Substring(0, i);
 				}
 
-				_entriesByName.Add(name, z);
+				_entriesByName.Add(name.Replace('\\', '/'), z);
 			}
 		}
 


### PR DESCRIPTION
a91fa2754e21b0b2323bd06593ebcb57f24468e0 broke all old .tasproj files in that all branch info was not loaded from them. I don't think that is a wise choice? That's just asking for another #2640.

Some more info in hopes that it's helpful: all "old" tasproj files were saved with `\` as path separator, which was changed to `/` in the aforementioned commit. Without my fix here, the new logic will fail to understand `\` as path separator and ignore all branch etc. info in .tasproj files.