### PR TITLE
N64 timing is bullshit

### DIFF
--- a/src/BizHawk.Client.Common/movie/HeaderKeys.cs
+++ b/src/BizHawk.Client.Common/movie/HeaderKeys.cs
@@ -21,6 +21,7 @@ namespace BizHawk.Client.Common
 		public const string SyncSettings = "SyncSettings";
 		public const string VBlankCount = "VBlankCount";
 		public const string CycleCount = "CycleCount";
+		public const string SecondCount = "SecondCount";
 		public const string Core = "Core";
 
 		public static bool Contains(string val) =>

--- a/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
+++ b/src/BizHawk.Client.Common/movie/MovieConversionExtensions.cs
@@ -8,6 +8,7 @@ using BizHawk.Emulation.Cores.Nintendo.Gameboy;
 using BizHawk.Emulation.Cores.Nintendo.GBHawk;
 using BizHawk.Emulation.Cores.Nintendo.SubNESHawk;
 using BizHawk.Emulation.Cores.Nintendo.SubGBHawk;
+using BizHawk.Emulation.Cores.Nintendo.N64;
 using BizHawk.Emulation.Cores.Sega.MasterSystem;
 using BizHawk.Emulation.Cores.Consoles.Sega.gpgx;
 using BizHawk.Emulation.Cores.Consoles.Sega.PicoDrive;
@@ -298,6 +299,11 @@ namespace BizHawk.Client.Common
 			if (emulator is SubNESHawk)
 			{
 				movie.HeaderEntries.Add(HeaderKeys.VBlankCount, "0");
+			}
+
+			if (emulator is N64)
+			{
+				movie.HeaderEntries.Add(HeaderKeys.SecondCount, "0");
 			}
 
 			movie.Core = ((CoreAttribute)Attribute

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.IO.cs
@@ -87,11 +87,16 @@ namespace BizHawk.Client.Common
 				{
 					Header[HeaderKeys.CycleCount] = subGb.CycleCount.ToString();
 				}
+				else if (Emulator is Emulation.Cores.Nintendo.N64.N64 n64)
+				{
+					Header[HeaderKeys.SecondCount] = n64.SecondCount.ToString();
+				}
 			}
 			else
 			{
 				Header.Remove(HeaderKeys.CycleCount);
 				Header.Remove(HeaderKeys.VBlankCount);
+				Header.Remove(HeaderKeys.SecondCount);
 			}
 		}
 

--- a/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
+++ b/src/BizHawk.Client.Common/movie/bk2/Bk2Movie.cs
@@ -76,6 +76,10 @@ namespace BizHawk.Client.Common
 					double cyclesPerSecond = PlatformFrameRates.GetFrameRate("GB_Clock", IsPal);
 					dblSeconds = numCycles / cyclesPerSecond;
 				}
+				else if (Header.ContainsKey(HeaderKeys.SecondCount))
+				{
+					dblSeconds = Convert.ToDouble(Header[HeaderKeys.SecondCount]);
+				}
 				else
 				{
 					ulong numFrames = (ulong) FrameCount;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
@@ -27,6 +27,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			writer.Write(IsLagFrame);
 			writer.Write(LagCount);
 			writer.Write(Frame);
+			writer.Write(SecondCount);
 		}
 
 		public void LoadStateBinary(BinaryReader reader)
@@ -49,6 +50,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			IsLagFrame = reader.ReadBoolean();
 			LagCount = reader.ReadInt32();
 			Frame = reader.ReadInt32();
+			SecondCount = reader.ReadInt32();
 		}
 
 		private readonly byte[] SaveStatePrivateBuff = new byte[16788288 + 1024];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.IStatable.cs
@@ -50,7 +50,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			IsLagFrame = reader.ReadBoolean();
 			LagCount = reader.ReadInt32();
 			Frame = reader.ReadInt32();
-			SecondCount = reader.ReadInt32();
+			SecondCount = reader.ReadDouble();
 		}
 
 		private readonly byte[] SaveStatePrivateBuff = new byte[16788288 + 1024];

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64.cs
@@ -159,6 +159,12 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 
 		public bool IsOverridingUserExpansionSlotSetting { get; set; }
 
+		public double SecondCount
+		{
+			get => _audioProvider._seconds;
+			set => _audioProvider._seconds = value;
+		}
+
 		public void Dispose()
 		{
 			RunThreadAction(() =>
@@ -259,6 +265,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			Frame = 0;
 			LagCount = 0;
 			IsLagFrame = false;
+			SecondCount = 0;
 		}
 
 		public bool DeterministicEmulation => false;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Audio.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64Audio.cs
@@ -14,6 +14,11 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 		private readonly mupen64plusApi coreAPI;
 
 		/// <summary>
+		/// seconds audio has played back
+		/// </summary>
+		public double _seconds { get; set; }
+
+		/// <summary>
 		/// Buffer for audio data
 		/// </summary>
 		private short[] audioBuffer = new short[0];
@@ -67,6 +72,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 
 			if (audioBufferSize > 0)
 			{
+				_seconds += audioBufferSize / 2.0 / SamplingRate;
 				api.GetAudioBuffer(audioBuffer);
 				if (RenderSound)
 					Resampler.EnqueueSamples(audioBuffer, audioBufferSize / 2);


### PR DESCRIPTION
This is an attempt to correct https://github.com/TASVideos/BizHawk/issues/2838 likely done horribly wrong. I am not an expert on N64, and hooking in audio for timing seemed to produce the most sane time (but it's still slightly off compared to sync to audio dumps, so I do not know what is differing).

EDIT: For testing I'm using the new 1 Key SM64 TAS, and the audio timing method I hooked up gives a time of 4:16.616. A Sync to Audio video dump however produces a 4:16.366 time, so the audio timing method hooked up appears off, and I do not know what would be differing between those times.

This PR is more just for feedback on what the fuck should be done regarding whatever the fuck Mupen is doing for timing, or whether I am just crazy.