### PR TITLE
Remove 2-way FirmwaresConfig<=>PathsConfig link

### DIFF
--- a/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.Events.cs
@@ -873,13 +873,13 @@ namespace BizHawk.Client.EmuHawk
 		{
 			if (e is RomLoader.RomErrorArgs args)
 			{
-				using var configForm = new FirmwaresConfig(FirmwareManager, Config.FirmwareUserSpecifications, Game, this, Config.PathEntries, retryLoadRom: true, reloadRomPath: args.RomPath);
+				using var configForm = new FirmwaresConfig(FirmwareManager, Config.FirmwareUserSpecifications, this, Config.PathEntries, retryLoadRom: true, reloadRomPath: args.RomPath);
 				var result = configForm.ShowDialog();
 				args.Retry = result == DialogResult.Retry;
 			}
 			else
 			{
-				using var configForm = new FirmwaresConfig(FirmwareManager, Config.FirmwareUserSpecifications, Game, this, Config.PathEntries);
+				using var configForm = new FirmwaresConfig(FirmwareManager, Config.FirmwareUserSpecifications, this, Config.PathEntries);
 				configForm.ShowDialog();
 			}
 		}
@@ -895,7 +895,7 @@ namespace BizHawk.Client.EmuHawk
 
 		private void PathsMenuItem_Click(object sender, EventArgs e)
 		{
-			using var form = new PathConfig(FirmwareManager, Config.FirmwareUserSpecifications, Game, this, Config.PathEntries);
+			using var form = new PathConfig(this, Config.PathEntries, Game.System);
 			form.ShowDialog();
 		}
 

--- a/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.Designer.cs
@@ -59,7 +59,7 @@ namespace BizHawk.Client.EmuHawk
 			this.tbbOpenFolder = new System.Windows.Forms.ToolStripButton();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.panel2 = new System.Windows.Forms.Panel();
-			this.linkBasePath = new System.Windows.Forms.LinkLabel();
+			this.linkBasePath = new System.Windows.Forms.Label();
 			this.label1 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -307,19 +307,18 @@ namespace BizHawk.Client.EmuHawk
 			// linkBasePath
 			// 
 			this.linkBasePath.AutoSize = true;
-			this.linkBasePath.Location = new System.Drawing.Point(125, 0);
+			this.linkBasePath.Location = new System.Drawing.Point(295, 0);
 			this.linkBasePath.Name = "linkBasePath";
 			this.linkBasePath.Size = new System.Drawing.Size(55, 13);
 			this.linkBasePath.TabIndex = 27;
 			this.linkBasePath.TabStop = true;
 			this.linkBasePath.Text = "linkLabel1";
-			this.linkBasePath.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkBasePath_LinkClicked);
 			// 
 			// label1
 			// 
 			this.label1.Location = new System.Drawing.Point(3, 0);
 			this.label1.Name = "label1";
-			this.label1.Text = "Firmwares Search Path:";
+			this.label1.Text = "Scan will look under (change in Config > Paths... > Global):";
 			// 
 			// label2
 			// 
@@ -378,7 +377,7 @@ namespace BizHawk.Client.EmuHawk
 				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiInfo;
 				private BizHawk.WinForms.Controls.ToolStripMenuItemEx tsmiCopy;
 				private System.Windows.Forms.Panel panel2;
-				private System.Windows.Forms.LinkLabel linkBasePath;
+				private System.Windows.Forms.Label linkBasePath;
 				private BizHawk.WinForms.Controls.LocLabelEx label1;
 				private System.Windows.Forms.ToolStripButton tbbImport;
 				private System.Windows.Forms.ColumnHeader columnHeader8;

--- a/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/FirmwaresConfig.cs
@@ -30,8 +30,6 @@ namespace BizHawk.Client.EmuHawk
 	{
 		private readonly IDictionary<string, string> _firmwareUserSpecifications;
 
-		private readonly IGameInfo _game;
-
 		private readonly IMainFormForConfig _mainForm;
 
 		private readonly PathEntryCollection _pathEntries;
@@ -108,14 +106,12 @@ namespace BizHawk.Client.EmuHawk
 		public FirmwaresConfig(
 			FirmwareManager firmwareManager,
 			IDictionary<string, string> firmwareUserSpecifications,
-			IGameInfo game,
 			IMainFormForConfig mainForm,
 			PathEntryCollection pathEntries,
 			bool retryLoadRom = false,
 			string reloadRomPath = null)
 		{
 			_firmwareUserSpecifications = firmwareUserSpecifications;
-			_game = game;
 			_mainForm = mainForm;
 			_pathEntries = pathEntries;
 			Manager = firmwareManager;
@@ -226,7 +222,9 @@ namespace BizHawk.Client.EmuHawk
 				WarpToSystemId(TargetSystem);
 			}
 
-			RefreshBasePath();
+			var oldBasePath = _currSelectorDir;
+			linkBasePath.Text = _currSelectorDir = _pathEntries.FirmwareAbsolutePath();
+			if (_currSelectorDir != oldBasePath) DoScan();
 
 			_cbAllowImport = new CheckBox
 			{
@@ -617,29 +615,6 @@ namespace BizHawk.Client.EmuHawk
 		private void TsmiCopy_Click(object sender, EventArgs e)
 		{
 			PerformListCopy();
-		}
-
-		private void LinkBasePath_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-		{
-			if (Owner is PathConfig)
-			{
-				DialogController.ShowMessageBox("C-C-C-Combo Breaker!", "Nice try, but");
-				return;
-			}
-
-			using var pathConfig = new PathConfig(Manager, _firmwareUserSpecifications, _game, _mainForm, _pathEntries);
-			pathConfig.ShowDialog(this);
-			RefreshBasePath();
-		}
-
-		private void RefreshBasePath()
-		{
-			string oldBasePath = _currSelectorDir;
-			linkBasePath.Text = _currSelectorDir = _pathEntries.FirmwareAbsolutePath();
-			if (oldBasePath != _currSelectorDir)
-			{
-				DoScan();
-			}
 		}
 
 		private void TbbImport_Click(object sender, EventArgs e)

--- a/src/BizHawk.Client.EmuHawk/config/PathConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/PathConfig.cs
@@ -6,21 +6,16 @@ using System.Windows.Forms;
 
 using BizHawk.Client.Common;
 using BizHawk.Common;
-using BizHawk.Emulation.Common;
 
 namespace BizHawk.Client.EmuHawk
 {
 	public partial class PathConfig : Form
 	{
-		private readonly FirmwareManager _firmwareManager;
-
-		private readonly IDictionary<string, string> _firmwareUserSpecifications;
-
-		private readonly IGameInfo _game;
-
 		private readonly IMainFormForConfig _mainForm;
 
 		private readonly PathEntryCollection _pathEntries;
+
+		private readonly string _sysID;
 
 		// All path text boxes should do some kind of error checking
 		// Config path under base, config will default to %exe%
@@ -47,18 +42,11 @@ namespace BizHawk.Client.EmuHawk
 			"%rom%",
 		};
 
-		public PathConfig(
-			FirmwareManager firmwareManager,
-			IDictionary<string, string> firmwareUserSpecifications,
-			IGameInfo game,
-			IMainFormForConfig mainForm,
-			PathEntryCollection pathEntries)
+		public PathConfig(IMainFormForConfig mainForm, PathEntryCollection pathEntries, string sysID)
 		{
-			_firmwareManager = firmwareManager;
-			_firmwareUserSpecifications = firmwareUserSpecifications;
-			_game = game;
 			_mainForm = mainForm;
 			_pathEntries = pathEntries;
+			_sysID = sysID;
 			InitializeComponent();
 			SpecialCommandsBtn.Image = Properties.Resources.Help;
 		}
@@ -67,7 +55,7 @@ namespace BizHawk.Client.EmuHawk
 		{
 			RecentForROMs.Checked = _pathEntries.UseRecentForRoms;
 
-			DoTabs(_pathEntries.ToList(), _game.System);
+			DoTabs(_pathEntries.ToList(), _sysID);
 			DoRomToggle();
 		}
 
@@ -127,11 +115,10 @@ namespace BizHawk.Client.EmuHawk
 					var tempSystem = path.System;
 					btn.Click += (sender, args) => BrowseFolder(tempBox, tempPath, tempSystem);
 
-					int infoPadding = UIHelper.ScaleX(0);
 					var label = new Label
 					{
 						Text = path.Type,
-						Location = new Point(widgetOffset + buttonWidth + padding + infoPadding, y + UIHelper.ScaleY(4)),
+						Location = new Point(widgetOffset + buttonWidth + padding, y + UIHelper.ScaleY(4)),
 						Size = new Size(UIHelper.ScaleX(100), UIHelper.ScaleY(15)),
 						Name = path.Type,
 						Anchor = AnchorStyles.Top | AnchorStyles.Right

--- a/src/BizHawk.Client.EmuHawk/config/PathConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/PathConfig.cs
@@ -128,35 +128,6 @@ namespace BizHawk.Client.EmuHawk
 					btn.Click += (sender, args) => BrowseFolder(tempBox, tempPath, tempSystem);
 
 					int infoPadding = UIHelper.ScaleX(0);
-					if (t.Name.Contains("Global") && path.Type == "Firmware")
-					{
-						infoPadding = UIHelper.ScaleX(26);
-
-						var firmwareButton = new Button
-						{
-							Name = "Global",
-							Text = "",
-							Image = Properties.Resources.Help,
-							Location = new Point(UIHelper.ScaleX(115), y + buttonOffsetY),
-							Size = new Size(buttonWidth, buttonHeight),
-							Anchor = AnchorStyles.Top | AnchorStyles.Right
-						};
-
-						firmwareButton.Click += (sender, e) =>
-						{
-							if (Owner is FirmwaresConfig)
-							{
-								_mainForm.DialogController.ShowMessageBox("C-C-C-Combo Breaker!", "Nice try, but");
-								return;
-							}
-
-							using var f = new FirmwaresConfig(_firmwareManager, _firmwareUserSpecifications, _game, _mainForm, _pathEntries) { TargetSystem = "Global" };
-							f.ShowDialog(this);
-						};
-
-						t.Controls.Add(firmwareButton);
-					}
-
 					var label = new Label
 					{
 						Text = path.Type,


### PR DESCRIPTION
I don't think the link in `FirmwaresConfig` which opens `PathsConfig` is very helpful, and the link in `PathsConfig` which opens `FirmwaresConfig` is even less so. Removing them makes a few hacks redundant.

edit: force-pushed to remove both links instead of just one