### PR TITLE
Add missing menacer keys

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGXControlConverter.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/GPGXControlConverter.cs
@@ -61,6 +61,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 		{
 			new CName("Lightgun Trigger", LibGPGX.INPUT_KEYS.INPUT_MENACER_TRIGGER),
 			new CName("Lightgun Start", LibGPGX.INPUT_KEYS.INPUT_MENACER_START),
+			new CName("Lightgun B", LibGPGX.INPUT_KEYS.INPUT_MENACER_B),
+			new CName("Lightgun C", LibGPGX.INPUT_KEYS.INPUT_MENACER_C),
 		};
 
 		private static readonly CName[] Activator = 

--- a/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/LibGPGX.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Sega/gpgx64/LibGPGX.cs
@@ -224,6 +224,8 @@ namespace BizHawk.Emulation.Cores.Consoles.Sega.gpgx
 			/* Menacer */
 			INPUT_MENACER_TRIGGER = 0x0040,
 			INPUT_MENACER_START = 0x0080,
+			INPUT_MENACER_B = 0x0020,
+			INPUT_MENACER_C = 0x0010,
 		}
 
 		[StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
See eafa39456f4a03395755b8ba69122655c843e9 and 307d85cee056298a6271f6537947296aeaa80a.
This will add extra keys that do nothing on certain non-menacer light guns, but that never seemed to bother anyone in 1.x.

Fixes #2717