### PR TITLE
Fix #2583 by adding a missing event handler

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/TAStudio/TAStudio.cs
@@ -562,6 +562,7 @@ namespace BizHawk.Client.EmuHawk
 			CurrentTasMovie.GreenzoneInvalidated = GreenzoneInvalidated;
 			Settings.RecentTas.Add(MovieSession.Movie.Filename);
 			MainForm.SetMainformMovieInfo();
+			CurrentTasMovie.PropertyChanged += TasMovie_OnPropertyChanged;
 		}
 
 		private bool LoadFile(FileInfo file, bool startsFromSavestate = false, int gotoFrame = 0)


### PR DESCRIPTION
- closes #2583

Note: while this works, I'm really unsure about the flow of loading a .bk2 versus loading a .tasproj file.

To me it seems like either I don't fully understand at which point what code is being run (and therefor `ConvertCurrentMovieToTasproj` having so little code makes sense) or
1. the `LoadFile` function below either does too much work, aka calls function that it doesn't need to
2. the `ConvertCurrentMovieToTasproj` is still missing some hard-to-notice features that the `LoadFile` function provides

either way the general loading code that is similar for both .bk2 and .tasproj files should probably be condensed so something like that can't happen.