### PR TITLE
Add new GLideN64 settings

### DIFF
--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
@@ -11,7 +11,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			{
 				UseDefaultHacks = true;
 
-				BackgroundsMode = 1;
+				BackgroundsMode = BackgroundsRenderingMode.Stripped;
 				MultiSampling = 0;
 				AspectRatio = AspectRatioMode.FourThree;
 				BufferSwapMode = SwapMode.OnVIUpdateCall;

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/N64/N64SyncSettings.GLideN64.cs
@@ -11,6 +11,7 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			{
 				UseDefaultHacks = true;
 
+				BackgroundsMode = 1;
 				MultiSampling = 0;
 				AspectRatio = AspectRatioMode.FourThree;
 				BufferSwapMode = SwapMode.OnVIUpdateCall;
@@ -46,6 +47,8 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 				txCacheSize = 100;
 				txHiresEnable = false;
 				txHiresFullAlphaChannel = false;
+				txEnhancedTextureFileStorage = false;
+				txHiresTextureFileStorage = false;
 				txHresAltCRC = false;
 				txDump = false;
 				txCacheCompression = true;
@@ -69,6 +72,21 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 				OverscanPalLeft = 0;
 				OverscanPalRight = 0;
 			}
+			
+			public enum BackgroundsRenderingMode
+			{
+				[Description("One Piece")]
+				OnePiece = 0,
+
+				[Description("Stripped")]
+				Stripped = 1
+			}
+			
+			[DefaultValue(BackgroundsRenderingMode.Stripped)]
+			[DisplayName("Background Rendering Mode")]
+			[Description("Render backgrounds mode (HLE only). (0=One Piece (fast), 1=Stripped (precise))")]
+			[Category("Emulation")]
+			public BackgroundsRenderingMode BackgroundsMode { get; set; }
 
 			[DefaultValue(true)]
 			[DisplayName("Use Default Hacks")]
@@ -480,7 +498,19 @@ namespace BizHawk.Emulation.Cores.Nintendo.N64
 			[Description("Allow to use alpha channel of high-res texture fully.")]
 			[Category("Texture Enhancement")]
 			public bool txHiresFullAlphaChannel { get; set; }
+			
+			[DefaultValue(false)]
+			[DisplayName("Texture Enhancement File Storage")]
+			[Description("Use file storage instead of memory cache for enhanced textures.")]
+			[Category("Texture Enhancement")]
+			public bool txEnhancedTextureFileStorage { get; set; }
 
+			[DefaultValue(false)]
+			[DisplayName("Texture Hires File Storage")]
+			[Description("Use file storage instead of memory cache for HD textures.")]
+			[Category("Texture Enhancement")]
+			public bool txHiresTextureFileStorage { get; set; }
+			
 			[DefaultValue(false)]
 			[DisplayName("Texture Hres Alt CRC")]
 			[Description("Use alternative method of paletted textures CRC calculation.")]


### PR DESCRIPTION
Needs the updated version of GLideN64 that is commited to master to be useful first:
https://github.com/TASVideos/GLideN64/tree/Branch_bizhawk

That version will not work unless threaded video is turned off.
@vadosnaprimer Can you please update the .dll file of the repo with a working 2020-02 build of GLideN64?

These settings are added:
- BackgroundsMode: Sets the rendering mode of large background images, like the JFIF backgrounds of Ocarina of Time. Defaults to stripped as it is more accurate. A user may want to change this to one piece mainly for texture pack usage or performance.
- txEnhancedTextureFileStorage: Use HTS cache instead of HTC for enhanced (upscaled) textures. Defaults to HTC.
- txHiresTextureFileStorage: Use HTS cache instead of HTC for HD textures. Textures are streamed from disk, eliminating the need to prefetch the textures at load. Boots the game near instantly and decreases RAM usage. Defaults to HTC.