### PR TITLE
Fix bug with delta state rewinder

### DIFF
--- a/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
+++ b/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
@@ -106,7 +106,7 @@ namespace BizHawk.Client.Common
 				_count++;
 				return;
 			}
-			if (!_buffer.WouldCapture(_masterFrame, frame))
+			if (!_buffer.WouldCapture(frame - _masterFrame))
 				return;
 
 			{

--- a/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
+++ b/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
@@ -106,7 +106,7 @@ namespace BizHawk.Client.Common
 				_count++;
 				return;
 			}
-			if (!_buffer.WillCapture(_masterFrame))
+			if (!_buffer.WouldCapture(_masterFrame, frame))
 				return;
 
 			{
@@ -189,7 +189,7 @@ namespace BizHawk.Client.Common
 						_masterLength = (int)sss.Position;
 						_masterFrame = frame;
 						_count++;
-					});
+					}, force: true);
 				});
 			}
 		}

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -170,15 +170,13 @@ namespace BizHawk.Client.Common
 		}
 
 		/// <summary>
-		/// Predict whether Capture() would capture a state, assuming another state that doesn't currently exist
-		/// is added first.  This is really weird and is leaking impl details so ZeldaWinder can use it.  Sorry!
+		/// Predict whether Capture() would capture a state, assuming a particular frame delta.
 		/// </summary>
-		/// <param name="frameAddedFirst">A frame that will be force captured before the frame we're about to capture here</param>
-		/// <param name="frameToMaybeCapture">The frame that we might capture.</param>
-		/// <returns>Whether Capture(frameToMaybeCapture) would actually capture, assuming Capture(frameAddedFirst, force = true) already happened</returns>
-		public bool WouldCapture(int frameAddedFirst, int frameToMaybeCapture)
+		/// <param name="frameDelta">The assumed frame delta.  Normally this will be equal to `nextStateFrame - GetState(Count - 1).Frame`.</param>
+		/// <returns>Whether Capture(nextStateFrame) would actually capture, assuming the frameDelta matched.</returns>
+		public bool WouldCapture(int frameDelta)
 		{
-			return ShouldCaptureForFrameDiff(frameToMaybeCapture - frameAddedFirst);
+			return ShouldCaptureForFrameDiff(frameDelta);
 		}
 
 		/// <summary>


### PR DESCRIPTION
When the deltastate rewinder needed to not capture a frame (interval > 1), it would get stuck and fail to capture any further frames.  Because the underlying zwinder buffer is one state behind in what it's storing, we need to adjust frame calc logic accordingly.

Closes https://github.com/TASVideos/BizHawk/issues/2866.