### PR TITLE
Set firmwares declared with `FirmwareAndOption` to `Ideal` status instead of `Acceptable`

### DIFF
--- a/src/BizHawk.Emulation.Common/Database/FirmwareDatabase.cs
+++ b/src/BizHawk.Emulation.Common/Database/FirmwareDatabase.cs
@@ -47,7 +47,7 @@ namespace BizHawk.Emulation.Common
 			void FirmwareAndOption(string hash, long size, string systemId, string id, string name, string desc)
 			{
 				Firmware(systemId, id, desc);
-				Option(systemId, id, File(hash, size, name, desc), FirmwareOptionStatus.Acceptable); //TODO should the single option for these firmwares be Ideal?
+				Option(systemId, id, File(hash, size, name, desc), FirmwareOptionStatus.Ideal);
 			}
 
 			// FDS has two OK variants  (http://tcrf.net/Family_Computer_Disk_System)


### PR DESCRIPTION
(`FirmwareAndOption` being the helper which declares a record *with a single option*.) These have always received the default of `Acceptable` since the status enum was introduced in f43859f42, with the exception of the FDS "Nintendo" BIOS (the first declaration, see b9e784e15). I believe that was unintentional.

This PR changes the *default* param value in `FirmwareAndOption`; individual calls may still override it with `Acceptable` if that is desired.

see also https://github.com/TASVideos/BizHawk/issues/2825#issuecomment-871231323 (icons for `Ideal` and `Acceptable` swapped?)