### PR TITLE
N64 plugin categories

### DIFF
--- a/src/BizHawk.Client.EmuHawk/config/N64/N64VideoPluginconfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/N64/N64VideoPluginconfig.Designer.cs
@@ -451,6 +451,7 @@
 			this.Controls.Add(this.SaveButton);
 			this.Controls.Add(this.N64plugintabcontrol);
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.MaximizeBox = false;
 			this.Name = "N64VideoPluginConfig";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
 			this.Text = "Plugin Settings";

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
@@ -70,11 +70,16 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 				OverscanPalRight = 0;
 			}
 
+			[DefaultValue(true)]
+			[DisplayName("Use Default Hacks")]
+			[Description("Use automatically detected framebuffer settings for games from .ini file.")]
+			[Category("Framebuffer")]
 			public bool UseDefaultHacks { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Multi-sampling")]
 			[Description("Enable/Disable MultiSampling (0=off, 2,4,8,16=quality)")]
+			[Category("Video")]
 			public int MultiSampling { get; set; }
 
 			public enum AspectRatioMode
@@ -95,6 +100,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(AspectRatioMode.FourThree)]
 			[DisplayName("Aspect Ratio")]
 			[Description("Screen aspect ratio (0=stretch, 1=force 4:3, 2=force 16:9, 3=adjust)")]
+			[Category("Video")]
 			public AspectRatioMode AspectRatio { get; set; }
 
 			public enum SwapMode
@@ -112,11 +118,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(SwapMode.OnVIUpdateCall)]
 			[DisplayName("Buffer swap mode")]
 			[Description("Swap frame buffers (0=On VI update call, 1=On VI origin change, 2=On buffer update)")]
+			[Category("Framebuffer")]
 			public SwapMode BufferSwapMode { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Use native resolution factor")]
 			[Description("Frame buffer size is the factor of N64 native resolution.")]
+			[Category("Emulation")]
 			public int UseNativeResolutionFactor { get; set; }
 
 			public enum bilinearFilteringMode
@@ -131,56 +139,67 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(bilinearFilteringMode.Standard)]
 			[DisplayName("Bilinear filtering mode")]
 			[Description("Bilinear filtering mode (0=N64 3point, 1=standard)")]
+			[Category("Video")]
 			public bilinearFilteringMode bilinearMode { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Enable Halos Removal")]
 			[Description("Remove halos around filtered textures")]
+			[Category("Video")]
 			public bool enableHalosRemoval { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Max level of Anisotropic Filtering")]
 			[Description("Max level of Anisotropic Filtering, 0 for off")]
+			[Category("Video")]
 			public bool MaxAnisotropy { get; set; }
 
 			[DefaultValue(500)]
 			[DisplayName("Cache Size")]
 			[Description("Size of texture cache in megabytes. Good value is VRAM*3/4")]
+			[Category("Texture Enhancement")]
 			public int CacheSize { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Show Internal Resolution")]
 			[Description("Show internal resolution.")]
+			[Category("OSD")]
 			public bool ShowInternalResolution { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Show Rendering Resolution")]
 			[Description("Show rendering resolution.")]
+			[Category("OSD")]
 			public bool ShowRenderingResolution { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("FXAA")]
 			[Description("Enable Fast Approximate Anti-Aliasing.")]
+			[Category("Video")]
 			public bool FXAA { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Color noise emulation")]
 			[Description("Enable color noise emulation.")]
+			[Category("Emulation")]
 			public bool EnableNoise { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("LOD emulation")]
 			[Description("Enable LOD emulation.")]
+			[Category("Emulation")]
 			public bool EnableLOD { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("HW Lighting")]
 			[Description("Enable hardware per-pixel lighting.")]
+			[Category("Emulation")]
 			public bool EnableHWLighting { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Shaders storage")]
 			[Description("Use persistent storage for compiled shaders.")]
+			[Category("Emulation")]
 			public bool EnableShadersStorage { get; set; }
 
 			public enum TexrectCoordsMode
@@ -198,96 +217,115 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(TexrectCoordsMode.Off)]
 			[DisplayName("Correct Texrect Coords")]
 			[Description("Make texrect coordinates continuous to avoid black lines between them. (0=Off, 1=Auto, 2=Force)")]
+			[Category("Emulation")]
 			public TexrectCoordsMode CorrectTexrectCoords { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Native Res Texrects")]
 			[Description("Render 2D texrects in native resolution to fix misalignment between parts of 2D image.")]
+			[Category("Emulation")]
 			public bool EnableNativeResTexrects { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Legacy Blending")]
 			[Description("Do not use shaders to emulate N64 blending modes. Works faster on slow GPU. Can cause glitches.")]
+			[Category("Emulation")]
 			public bool EnableLegacyBlending { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Fragment Depth Write")]
 			[Description("Enable writing of fragment depth. Some mobile GPUs do not support it, thus it made optional. Leave enabled.")]
+			[Category("Framebuffer")]
 			public bool EnableFragmentDepthWrite { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("FB Emulation")]
 			[Description("Enable frame and|or depth buffer emulation.")]
+			[Category("Framebuffer")]
 			public bool EnableFBEmulation { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Copy auxiliary to RDRAM")]
 			[Description("Copy auxiliary buffers to RDRAM")]
+			[Category("Framebuffer")]
 			public bool EnableCopyAuxiliaryToRDRAM { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("N64 Depth Compare")]
 			[Description("Enable N64 depth compare instead of OpenGL standard one. Experimental.")]
+			[Category("Framebuffer")]
 			public bool EnableN64DepthCompare { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Enable Overscan")]
 			[Description("Enable resulted image crop by Overscan.")]
+			[Category("Video")]
 			public bool EnableOverscan { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan NTSC Top")]
 			[Description("NTSC mode. Top bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanNtscTop { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan NTSC Bottom")]
 			[Description("NTSC mode. Bottom bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanNtscBottom { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan NTSC Left")]
 			[Description("NTSC mode. Left bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanNtscLeft { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan NTSC Right")]
 			[Description("NTSC mode. Right bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanNtscRight { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan PAL Top")]
 			[Description("PAL mode. Top bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanPalTop { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan PAL Bottom")]
 			[Description("PAL mode. Bottom bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanPalBottom { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan PAL Left")]
 			[Description("PAL mode. Left bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanPalLeft { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Overscan PAL Right")]
 			[Description("PAL mode. Right bound of Overscan.")]
+			[Category("Video")]
 			public int OverscanPalRight { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("FB Info")]
 			[Description("Disable buffers read/write with FBInfo. Use for games, which do not work with FBInfo.")]
+			[Category("Framebuffer")]
 			public bool DisableFBInfo { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("FB Info Read Color Chunk")]
 			[Description("Read color buffer by 4kb chunks (strict follow to FBRead specification)")]
+			[Category("Framebuffer")]
 			public bool FBInfoReadColorChunk { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("FB Info Read Depth Chunk")]
 			[Description("Read depth buffer by 4kb chunks (strict follow to FBRead specification)")]
+			[Category("Framebuffer")]
 			public bool FBInfoReadDepthChunk { get; set; }
 
 			public enum CopyColorToRDRAMMode
@@ -305,6 +343,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(CopyColorToRDRAMMode.AsyncMode)]
 			[DisplayName("Copy Color To RDRAM")]
 			[Description("Enable color buffer copy to RDRAM (0=do not copy, 1=copy in sync mode, 2=copy in async mode)")]
+			[Category("Framebuffer")]
 			public CopyColorToRDRAMMode EnableCopyColorToRDRAM { get; set; }
 
 			public enum CopyDepthToRDRAMMode
@@ -322,11 +361,13 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(CopyDepthToRDRAMMode.DoNotCopy)]
 			[DisplayName("Copy Depth To RDRAM")]
 			[Description("Enable depth buffer copy to RDRAM  (0=do not copy, 1=copy from video memory, 2=use software render)")]
+			[Category("Framebuffer")]
 			public CopyDepthToRDRAMMode EnableCopyDepthToRDRAM { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Copy Color From RDRAM")]
 			[Description("Enable color buffer copy from RDRAM.")]
+			[Category("Framebuffer")]
 			public bool EnableCopyColorFromRDRAM { get; set; }
 
 			public enum TextureFilterMode
@@ -356,6 +397,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(TextureFilterMode.None)]
 			[DisplayName("Texture filter")]
 			[Description("Texture filter (0=none, 1=Smooth filtering 1, 2=Smooth filtering 2, 3=Smooth filtering 3, 4=Smooth filtering 4, 5=Sharp filtering 1, 6=Sharp filtering 2)")]
+			[Category("Texture Enhancement")]
 			public TextureFilterMode txFilterMode { get; set; }
 
 			public enum TextureEnhancementMode
@@ -406,71 +448,85 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(TextureEnhancementMode.None)]
 			[DisplayName("Texture Enhancement Mode")]
 			[Description("Texture Enhancement (0=none, 1=store as is, 2=X2, 3=X2SAI, 4=HQ2X, 5=HQ2XS, 6=LQ2X, 7=LQ2XS, 8=HQ4X, 9=2xBRZ, 10=3xBRZ, 11=4xBRZ, 12=5xBRZ), 13=6xBRZ)")]
+			[Category("Texture Enhancement")]
 			public TextureEnhancementMode txEnhancementMode { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Deposterize")]
 			[Description("Deposterize texture before enhancement.")]
+			[Category("Texture Enhancement")]
 			public bool txDeposterize { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Filter Ignore BG")]
 			[Description("Don't filter background textures.")]
+			[Category("Texture Enhancement")]
 			public bool txFilterIgnoreBG { get; set; }
 
 			[DefaultValue(100)]
 			[DisplayName("Texture Cache Size")]
 			[Description("Size of filtered textures cache in megabytes.")]
+			[Category("Texture Enhancement")]
 			public int txCacheSize { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Hires Enable")]
 			[Description("Use high-resolution texture packs if available.")]
+			[Category("Texture Enhancement")]
 			public bool txHiresEnable { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Hires Full Alpha Channel")]
 			[Description("Allow to use alpha channel of high-res texture fully.")]
+			[Category("Texture Enhancement")]
 			public bool txHiresFullAlphaChannel { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Hres Alt CRC")]
 			[Description("Use alternative method of paletted textures CRC calculation.")]
+			[Category("Texture Enhancement")]
 			public bool txHresAltCRC { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Dump")]
 			[Description("Enable dump of loaded N64 textures.")]
+			[Category("Texture Enhancement")]
 			public bool txDump { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Texture Cache Compression")]
 			[Description("Zip textures cache.")]
+			[Category("Texture Enhancement")]
 			public bool txCacheCompression { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Force 16bpp")]
 			[Description("Force use 16bit texture formats for HD textures.")]
+			[Category("Texture Enhancement")]
 			public bool txForce16bpp { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Texture Save Cache")]
 			[Description("Save texture cache to hard disk.")]
+			[Category("Texture Enhancement")]
 			public bool txSaveCache { get; set; }
 
 			[DefaultValue("")]
 			[DisplayName("Texture Path")]
 			[Description("Path to folder with hi-res texture packs.")]
+			[Category("Texture Enhancement")]
 			public string txPath { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Enable Bloom")]
 			[Description("Enable bloom filter")]
+			[Category("Emulation")]
 			public bool EnableBloom { get; set; }
 
 			[DefaultValue(4)]
 			[DisplayName("Bloom Threshold Level")]
 			[Description("Brightness threshold level for bloom. Values [2, 6]")]
+			[Category("Emulation")]
 			public int bloomThresholdLevel { get; set; }
 
 			public enum BlendMode
@@ -488,26 +544,31 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(BlendMode.Strong)]
 			[DisplayName("Bloom Blend Mode")]
 			[Description("Bloom blend mode (0=Strong, 1=Mild, 2=Light)")]
+			[Category("Emulation")]
 			public BlendMode bloomBlendMode { get; set; }
 
 			[DefaultValue(10)]
 			[DisplayName("Blur Amount")]
 			[Description("Blur radius. Values [2, 10]")]
+			[Category("Emulation")]
 			public int blurAmount { get; set; }
 
 			[DefaultValue(20)]
 			[DisplayName("Blur Strength")]
 			[Description("Blur strength. Values [10, 100]")]
+			[Category("Emulation")]
 			public int blurStrength { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Gamma Correction")]
 			[Description("Force gamma correction.")]
+			[Category("Emulation")]
 			public bool ForceGammaCorrection { get; set; }
 
 			[DefaultValue(2.0)]
 			[DisplayName("Gamma Correction Level")]
 			[Description("Gamma correction level.")]
+			[Category("Emulation")]
 			public float GammaCorrectionLevel { get; set; }
 
 			public N64GLideN64PluginSettings Clone()

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.Glide.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.Glide.cs
@@ -68,222 +68,277 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(1)]
 			[DisplayName("Wire Frame Mode")]
 			[Description("0=Normal colors, 1=Vertex colors, 2=Red only")]
+			[Category("General")]
 			public int wfmode { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Wire Frame Display")]
+			[Category("General")]
 			public bool wireframe { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Card ID")]
+			[Category("General")]
 			public int card_id { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Zelda corona fix")]
+			[Category("General")]
 			public bool flame_corona { get; set; }
 
 			[DefaultValue(2)]
 			[DisplayName("Force microcode")]
+			[Category("General")]
 			public int ucode { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Auto-detect microcode")]
+			[Category("General")]
 			public bool autodetect_ucode { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Motion Blur")]
+			[Category("General")]
 			public bool motionblur { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer read every frame")]
+			[Category("General")]
 			public bool fb_read_always { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Display unknown combines as red")]
+			[Category("General")]
 			public bool unk_as_red { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Filter Cache")]
+			[Category("General")]
 			public bool filter_cache { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Fast CRC")]
+			[Category("General")]
 			public bool fast_crc { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Disable Aux Buffer")]
+			[Category("General")]
 			public bool disable_auxbuf { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Use framebuffer objects")]
+			[Category("General")]
 			public bool fbo { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Disable GLSL combiners")]
+			[Category("General")]
 			public bool noglsl { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Disable dithered alpha")]
+			[Category("General")]
 			public bool noditheredalpha { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Texture Filter")]
 			[Description("0=None, 1=Blur edges, 2=Super 2xSai, 3=Hq2x, 4=Hq4x")]
+			[Category("General")]
 			public int tex_filter { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Render")] 
+			[Category("General")]
 			public bool fb_render { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Wrap textures too big for tmem")]
+			[Category("Per Game Settings")]
 			public bool wrap_big_tex { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Use Sts1 Only")]
+			[Category("Per Game Settings")]
 			public bool use_sts1_only { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Soft Depth Compare")]
+			[Category("Per Game Settings")]
 			public bool soft_depth_compare { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("PPL")]
+			[Category("Per Game Settings")]
 			public bool PPL { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Optimize Write")]
+			[Category("Per Game Settings")]
 			public bool fb_optimize_write { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Framebuffer Optimize Texture Rectangle")]
+			[Category("Per Game Settings")]
 			public bool fb_optimize_texrect { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Increase Texture Rectangle Edge")]
+			[Category("Per Game Settings")]
 			public bool increase_texrect_edge { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Increase Prim Depth")]
+			[Category("Per Game Settings")]
 			public bool increase_primdepth { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Ignore Previous")]
+			[Category("Per Game Settings")]
 			public bool fb_ignore_previous { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Ignore Aux Copy")]
+			[Category("Per Game Settings")]
 			public bool fb_ignore_aux_copy { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Framebuffer High Resolution Buffer Clear")]
+			[Category("Per Game Settings")]
 			public bool fb_hires_buf_clear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Mirco Check")]
+			[Category("Per Game Settings")]
 			public bool force_microcheck { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Depth Compare")]
+			[Category("Per Game Settings")]
 			public bool force_depth_compare { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Fog Enabled")]
+			[Category("Per Game Settings")]
 			public bool fog { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Fill Color Fix")]
+			[Category("Per Game Settings")]
 			public bool fillcolor_fix { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Smart Framebuffer")]
+			[Category("Per Game Settings")]
 			public bool fb_smart { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Read Alpha")]
+			[Category("Per Game Settings")]
 			public bool fb_read_alpha { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Get Framebuffer Info")]
+			[Category("General")]
 			public bool fb_get_info { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("High Res Framebuffer")]
+			[Category("Per Game Settings")]
 			public bool fb_hires { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Clear Framebuffer")]
+			[Category("Per Game Settings")]
 			public bool fb_clear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Detect CPU Writes")]
+			[Category("Per Game Settings")]
 			public bool detect_cpu_write { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Decrease Fill Rect Edge")]
+			[Category("Per Game Settings")]
 			public bool decrease_fillrect_edge { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Buffer Clear on Every Frame")]
+			[Category("Per Game Settings")]
 			public bool buff_clear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Alt Text Size")]
+			[Category("Per Game Settings")]
 			public bool alt_tex_size { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Use Default Hacks")]
+			[Description("Use defaults for current game. This overrides all per game settings.")]
+			[Category("Hacks")]
 			public bool UseDefaultHacks { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Enable Hacks for Game")]
+			[Category("More Per Game Settings")]
 			public int enable_hacks_for_game { get; set; }
 
 			[DefaultValue(1)]
 			[DisplayName("Buffer swapping method")]
 			[Description("0=Old, 1=New, 2=Hybrid")]
+			[Category("More Per Game Settings")]
 			public int swapmode { get; set; }
 
 			[DefaultValue(1041204192)]
 			[DisplayName("Stipple Pattern")]
+			[Category("More Per Game Settings")]
 			public int stipple_pattern { get; set; }
 
 			[DefaultValue(2)]
 			[DisplayName("Stipple Mode")]
+			[Category("More Per Game Settings")]
 			public int stipple_mode { get; set; }
 
 			[DefaultValue(100000)]
 			[DisplayName("Y Scale")]
+			[Category("General")]
 			public int scale_y { get; set; }
 
 			[DefaultValue(100000)]
 			[DisplayName("X Scale")]
+			[Category("General")]
 			public int scale_x { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Y Offset")]
+			[Category("General")]
 			public int offset_y { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("X Offset")]
+			[Category("General")]
 			public int offset_x { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("LOD calculation")]
 			[Description("0=Off, 1=Fast, 2=Precise")]
+			[Category("More Per Game Settings")]
 			public int lodmode { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Fix Text Coordinates")]
+			[Category("More Per Game Settings")]
 			public int fix_tex_coord { get; set; }
 
 			[DefaultValue(1)]
 			[DisplayName("Filtering Mode")]
 			[Description("0=None, 1=Force bilinear, 2=Force point-sampled")]
+			[Category("More Per Game Settings")]
 			public int filtering { get; set; }
 
 			[DefaultValue(20)]
 			[DisplayName("Depth bias level")]
+			[Category("More Per Game Settings")]
 			public int depth_bias { get; set; }
 
 			public N64GlidePluginSettings Clone()

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GlideMk2.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GlideMk2.cs
@@ -57,174 +57,218 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 
 			[DefaultValue(true)]
 			[DisplayName("Wrapper FBO")]
+			[Category("General")]
 			public bool wrpFBO { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Card ID")]
+			[Category("General")]
 			public int card_id { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Use Sts1 Only")]
+			[Category("Per Game Settings")]
 			public bool use_sts1_only { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Optimize Texture Rectangle")]
+			[Category("Per Game Settings")]
 			public bool optimize_texrect { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Increase Texture Rectangle Edge")]
+			[Category("Per Game Settings")]
 			public bool increase_texrect_edge { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Ignore Aux Copy")]
+			[Category("Per Game Settings")]
 			public bool ignore_aux_copy { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("High Res Buffer Clear")]
+			[Category("Per Game Settings")]
 			public bool hires_buf_clear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Micro Check")]
+			[Category("Per Game Settings")]
 			public bool force_microcheck { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Fog Enabled")]
+			[Category("Per Game Settings")]
 			public bool fog { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Smart Framebuffer")]
+			[Category("Per Game Settings")]
 			public bool fb_smart { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer Read Alpha")]
+			[Category("Per Game Settings")]
 			public bool fb_read_alpha { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("High Res Framebuffer")]
+			[Category("Per Game Settings")]
 			public bool fb_hires { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Detect CPU Writes")]
+			[Category("Per Game Settings")]
 			public bool detect_cpu_write { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Decrease Fill Rectangle Edge")]
+			[Category("Per Game Settings")]
 			public bool decrease_fillrect_edge { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Buffer Clear")]
+			[Category("Per Game Settings")]
 			public bool buff_clear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Alt Texture Size")]
+			[Category("Per Game Settings")]
 			public bool alt_tex_size { get; set; }
 
 			[DefaultValue(1)]
 			[DisplayName("Swap Mode")]
+			[Category("More Per Game Settings")]
 			public int swapmode { get; set; }
 
 			[DefaultValue(1041204192)]
 			[DisplayName("Stipple Pattern")]
+			[Category("More Per Game Settings")]
 			public int stipple_pattern { get; set; }
 
 			[DefaultValue(2)]
 			[DisplayName("Stipple Mode")]
+			[Category("More Per Game Settings")]
 			public int stipple_mode { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("LOD Calcuation")]
+			[Category("More Per Game Settings")]
 			public int lodmode { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Filtering")]
+			[Category("More Per Game Settings")]
 			public int filtering { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Wrapper Anisotropic Filtering")]
+			[Category("General")]
 			public bool wrpAnisotropic { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Correct Viewport")]
+			[Category("Per Game Settings")]
 			public bool correct_viewport { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Calc Sphere")]
+			[Category("Per Game Settings")]
 			public bool force_calc_sphere { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Pal230")]
+			[Category("Per Game Settings")]
 			public bool pal230 { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Texture Correction")]
+			[Category("Per Game Settings")]
 			public bool texture_correction { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("N64 Z Scale")]
+			[Category("Per Game Settings")]
 			public bool n64_z_scale { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Old Style Adither")]
+			[Category("Per Game Settings")]
 			public bool old_style_adither { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Z Mode Compare Less")]
+			[Category("Per Game Settings")]
 			public bool zmode_compare_less { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Adjust Aspect")]
+			[Category("Per Game Settings")]
 			public bool adjust_aspect { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Clip Z Max")]
+			[Category("Per Game Settings")]
 			public bool clip_zmax { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Clip Z Min")]
+			[Category("Per Game Settings")]
 			public bool clip_zmin { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Quad 3D")]
+			[Category("Per Game Settings")]
 			public bool force_quad3d { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Useless is Useless")]
+			[Category("Per Game Settings")]
 			public bool useless_is_useless { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Framebuffer read every frame")]
+			[Category("Per Game Settings")]
 			public bool fb_read_always { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Get Framebuffer Info")]
+			[Category("General")]
 			public bool fb_get_info { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Framebuffer Render")]
+			[Category("General")]
 			public bool fb_render { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Aspect Mode")]
+			[Category("More Per Game Settings")]
 			public int aspectmode { get; set; }
 
 			[DefaultValue(1)]
 			[DisplayName("Framebuffer CRC Mode")]
+			[Category("More Per Game Settings")]
 			public int fb_crc_mode { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Fast CRC")]
+			[Category("Per Game Settings")]
 			public bool fast_crc { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Use Default Hacks")]
+			[Description("Use defaults for current game. This overrides all per game settings.")]
+			[Category("Hacks")]
 			public bool UseDefaultHacks { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Enable Hacks for Game")]
+			[Category("More Per Game Settings")]
 			public int enable_hacks_for_game { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Read Back to Screen")]
+			[Category("More Per Game Settings")]
 			public int read_back_to_screen { get; set; }
 
 			public N64Glide64mk2PluginSettings Clone()

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.Rice.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.Rice.cs
@@ -79,279 +79,342 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[DefaultValue(0)]
 			[DisplayName("Frame Buffer Emulation")]
 			[Description("0=ROM default, 1=disable")]
+			[Category("Game Default Options")]
 			public int FrameBufferSetting { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Frame Buffer Write Back Control")]
 			[Description("Frequency to write back the frame buffer: 0=every frame, 1=every other frame, etc")]
+			[Category("Game Default Options")]
 			public int FrameBufferWriteBackControl { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Render-to-texture emulation")]
 			[Description("0=none, 1=ignore, 2=normal, 3=write back, 4=write back and reload")]
+			[Category("Game Default Options")]
 			public int RenderToTexture { get; set; }
 
 			[DefaultValue(4)]
 			[DisplayName("Screen Update Setting")]
 			[Description("0=ROM default, 1=VI origin update, 2=VI origin change, 3=CI change, 4=first CI change, 5=first primitive draw, 6=before screen clear, 7=after screen drawn")]
+			[Category("General")]
 			public int ScreenUpdateSetting { get; set; }
 
 			[DefaultValue(2)]
 			[DisplayName("Mip Mapping")]
 			[Description("0=no, 1=nearest, 2=bilinear, 3=trilinear")]
+			[Category("General")]
 			public int Mipmapping { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Fog Method")]
 			[Description("0=Disable, 1=Enable n64 choose, 2=Force Fog")]
+			[Category("General")]
 			public int FogMethod { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Force Texture Filter")]
 			[Description("0=auto: n64 choose, 1=force no filtering, 2=force filtering")]
+			[Category("Texture Enhancement")]
 			public int ForceTextureFilter { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Primary texture enhancement filter")]
 			[Description("0=None, 1=2X, 2=2XSAI, 3=HQ2X, 4=LQ2X, 5=HQ4X, 6=Sharpen, 7=Sharpen More, 8=External, 9=Mirrored")]
+			[Category("Texture Enhancement")]
 			public int TextureEnhancement { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Secondary texture enhancement filter")]
 			[Description("0 = none, 1-4 = filtered")]
+			[Category("Texture Enhancement")]
 			public int TextureEnhancementControl { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Texture Quality")]
 			[Description("Color bit depth to use for textures: 0=default, 1=32 bits, 2=16 bits")]
+			[Category("General")]
 			public int TextureQuality { get; set; }
 
 			[DefaultValue(16)]
 			[DisplayName("OpenGL Depth Buffer Setting")]
 			[Description("Z-buffer depth (only 16 or 32)")]
+			[Category("General")]
 			public int OpenGLDepthBufferSetting { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Enable/Disable MultiSampling")]
 			[Description("0=off, 2,4,8,16=quality")]
+			[Category("General")]
 			public int MultiSampling { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Color Quality")]
 			[Description("Color bit depth for rendering window: 0=32 bits, 1=16 bits")]
+			[Category("General")]
 			public int ColorQuality { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("OpenGL Render Setting")]
 			[Description("0=auto, 1=OGL_1.1, 2=OGL_1.2, 3=OGL_1.3, 4=OGL_1.4, 5=OGL_1.4_V2, 6=OGL_TNT2, 7=NVIDIA_OGL, 8=OGL_FRAGMENT_PROGRAM")]
+			[Category("General")]
 			public int OpenGLRenderSetting { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Anisotropic Filtering")]
 			[Description("0=no filtering, 2-16=quality")]
+			[Category("General")]
 			public int AnisotropicFiltering { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Normal Alpha Blender")]
 			[Description("Force to use normal alpha blender")]
+			[Category("Game Default Options")]
 			public bool NormalAlphaBlender { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Fast Texture Loading")]
 			[Description("Use a faster algorithm to speed up texture loading and CRC computation")]
+			[Category("General")]
 			public bool FastTextureLoading { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Accurate Texture Mapping")]
 			[Description("Use different texture coordinate clamping code")]
+			[Category("General")]
 			public bool AccurateTextureMapping { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("In N64 Resolution")]
 			[Description("Force emulated frame buffers to be in N64 native resolution")]
+			[Category("General")]
 			public bool InN64Resolution { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Save VRAM")]
 			[Description("Try to reduce Video RAM usage (should never be used)")]
+			[Category("General")]
 			public bool SaveVRAM { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Double Size for Small Texture Buffer")]
 			[Description("Enable this option to have better render-to-texture quality")]
+			[Category("Game Default Options")]
 			public bool DoubleSizeForSmallTxtrBuf { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Default Combiner Disable")]
 			[Description("Force to use normal color combiner")]
+			[Category("Game Default Options")]
 			public bool DefaultCombinerDisable { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Enable Hacks")]
 			[Description("Enable game-specific settings from INI file")]
+			[Category("General")]
 			public bool EnableHacks { get; set; }
 
 			[DefaultValue(false)]
-			[DisplayName("WinFrame Mode")]
-			[Description("If enabled, graphics will be drawn in WinFrame mode instead of solid and texture mode")]
+			[DisplayName("Wireframe Mode")]
+			[Description("If enabled, graphics will be drawn in Wireframe mode instead of solid and texture mode")]
+			[Category("General")]
 			public bool WinFrameMode { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Full TMEM Emulation")]
 			[Description("N64 Texture Memory Full Emulation (may fix some games, may break others)")]
+			[Category("General")]
 			public bool FullTMEMEmulation { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("OpenGL Vertex Clipper")]
 			[Description("Enable vertex clipper for fog operations")]
+			[Category("General")]
 			public bool OpenGLVertexClipper { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Enable SSE")]
+			[Category("General")]
 			public bool EnableSSE { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Enable Vertex Shader")]
+			[Category("General")]
 			public bool EnableVertexShader { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Skip Frame")]
 			[Description("If this option is enabled, the plugin will skip every other frame")]
+			[Category("General")]
 			public bool SkipFrame { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Text Rect Only")]
 			[Description("If enabled, texture enhancement will be done only for TxtRect ucode")]
+			[Category("Texture Enhancement")]
 			public bool TexRectOnly { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Small Texture Only")]
 			[Description("If enabled, texture enhancement will be done only for textures width+height<=128")]
+			[Category("Texture Enhancement")]
 			public bool SmallTextureOnly { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Load Hi Res CRC Only")]
 			[Description("Select hi-resolution textures based only on the CRC and ignore format+size information (Glide64 compatibility)")]
+			[Category("Texture Enhancement")]
 			public bool LoadHiResCRCOnly { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Load Hi Res Textures")]
+			[Category("Texture Enhancement")]
 			public bool LoadHiResTextures { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Dump Textures to Files")]
+			[Category("Texture Enhancement")]
 			public bool DumpTexturesToFiles { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Use Default Hacks")]
+			[Description("Use defaults for current game. This overrides all per game settings.")]
+			[Category("Per-Game Hacks")]
 			public bool UseDefaultHacks { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Disable Texture CRC")]
+			[Category("Per-Game Hacks")]
 			public bool DisableTextureCRC { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Disable Culling")]
+			[Category("Per-Game Hacks")]
 			public bool DisableCulling { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Include TexRect Edge")]
+			[Category("Per-Game Hacks")]
 			public bool IncTexRectEdge { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("ZHack")]
+			[Category("Per-Game Hacks")]
 			public bool ZHack { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture Scale Hack")]
+			[Category("Per-Game Hacks")]
 			public bool TextureScaleHack { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Primary Depth Hack")]
+			[Category("Per-Game Hacks")]
 			public bool PrimaryDepthHack { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Texture 1 Hack")]
+			[Category("Per-Game Hacks")]
 			public bool Texture1Hack { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Fast Load Tile")]
+			[Category("Per-Game Hacks")]
 			public bool FastLoadTile { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Use Smaller Texture")]
+			[Category("Per-Game Hacks")]
 			public bool UseSmallerTexture { get; set; }
 
 			[DefaultValue(-1)]
 			[DisplayName("VI Width")]
+			[Category("Per-Game Hacks")]
 			public int VIWidth { get; set; }
 
 			[DefaultValue(-1)]
 			[DisplayName("VI Height")]
+			[Category("Per-Game Hacks")]
 			public int VIHeight { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Use CI Width and Ratio")]
+			[Category("Per-Game Hacks")]
 			public int UseCIWidthAndRatio { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Full THEM")]
+			[Category("Per-Game Hacks")]
 			public int FullTMEM { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Text Size Method 2")]
+			[Category("Per-Game Hacks")]
 			public bool TxtSizeMethod2 { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Enable Txt LOD")]
+			[Category("Per-Game Hacks")]
 			public bool EnableTxtLOD { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Fast Texture CRC")]
+			[Category("Per-Game Hacks")]
 			public int FastTextureCRC { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Emulate Clear")]
+			[Category("Per-Game Hacks")]
 			public bool EmulateClear { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Screen Clear")]
+			[Category("Per-Game Hacks")]
 			public bool ForceScreenClear { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Accurate Texture Mapping Hack")]
+			[Category("Per-Game Hacks")]
 			public int AccurateTextureMappingHack { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Normal Blender")]
+			[Category("Per-Game Hacks")]
 			public int NormalBlender { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Disable Blender")]
+			[Category("Per-Game Hacks")]
 			public bool DisableBlender { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Force Depth Buffer")]
+			[Category("Per-Game Hacks")]
 			public bool ForceDepthBuffer { get; set; }
 
 			[DefaultValue(false)]
 			[DisplayName("Disable Obj BG")]
+			[Category("Per-Game Hacks")]
 			public bool DisableObjBG { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Frame Buffer Option")]
+			[Category("Per-Game Hacks")]
 			public int FrameBufferOption { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Render to Texture Option")]
+			[Category("Per-Game Hacks")]
 			public int RenderToTextureOption { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Screen Update Setting Hack")]
+			[Category("General")]
 			public int ScreenUpdateSettingHack { get; set; }
 
 			[DefaultValue(0)]
 			[DisplayName("Enable Hacks for Game")]
+			[Category("Per-Game Hacks")]
 			public int EnableHacksForGame { get; set; }
 
 			public N64RicePluginSettings Clone()


### PR DESCRIPTION
Add `Category` attributes to N64 Plugin classes so that the `PropertyGrid` controls organizes them. Also disabled the maximize button for the N64 plugin form because the form is not resizable to begin with and maximizing the window breaks the `PropertyGrid` anchors.
- Does not add to the maintenance cost of updating the plugins any more than adding other attributes (`Name`, `Description`, etc) does.
- Forgetting to add a `Category` attribute does not break anything. The property will still show up just fine under a "Misc" category.
- For the most part, categories were taken from the organization of version 2.4.2 with only very cursory organizational changes.
  - GLideN64 organization borrows from the mupen64 (zilmar-spec) plugin layout
  - "Hacks" category for the per-game hacks override setting present in the glide64- plugins

### GLideN64
![F1aAxraxrl](https://user-images.githubusercontent.com/1929934/116795495-3ec15b00-aa8a-11eb-84af-80d82fbc7be3.png)

### GlideMk2
![euEN6XnttV](https://user-images.githubusercontent.com/1929934/116795504-5567b200-aa8a-11eb-803b-67cf8ef5514f.png)

### Glide64
![AeZr2EbQXv](https://user-images.githubusercontent.com/1929934/116795508-5993cf80-aa8a-11eb-97f7-ecc42d530953.png)

### Rice
![z4DXBkF6FR](https://user-images.githubusercontent.com/1929934/116795509-5dbfed00-aa8a-11eb-9fb1-59fa2a511121.png)
