### PR TITLE
Fix #2877

### DIFF
--- a/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
+++ b/src/BizHawk.Client.Common/rewind/ZeldaWinder.cs
@@ -231,31 +231,27 @@ namespace BizHawk.Client.Common
 			if (!_active || _count == 0)
 				return false;
 
-			if (_masterFrame == frameToAvoid && _count > 1)
+			if (_masterFrame == frameToAvoid)
 			{
-				var index = _buffer.Count - 1;
-				RefillMaster(_buffer.GetState(index));
-				_buffer.InvalidateEnd(index);
-				_stateSource.LoadStateBinary(new BinaryReader(new MemoryStream(_master, 0, _masterLength, false)));
+				if (_count > 1)
+				{
+					var index = _buffer.Count - 1;
+					RefillMaster(_buffer.GetState(index));
+					_buffer.InvalidateEnd(index);
+					_stateSource.LoadStateBinary(new BinaryReader(new MemoryStream(_master, 0, _masterLength, false)));
+				}
+				else
+				{
+					_stateSource.LoadStateBinary(new BinaryReader(new MemoryStream(_master, 0, _masterLength, false)));
+					_masterFrame = -1;
+				}
 				_count--;
 			}
 			else
 			{
+				// The emulator will frame advance without giving us a chance to
+				// re-capture this frame, so we shouldn't invalidate this state just yet.
 				_stateSource.LoadStateBinary(new BinaryReader(new MemoryStream(_master, 0, _masterLength, false)));
-				Work(() =>
-				{
-					var index = _buffer.Count - 1;
-					if (index >= 0)
-					{
-						RefillMaster(_buffer.GetState(index));
-						_buffer.InvalidateEnd(index);
-					}
-					else
-					{
-						_masterFrame = -1;
-					}
-					_count--;
-				});
 			}
 			return true;
 		}

--- a/src/BizHawk.Client.Common/rewind/Zwinder.cs
+++ b/src/BizHawk.Client.Common/rewind/Zwinder.cs
@@ -66,14 +66,21 @@ namespace BizHawk.Client.Common
 				return false;
 			var index = Count - 1;
 			var state = _buffer.GetState(index);
-			if (state.Frame == frameToAvoid && Count > 1)
+			if (state.Frame == frameToAvoid)
 			{
-				// Do not decrement index again.  We will "head" this state and not pop it since it will be advanced past
-				// without an opportunity to capture.  This is a bit hackish.
-				state = _buffer.GetState(index - 1);
+				if (Count > 1)
+				{
+					state = _buffer.GetState(index - 1);
+				}
+				_stateSource.LoadStateBinary(new BinaryReader(state.GetReadStream()));
+				_buffer.InvalidateEnd(index);
 			}
-			_stateSource.LoadStateBinary(new BinaryReader(state.GetReadStream()));
-			_buffer.InvalidateEnd(index);
+			else
+			{
+				// The emulator will frame advance without giving us a chance to
+				// re-capture this frame, so we shouldn't invalidate this state just yet.
+				_stateSource.LoadStateBinary(new BinaryReader(state.GetReadStream()));
+			}
 			return true;
 		}
 


### PR DESCRIPTION
Fix #2877 This fix affects the rewind function (both in Zwinder and Zeldawinder)

https://github.com/TASVideos/BizHawk/blob/fd0d5a38c780dc167496a459deb8ee31ca8b40b8/src/BizHawk.Client.Common/rewind/Zwinder.cs#L63-L78

The main difficulty here is that the emulator frame advances after loading a rewind, so we need to avoid loading a rewind from just 1 frame ago.
In this function, we need to handle 3 dinstinct cases (excluding the trivial case where we return false).

1. `state.Frame == frameToAvoid` and `Count = 1`.
2. `state.Frame == frameToAvoid` and `Count > 1`.
3. `state.Frame != frameToAvoid`.

Here's how I think these cases should be handeled:

1. `state.Frame == frameToAvoid` and `Count = 1`.
   - Load the 1 state we have, then invalidate the rewind buffer (then it's empty).
   - Note: This is then handeled by the emulator by not frame advancing. In particular, we need to invalidate the state to avoid capturing it again.
   - The current master also handles this case this way.
2. `state.Frame == frameToAvoid` and `Count > 1`.
   - Load the second-newest state, then invalidate the newest state.
   - The current master also handles this case this way.
3. `state.Frame != frameToAvoid`.
   - Load the newest state, but do *not* invalidate it.
   - This case can only happen if RewindInterval > 1.
   - The current master *does* invalidate the newest state, which leads to the linked issue.
