### PR TITLE
Simplify IToolForm and remove winform specific notions

### DIFF
--- a/src/BizHawk.Client.Common/tools/Interfaces/IToolForm.cs
+++ b/src/BizHawk.Client.Common/tools/Interfaces/IToolForm.cs
@@ -40,12 +40,23 @@
 		/// </summary>
 		bool AskSaveChanges();
 
+		/// <summary>
+		/// Returns a value indicating whether or not the current tool is active and running
+		/// </summary>
+		bool IsActive { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether a tool is actually open.
+		/// This value should be the same as <see cref="IsActive"/>
+		/// except for tools that can be closed/hidden,
+		/// where the tool can be active but not loaded
+		/// </summary>
+		bool IsLoaded { get; }
+
 		// Necessary winform calls
 		bool Focus();
 		bool ContainsFocus { get; }
 		void Show();
 		void Close();
-		bool IsDisposed { get; }
-		bool IsHandleCreated { get; }
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/ToolFormBase.cs
@@ -27,6 +27,9 @@ namespace BizHawk.Client.EmuHawk
 
 		public virtual bool AskSaveChanges() => true;
 
+		public virtual bool IsActive => IsHandleCreated && !IsDisposed;
+		public virtual bool IsLoaded => IsActive;
+
 		public virtual void Restart() {}
 
 		public virtual void UpdateValues(ToolFormUpdateType type)

--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamWatch.cs
@@ -102,6 +102,9 @@ namespace BizHawk.Client.EmuHawk
 			SetColumns();
 		}
 
+		public override bool IsActive => Config!.DisplayRamWatch || base.IsActive;
+		public override bool IsLoaded => base.IsActive;
+
 		private void SetColumns()
 		{
 			WatchListView.AllColumns.AddRange(Settings.Columns);
@@ -117,14 +120,14 @@ namespace BizHawk.Client.EmuHawk
 			{
 				Columns = new List<RollColumn>
 				{
-					new RollColumn { Text = "Address", Name = WatchList.Address, Visible = true, UnscaledWidth = 60, Type = ColumnType.Text },
-					new RollColumn { Text = "Value", Name = WatchList.Value, Visible = true, UnscaledWidth = 59, Type = ColumnType.Text },
-					new RollColumn { Text = "Prev", Name = WatchList.Prev, Visible = false, UnscaledWidth = 59, Type = ColumnType.Text },
-					new RollColumn { Text = "Changes", Name = WatchList.ChangesCol, Visible = true, UnscaledWidth = 60, Type = ColumnType.Text },
-					new RollColumn { Text = "Diff", Name = WatchList.Diff, Visible = false, UnscaledWidth = 59, Type = ColumnType.Text },
-					new RollColumn { Text = "Type", Name = WatchList.Type, Visible = false, UnscaledWidth = 55, Type = ColumnType.Text },
-					new RollColumn { Text = "Domain", Name = WatchList.Domain, Visible = true, UnscaledWidth = 55, Type = ColumnType.Text },
-					new RollColumn { Text = "Notes", Name = WatchList.Notes, Visible = true, UnscaledWidth = 128, Type = ColumnType.Text }
+					new() { Text = "Address", Name = WatchList.Address, Visible = true, UnscaledWidth = 60, Type = ColumnType.Text },
+					new() { Text = "Value", Name = WatchList.Value, Visible = true, UnscaledWidth = 59, Type = ColumnType.Text },
+					new() { Text = "Prev", Name = WatchList.Prev, Visible = false, UnscaledWidth = 59, Type = ColumnType.Text },
+					new() { Text = "Changes", Name = WatchList.ChangesCol, Visible = true, UnscaledWidth = 60, Type = ColumnType.Text },
+					new() { Text = "Diff", Name = WatchList.Diff, Visible = false, UnscaledWidth = 59, Type = ColumnType.Text },
+					new() { Text = "Type", Name = WatchList.Type, Visible = false, UnscaledWidth = 55, Type = ColumnType.Text },
+					new() { Text = "Domain", Name = WatchList.Domain, Visible = true, UnscaledWidth = 55, Type = ColumnType.Text },
+					new() { Text = "Notes", Name = WatchList.Notes, Visible = true, UnscaledWidth = 128, Type = ColumnType.Text }
 				};
 			}
 


### PR DESCRIPTION
replace some winforms specific values and ram watch chacks with IToolForm properties.  Removes hacks, and some winforms dependencies in tools, and allows for easier implementation of closeable tools

Note: this is a breaking change to existing external tools