### PR TITLE
Always initialize MMF LUA functions + Add some MMF LUA functions

### DIFF
--- a/src/BizHawk.Client.Common/Api/MemoryMappedFiles.cs
+++ b/src/BizHawk.Client.Common/Api/MemoryMappedFiles.cs
@@ -27,7 +27,15 @@ namespace BizHawk.Client.Common
 			return Encoding.UTF8.GetString(bytes);
 		}
 
-		public int ScreenShotToFile() => WriteToFile(Filename, _takeScreenshotCallback());
+		public int ScreenShotToFile()
+		{
+			if (Filename is null)
+			{
+				Console.WriteLine("MMF screenshot target not set; start EmuHawk with `--mmf=filename`");
+				return 0;
+			}
+			return WriteToFile(Filename, _takeScreenshotCallback());
+		}
 
 		public int WriteToFile(string filename, byte[] outputBytes)
 		{

--- a/src/BizHawk.Client.Common/Api/MemoryMappedFiles.cs
+++ b/src/BizHawk.Client.Common/Api/MemoryMappedFiles.cs
@@ -21,10 +21,21 @@ namespace BizHawk.Client.Common
 
 		public string ReadFromFile(string filename, int expectedSize)
 		{
-			using var viewAccessor = MemoryMappedFile.OpenExisting(filename).CreateViewAccessor();
+			var bytes = ReadBytesFromFile(filename, expectedSize);
+			return Encoding.UTF8.GetString(bytes);
+		}
+
+		public byte[] ReadBytesFromFile(string filename, int expectedSize)
+		{
+			if (!_mmfFiles.TryGetValue(filename, out var mmfFile))
+			{
+				mmfFile = _mmfFiles[filename] = MemoryMappedFile.OpenExisting(filename);
+			}
+
+			using var viewAccessor = mmfFile.CreateViewAccessor(0, expectedSize, MemoryMappedFileAccess.Read);
 			var bytes = new byte[expectedSize];
 			viewAccessor.ReadArray(0, bytes, 0, expectedSize);
-			return Encoding.UTF8.GetString(bytes);
+			return bytes;
 		}
 
 		public int ScreenShotToFile()

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -153,10 +153,30 @@ namespace BizHawk.Client.Common
 		{
 			return APIs.Comm.MMF.WriteToFile(mmf_filename, outputString);
 		}
+		[LuaMethod("mmfWriteBytes", "Write bytes to a memory mapped file")]
+		public int MmfWriteBytes(string mmf_filename, LuaTable byteArray)
+		{
+			return APIs.Comm.MMF.WriteToFile(mmf_filename, _th.EnumerateValues<double>(byteArray).Select(d => (byte)d).ToArray());
+		}
+		[LuaMethod("mmfCopyFromMemory", "Copy a section of the memory to a memory mapped file")]
+		public int MmfCopyFromMemory(string mmf_filename, long addr, int length, string domain)
+		{
+			return APIs.Comm.MMF.WriteToFile(mmf_filename, APIs.Memory.ReadByteRange(addr, length, domain).ToArray());
+		}
+		[LuaMethod("mmfCopyToMemory", "Copy a memory mapped file to a section of the memory")]
+		public void MmfCopyToMemory(string mmf_filename, long addr, int length, string domain)
+		{
+			APIs.Memory.WriteByteRange(addr, new List<byte>(APIs.Comm.MMF.ReadBytesFromFile(mmf_filename, length)), domain);
+		}
 		[LuaMethod("mmfRead", "Reads a string from a memory mapped file")]
 		public string MmfRead(string mmf_filename, int expectedSize)
 		{
 			return APIs.Comm.MMF.ReadFromFile(mmf_filename, expectedSize);
+		}
+		[LuaMethod("mmfReadBytes", "Reads bytes from a memory mapped file")]
+		public LuaTable MmfReadBytes(string mmf_filename, int expectedSize)
+		{
+			return _th.ListToTable(APIs.Comm.MMF.ReadBytesFromFile(mmf_filename, expectedSize));
 		}
 
 		// All HTTP related methods

--- a/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
+++ b/src/BizHawk.Client.Common/lua/CommonLibs/CommLuaLibrary.cs
@@ -57,7 +57,7 @@ namespace BizHawk.Client.Common
 			return APIs.Comm.Sockets.SendString(SendString);
 		}
 
-		[LuaMethod("socketServerSendBytes", "sends a string to the Socket server")]
+		[LuaMethod("socketServerSendBytes", "sends bytes to the Socket server")]
 		public int SocketServerSendBytes(LuaTable byteArray)
 		{
 			if (!CheckSocketServer()) return -1;
@@ -133,43 +133,30 @@ namespace BizHawk.Client.Common
 		[LuaMethod("mmfSetFilename", "Sets the filename for the screenshots")]
 		public void MmfSetFilename(string filename)
 		{
-			CheckMmf();
 			APIs.Comm.MMF.Filename = filename;
 		}
 
 		[LuaMethod("mmfGetFilename", "Gets the filename for the screenshots")]
 		public string MmfGetFilename()
 		{
-			CheckMmf();
-			return APIs.Comm.MMF?.Filename;
+			return APIs.Comm.MMF.Filename;
 		}
 
 		[LuaMethod("mmfScreenshot", "Saves screenshot to memory mapped file")]
 		public int MmfScreenshot()
 		{
-			CheckMmf();
 			return APIs.Comm.MMF.ScreenShotToFile();
 		}
 
 		[LuaMethod("mmfWrite", "Writes a string to a memory mapped file")]
 		public int MmfWrite(string mmf_filename, string outputString)
 		{
-			CheckMmf();
 			return APIs.Comm.MMF.WriteToFile(mmf_filename, outputString);
 		}
 		[LuaMethod("mmfRead", "Reads a string from a memory mapped file")]
 		public string MmfRead(string mmf_filename, int expectedSize)
 		{
-			CheckMmf();
-			return APIs.Comm.MMF?.ReadFromFile(mmf_filename, expectedSize);
-		}
-
-		private void CheckMmf()
-		{
-			if (APIs.Comm.MMF == null)
-			{
-				Log("Memory mapped file was not initialized, please initialize it via the command line");
-			}
+			return APIs.Comm.MMF.ReadFromFile(mmf_filename, expectedSize);
 		}
 
 		// All HTTP related methods

--- a/src/BizHawk.Client.EmuHawk/MainForm.cs
+++ b/src/BizHawk.Client.EmuHawk/MainForm.cs
@@ -605,9 +605,7 @@ namespace BizHawk.Client.EmuHawk
 				_argParser.HTTPAddresses == null
 					? null
 					: new HttpCommunication(NetworkingTakeScreenshot, _argParser.HTTPAddresses.Value.UrlGet, _argParser.HTTPAddresses.Value.UrlPost),
-				_argParser.MMFFilename == null
-					? null
-					: new MemoryMappedFiles(NetworkingTakeScreenshot, _argParser.MMFFilename),
+				new MemoryMappedFiles(NetworkingTakeScreenshot, _argParser.MMFFilename),
 				_argParser.SocketAddress == null
 					? null
 					: new SocketServer(NetworkingTakeScreenshot, _argParser.SocketAddress.Value.IP, _argParser.SocketAddress.Value.Port)


### PR DESCRIPTION
This commit adresses two things:

1. Currently, the MMF LUA functions are only available if Bizhawk is started with the "--mmf=filename" flag.
I think this is not intuitive, because we should not have to specify a filename in order to active MMF functions
as the given "filename" is only used for "mmfScreenshot" (and even for this function, the filename can be set in the LUA).
I changed this behavior so that MMF functions are always available, and "mmfScreenshot" will fail with a log if
no filename has been specified by the command line nor by the LUA script.

2. I have added several LUA functions:

- "mmfWriteBytes", "mmfReadBytes": to send/read a sequence of bytes to/from a memory mapped file
- "mmfCopyToMemory", "mmfCopyFromMemory": to copy the content of a memory mapped file to a given location in the emulator memory (and the other direction).
Note that this could be achieved directly in the LUA script with the combination of "memory.readbyterange" and "mmfWriteBytes", but is is A LOT slower
(probably because of the type conversions). Also note that I personaly need these functions in order to be able to efficiently read/write to the game memory
from an external tool.

