### PR TITLE
Add HandleWatchSizeSelected() to allow user-initiated watch size changes to be ignored if they reset the setting to the same value

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Watch/RamSearch.cs
@@ -631,6 +631,14 @@ namespace BizHawk.Client.EmuHawk
 			_searches.SetPreviousType(type);
 		}
 
+		private void HandleWatchSizeSelected(WatchSize newWatchSize)
+		{
+			if (_settings.Size != newWatchSize)
+			{
+				SetSize(newWatchSize);
+			}
+		}
+
 		private void SetSize(WatchSize size)
 		{
 			_settings.Size = size;
@@ -1124,17 +1132,17 @@ namespace BizHawk.Client.EmuHawk
 
 		private void ByteMenuItem_Click(object sender, EventArgs e)
 		{
-			SetSize(WatchSize.Byte);
+			HandleWatchSizeSelected(WatchSize.Byte);
 		}
 
 		private void WordMenuItem_Click(object sender, EventArgs e)
 		{
-			SetSize(WatchSize.Word);
+			HandleWatchSizeSelected(WatchSize.Word);
 		}
 
 		private void DWordMenuItem_Click_Click(object sender, EventArgs e)
 		{
-			SetSize(WatchSize.DWord);
+			HandleWatchSizeSelected(WatchSize.DWord);
 		}
 
 		private void CheckMisalignedMenuItem_Click(object sender, EventArgs e)
@@ -1419,7 +1427,7 @@ namespace BizHawk.Client.EmuHawk
 				return;
 			}
 
-			SetSize(SelectedSize);
+			HandleWatchSizeSelected(SelectedSize);
 		}
 
 		private void DisplayTypeDropdown_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
fixes #2857 selecting the same combo box value in ram search should not reset the search

The issue was that a selected index changed event was always fired when an item was selected from the watch size dropdown, even if the selected setting was the same as the current setting. SetSize() was always called in this case, which would result in NewSearch() being called, even though the size was just being set to the same setting it was before.

This fix addresses the issue by separating out setting the size (SetSize()) from handling a size selection (HandleWatchSizeSelected()). In HandleWatchSizeSelected(), SetSize() will only be called if the size setting has actually changed. This also allows SetSize() to still be called directly to always perform a setting change. This allows for the initialization case where the size setting is already 1, but initialization needs to be performed (there is no "uninitialized" setting to differentiate this case).

Still need to test a bit
* Ensure searches are initialized as expected on startup
* Ensure setting the size to the same setting via the menu or dropdown doesn't start a new search
* Ensure setting the size to a different setting via the menu or drop does start a new search