### PR TITLE
Add initial marker in frame 0 when loading older tasprojs

### DIFF
--- a/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/TasMovie.IO.cs
@@ -74,6 +74,7 @@ namespace BizHawk.Client.Common
 				else
 				{
 					Session.PopupMessage("The current .tasproj is not compatible with this version of BizHawk! .tasproj features failed to load.");
+					Markers.Add(0, StartsFromSavestate ? "Savestate" : "Power on");
 				}
 			}
 		}


### PR DESCRIPTION
Before this would load old "incompatible" .tasprojs without any marker, making the first created marker take slot 1 and be uneditable and undeletable, seemingly without reason.
I have looked a bit into the discussion around this (#2023), but I think a quick fix is better for now.

Not sure if this line of code should be duplicated in the code as often as it is now (3 times total), so I'm open for suggestions on whether this could be handled better.