### PR TITLE
Fix crash when XInput controllers disconnect

### DIFF
--- a/src/BizHawk.Bizware.DirectX/DirectInputAdapter.cs
+++ b/src/BizHawk.Bizware.DirectX/DirectInputAdapter.cs
@@ -48,6 +48,8 @@ namespace BizHawk.Bizware.DirectX
 		{
 			foreach (var pad in GamePad360.EnumerateDevices())
 			{
+				if (!pad.IsConnected)
+					continue;
 				for (int b = 0, n = pad.NumButtons; b < n; b++) handleButton(pad.InputNamePrefix + pad.ButtonName(b), pad.Pressed(b), ClientInputFocus.Pad);
 				foreach (var (axisName, f) in pad.GetAxes()) handleAxis(pad.InputNamePrefix + axisName, (int) f);
 				_lastHapticsSnapshot.TryGetValue(pad.InputNamePrefix + "Left", out var leftStrength);

--- a/src/BizHawk.Bizware.DirectX/GamePad360.cs
+++ b/src/BizHawk.Bizware.DirectX/GamePad360.cs
@@ -121,7 +121,7 @@ namespace BizHawk.Bizware.DirectX
 		private XINPUT_STATE _state;
 
 		public int PlayerNumber => (int)_index0 + 1;
-
+		public bool IsConnected => _controller.IsConnected;
 		public readonly string InputNamePrefix;
 
 		private GamePad360(uint index0, Controller c)

--- a/src/BizHawk.Bizware.DirectX/GamePad360.cs
+++ b/src/BizHawk.Bizware.DirectX/GamePad360.cs
@@ -236,9 +236,6 @@ namespace BizHawk.Bizware.DirectX
 		public void SetVibration(int left, int right)
 		{
 			static ushort Conv(int i) => unchecked((ushort) ((i >> 15) & 0xFFFF));
-			
-			if (!_controller.IsConnected)
-				return;
 
 			try
 			{

--- a/src/BizHawk.Bizware.DirectX/GamePad360.cs
+++ b/src/BizHawk.Bizware.DirectX/GamePad360.cs
@@ -236,7 +236,15 @@ namespace BizHawk.Bizware.DirectX
 		public void SetVibration(int left, int right)
 		{
 			static ushort Conv(int i) => unchecked((ushort) ((i >> 15) & 0xFFFF));
-			_controller.SetVibration(new() { LeftMotorSpeed = Conv(left), RightMotorSpeed = Conv(right) });
+
+			try
+			{
+				_controller.SetVibration(new() { LeftMotorSpeed = Conv(left), RightMotorSpeed = Conv(right) });
+			}
+			catch (XInputException)
+			{
+				// Ignored, most likely the controller disconnected
+			}
 		}
 	}
 }

--- a/src/BizHawk.Bizware.DirectX/GamePad360.cs
+++ b/src/BizHawk.Bizware.DirectX/GamePad360.cs
@@ -236,6 +236,9 @@ namespace BizHawk.Bizware.DirectX
 		public void SetVibration(int left, int right)
 		{
 			static ushort Conv(int i) => unchecked((ushort) ((i >> 15) & 0xFFFF));
+			
+			if (!_controller.IsConnected)
+				return;
 
 			try
 			{


### PR DESCRIPTION
Fixes #2782

Skips polling on disconnected Xinput controllers, wraps SetVibration call in a try/catch