### PR TITLE
Always initialize MMF + Implement new LUA functions

### DIFF
--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Client.Common
 			return APIs.Comm.Sockets.SendString(SendString);
 		}
 
-		[LuaMethod("socketServerSendBytes", "sends a string to the Socket server")]
+		[LuaMethod("socketServerSendBytes", "sends bytes to the Socket server")]
 		public int SocketServerSendBytes(LuaTable byteArray)
 		{
 			if (!CheckSocketServer()) return -1;
@@ -133,43 +133,55 @@ namespace BizHawk.Client.Common
 		[LuaMethod("mmfSetFilename", "Sets the filename for the screenshots")]
 		public void MmfSetFilename(string filename)
 		{
-			CheckMmf();
 			APIs.Comm.MMF.Filename = filename;
 		}
 
 		[LuaMethod("mmfGetFilename", "Gets the filename for the screenshots")]
 		public string MmfGetFilename()
 		{
-			CheckMmf();
-			return APIs.Comm.MMF?.Filename;
+			return APIs.Comm.MMF.Filename;
 		}
 
 		[LuaMethod("mmfScreenshot", "Saves screenshot to memory mapped file")]
 		public int MmfScreenshot()
 		{
-			CheckMmf();
+			if (APIs.Comm.MMF.Filename == null)
+			{
+				Log("Memory mapped filename was not initialized, please initialize it via the command line");
+				return -1;
+			}
 			return APIs.Comm.MMF.ScreenShotToFile();
 		}
 
 		[LuaMethod("mmfWrite", "Writes a string to a memory mapped file")]
 		public int MmfWrite(string mmf_filename, string outputString)
 		{
-			CheckMmf();
 			return APIs.Comm.MMF.WriteToFile(mmf_filename, outputString);
+		}
+		[LuaMethod("mmfWriteBytes", "Write bytes to a memory mapped file")]
+		public int MmfWriteBytes(string mmf_filename, LuaTable byteArray)
+		{
+			return APIs.Comm.MMF.WriteToFile(mmf_filename, _th.EnumerateValues<double>(byteArray).Select(d => (byte)d).ToArray());
+		}
+		[LuaMethod("mmfCopyFromMemory", "Copy a section of the memory to a memory mapped file")]
+		public int MmfCopyFromMemory(string mmf_filename, long addr, int length, string domain)
+		{
+			return APIs.Comm.MMF.WriteToFile(mmf_filename, APIs.Memory.ReadByteRange(addr, length, domain).ToArray());
+		}
+		[LuaMethod("mmfCopyToMemory", "Copy a memory mapped file to a section of the memory")]
+		public void MmfCopyToMemory(string mmf_filename, long addr, int length, string domain)
+		{
+			APIs.Memory.WriteByteRange(addr, new List<byte>(APIs.Comm.MMF.ReadBytesFromFile(mmf_filename, length)), domain);
 		}
 		[LuaMethod("mmfRead", "Reads a string from a memory mapped file")]
 		public string MmfRead(string mmf_filename, int expectedSize)
 		{
-			CheckMmf();
-			return APIs.Comm.MMF?.ReadFromFile(mmf_filename, expectedSize);
+			return APIs.Comm.MMF.ReadFromFile(mmf_filename, expectedSize);
 		}
-
-		private void CheckMmf()
+		[LuaMethod("mmfReadBytes", "Reads bytes from a memory mapped file")]
+		public LuaTable MmfReadBytes(string mmf_filename, int expectedSize)
 		{
-			if (APIs.Comm.MMF == null)
-			{
-				Log("Memory mapped file was not initialized, please initialize it via the command line");
-			}
+			return _th.ListToTable(APIs.Comm.MMF.ReadBytesFromFile(mmf_filename, expectedSize));
 		}
 
 		// All HTTP related methods

--- a/src/BizHawk.Client.Common/lua/CommonLibs/MemoryLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/MemoryLuaLibrary.cs
@@ -47,12 +47,23 @@ namespace BizHawk.Client.Common
 		public void WriteByte(long addr, uint value, string domain = null) => APIs.Memory.WriteByte(addr, value, domain);
 
 		[LuaMethodExample("local nlmemrea = memory.readbyterange( 0x100, 30, mainmemory.getname( ) );")]
-		[LuaMethod("readbyterange", "Reads the address range that starts from address, and is length long. Returns the result into a table of key value pairs (where the address is the key).")]
+		[LuaMethod("readbyterange", "Reads the address range that starts from address, and is length long. Returns the result into a table of key value pairs (where the keys go from 0 to length-1).")]
 		public LuaTable ReadByteRange(long addr, int length, string domain = null) => _th.ListToTable(APIs.Memory.ReadByteRange(addr, length, domain));
 
+		[LuaMethodExample("")]
+		[LuaMethod("writebyterangeataddress", "Writes the given values as a contiguous block of unsigned bytes to a specific address")]
+		public void WriteByteRangeAtAddress(LuaTable memoryblock, long addr, string domain = null)
+		{
+			int i = 0;
+			foreach (var v in _th.EnumerateValues<double>(memoryblock))
+			{
+				APIs.Memory.WriteByte(addr+i, (uint)v, domain);
+				i++;
+			}
+		}
 		/// <remarks>TODO C# version requires a contiguous address range</remarks>
 		[LuaMethodExample("")]
-		[LuaMethod("writebyterange", "Writes the given values to the given addresses as unsigned bytes")]
+		[LuaMethod("writebyterange", "Writes all the values of the table (as unsigned bytes) to the address indicated by the associated key")]
 		public void WriteByteRange(LuaTable memoryblock, string domain = null)
 		{
 #if true

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -605,9 +605,7 @@ namespace BizHawk.Client.EmuHawk
 				_argParser.HTTPAddresses == null
 					? null
 					: new HttpCommunication(NetworkingTakeScreenshot, _argParser.HTTPAddresses.Value.UrlGet, _argParser.HTTPAddresses.Value.UrlPost),
-				_argParser.MMFFilename == null
-					? null
-					: new MemoryMappedFiles(NetworkingTakeScreenshot, _argParser.MMFFilename),
+				new MemoryMappedFiles(NetworkingTakeScreenshot, _argParser.MMFFilename),
 				_argParser.SocketAddress == null
 					? null
 					: new SocketServer(NetworkingTakeScreenshot, _argParser.SocketAddress.Value.IP, _argParser.SocketAddress.Value.Port)


### PR DESCRIPTION
This commit adresses two things:

1. Currently, the MMF LUA functions are only available if Bizhawk is started with the "--mmf=filename" flag.
I think this is not intuitive, because we should not have to specify a filename in order to active MMF functions
as the given "filename" is only used for "mmfScreenshot" (and even for this function, the filename can be set in the LUA).
I changed this behavior so that MMF functions are always available, and "mmfScreenshot" will fail with a log if
no filename has been specified by the command line nor by the LUA script.

2. I have added several LUA functions:

- "memory.writebyterangeataddress": This is because the function "memory.writebyterange" does not match with what "memory.readbyterange" returns...
"memory.readbyterange" returns a table with the keys going from 0 to len-1, while "memory.writebyterange" returns a table with each key being the full address (not starting at 0).
Actually, "memory.writebyterange" is not only for writing a range, by any set of addresses.
On the other hand, the new function "memory.writebyterangeataddress" has a behavior similar to "memory.readbyterange" or "comm.socketServerSendBytes":
the lua table given as argument is seen as an array instead of an (address, value) dictionnary.

- "mmfWriteBytes", "mmfReadBytes": to send/read a sequence of bytes to/from a memory mapped file

- "mmfCopyToMemory", "mmfCopyFromMemory": to copy the content of a memory mapped file to a given location in the emulator memory (and the other direction).
Note that this could be achieved directly in the LUA script with the combination of "memory.readbyterange" and "mmfWriteBytes", but is is A LOT slower
(probably because of the type conversions). Also note that I personaly need these functions in order to be able to efficiently read/write to the game memory
from an external tool.