### PR TITLE
Skip DirectInput initialization for device names containing "Xbox One…

### DIFF
--- a/src/BizHawk.Bizware.DirectX/GamePad.cs
+++ b/src/BizHawk.Bizware.DirectX/GamePad.cs
@@ -26,7 +26,7 @@ namespace BizHawk.Bizware.DirectX
 				{
 					Console.WriteLine("joy device: {0} `{1}`", device.InstanceGuid, device.ProductName);
 
-					if (device.ProductName.Contains("XBOX 360"))
+					if (device.ProductName.Contains("XBOX 360") || device.ProductName.Contains("Xbox One") || device.ProductName.Contains("XINPUT"))
 						continue; // Don't input XBOX 360 controllers into here; we'll process them via XInput (there are limitations in some trigger axes when xbox pads go over xinput)
 
 					var joystick = new Joystick(_directInput, device.InstanceGuid);


### PR DESCRIPTION
…" or "XINPUT"

Fixes #2784

No idea if this is an exhaustive check but it should at least pick up official controllers and hopefully a lot of generic ones (such as 8bitdo)