### PR TITLE
Add config option for rewinds every fixed number of frames.

### DIFF
--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -49,7 +49,7 @@
 		public bool UseDelta { get; set; }
 		public bool Enabled { get; set; } = true;
 		public long BufferSize { get; set; } = 512; // in mb
-		public bool UseFixedRewindInterval { get; set; } = true;
+		public bool UseFixedRewindInterval { get; set; } = false;
 		public int TargetFrameLength { get; set; } = 600;
 		public int TargetRewindInterval { get; set; } = 5;
 		public IRewindSettings.BackingStoreType BackingStore { get; set; } = IRewindSettings.BackingStoreType.Memory;

--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -20,9 +20,18 @@
 		long BufferSize { get; }
 
 		/// <summary>
+		/// Specifies whether TargetFrameLength or TargetRewindFrequency is used.
+		/// </summary>
+		public bool ConsistentRewindFrequency { get; }
+		
+		/// <summary>
 		/// Desired frame length (number of emulated frames you can go back before running out of buffer)
 		/// </summary>
 		int TargetFrameLength { get; }
+		/// <summary>
+		/// Desired rewind frequency (number of emulated frames you can go back per rewind)
+		/// </summary>
+		int TargetRewindFrequency { get; }
 
 		public enum BackingStoreType
 		{
@@ -39,7 +48,9 @@
 		public bool UseDelta { get; set; }
 		public bool Enabled { get; set; } = true;
 		public long BufferSize { get; set; } = 512; // in mb
+		public bool ConsistentRewindFrequency { get; set; } = true;
 		public int TargetFrameLength { get; set; } = 600;
+		public int TargetRewindFrequency { get; set; } = 5;
 		public IRewindSettings.BackingStoreType BackingStore { get; set; } = IRewindSettings.BackingStoreType.Memory;
 	}
 }

--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -23,11 +23,12 @@
 		/// Specifies whether TargetFrameLength or TargetRewindInterval is used.
 		/// </summary>
 		public bool UseFixedRewindInterval { get; }
-		
+
 		/// <summary>
 		/// Desired frame length (number of emulated frames you can go back before running out of buffer)
 		/// </summary>
 		int TargetFrameLength { get; }
+
 		/// <summary>
 		/// Desired rewind interval (number of emulated frames you can go back per rewind)
 		/// </summary>

--- a/src/BizHawk.Client.Common/config/RewindConfig.cs
+++ b/src/BizHawk.Client.Common/config/RewindConfig.cs
@@ -20,18 +20,18 @@
 		long BufferSize { get; }
 
 		/// <summary>
-		/// Specifies whether TargetFrameLength or TargetRewindFrequency is used.
+		/// Specifies whether TargetFrameLength or TargetRewindInterval is used.
 		/// </summary>
-		public bool ConsistentRewindFrequency { get; }
+		public bool UseFixedRewindInterval { get; }
 		
 		/// <summary>
 		/// Desired frame length (number of emulated frames you can go back before running out of buffer)
 		/// </summary>
 		int TargetFrameLength { get; }
 		/// <summary>
-		/// Desired rewind frequency (number of emulated frames you can go back per rewind)
+		/// Desired rewind interval (number of emulated frames you can go back per rewind)
 		/// </summary>
-		int TargetRewindFrequency { get; }
+		int TargetRewindInterval { get; }
 
 		public enum BackingStoreType
 		{
@@ -48,9 +48,9 @@
 		public bool UseDelta { get; set; }
 		public bool Enabled { get; set; } = true;
 		public long BufferSize { get; set; } = 512; // in mb
-		public bool ConsistentRewindFrequency { get; set; } = true;
+		public bool UseFixedRewindInterval { get; set; } = true;
 		public int TargetFrameLength { get; set; } = 600;
-		public int TargetRewindFrequency { get; set; } = 5;
+		public int TargetRewindInterval { get; set; } = 5;
 		public IRewindSettings.BackingStoreType BackingStore { get; set; } = IRewindSettings.BackingStoreType.Memory;
 	}
 }

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
@@ -107,6 +107,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = CurrentUseCompression,
 				BufferSize = CurrentBufferSize,
+				ConsistentRewindFrequency = false,
 				TargetFrameLength = CurrentTargetFrameLength,
 				BackingStore = CurrentStoreType
 			};
@@ -117,6 +118,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = RecentUseCompression,
 				BufferSize = RecentBufferSize,
+				ConsistentRewindFrequency = false,
 				TargetFrameLength = RecentTargetFrameLength,
 				BackingStore = RecentStoreType
 			};
@@ -127,6 +129,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = GapsUseCompression,
 				BufferSize = GapsBufferSize,
+				ConsistentRewindFrequency = false,
 				TargetFrameLength = GapsTargetFrameLength,
 				BackingStore = GapsStoreType
 			};

--- a/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
+++ b/src/BizHawk.Client.Common/movie/tasproj/ZwinderStateManagerSettings.cs
@@ -107,7 +107,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = CurrentUseCompression,
 				BufferSize = CurrentBufferSize,
-				ConsistentRewindFrequency = false,
+				UseFixedRewindInterval = false,
 				TargetFrameLength = CurrentTargetFrameLength,
 				BackingStore = CurrentStoreType
 			};
@@ -118,7 +118,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = RecentUseCompression,
 				BufferSize = RecentBufferSize,
-				ConsistentRewindFrequency = false,
+				UseFixedRewindInterval = false,
 				TargetFrameLength = RecentTargetFrameLength,
 				BackingStore = RecentStoreType
 			};
@@ -129,7 +129,7 @@ namespace BizHawk.Client.Common
 			{
 				UseCompression = GapsUseCompression,
 				BufferSize = GapsBufferSize,
-				ConsistentRewindFrequency = false,
+				UseFixedRewindInterval = false,
 				TargetFrameLength = GapsTargetFrameLength,
 				BackingStore = GapsStoreType
 			};

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -55,16 +55,15 @@ namespace BizHawk.Client.Common
 				default:
 					throw new ArgumentException("Unsupported store type for ZwinderBuffer.");
 			}
-			if (settings.ConsistentRewindFrequency)
+			if (settings.UseFixedRewindInterval)
 			{
 				_fixedRewindInterval = true;
-				_targetRewindInterval = settings.TargetRewindFrequency;
+				_targetRewindInterval = settings.TargetRewindInterval;
 			}
 			else
 			{
 				_fixedRewindInterval = false;
 				_targetFrameLength = settings.TargetFrameLength;
-
 			}
 			_states = new StateInfo[STATEMASK + 1];
 			_useCompression = settings.UseCompression;
@@ -161,8 +160,8 @@ namespace BizHawk.Client.Common
 			long size = 1L << (int)Math.Floor(Math.Log(targetSize, 2));
 			return Size == size &&
 				_useCompression == settings.UseCompression &&
-				_fixedRewindInterval == settings.ConsistentRewindFrequency &&
-				(_fixedRewindInterval ? _targetRewindInterval == settings.TargetRewindFrequency : _targetFrameLength == settings.TargetFrameLength) &&
+				_fixedRewindInterval == settings.UseFixedRewindInterval &&
+				(_fixedRewindInterval ? _targetRewindInterval == settings.TargetRewindInterval : _targetFrameLength == settings.TargetFrameLength) &&
 				_backingStoreType == settings.BackingStore;
 		}
 
@@ -367,9 +366,9 @@ namespace BizHawk.Client.Common
 				ret = new ZwinderBuffer(new RewindConfig
 				{
 					BufferSize = (int)(size >> 20),
-					ConsistentRewindFrequency = false,
+					UseFixedRewindInterval = false,
 					TargetFrameLength = targetFrameLength,
-					TargetRewindFrequency = 5,
+					TargetRewindInterval = 5,
 					UseCompression = useCompression
 				});
 				if (ret.Size != size || ret._sizeMask != sizeMask)

--- a/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
+++ b/src/BizHawk.Client.Common/rewind/ZwinderBuffer.cs
@@ -55,7 +55,17 @@ namespace BizHawk.Client.Common
 				default:
 					throw new ArgumentException("Unsupported store type for ZwinderBuffer.");
 			}
-			_targetFrameLength = settings.TargetFrameLength;
+			if (settings.ConsistentRewindFrequency)
+			{
+				_fixedRewindInterval = true;
+				_targetRewindInterval = settings.TargetRewindFrequency;
+			}
+			else
+			{
+				_fixedRewindInterval = false;
+				_targetFrameLength = settings.TargetFrameLength;
+
+			}
 			_states = new StateInfo[STATEMASK + 1];
 			_useCompression = settings.UseCompression;
 		}
@@ -98,7 +108,9 @@ namespace BizHawk.Client.Common
 
 		private readonly long _sizeMask;
 
+		private readonly bool _fixedRewindInterval;
 		private readonly int _targetFrameLength;
+		private readonly int _targetRewindInterval;
 
 		private struct StateInfo
 		{
@@ -129,6 +141,11 @@ namespace BizHawk.Client.Common
 			{
 				return 1; // shrug
 			}
+			
+			if (_fixedRewindInterval)
+			{
+				return _targetRewindInterval;
+			}
 
 			// assume that the most recent state size is representative of stuff
 			var sizeRatio = Size / (float)_states[HeadStateIndex].Size;
@@ -144,7 +161,8 @@ namespace BizHawk.Client.Common
 			long size = 1L << (int)Math.Floor(Math.Log(targetSize, 2));
 			return Size == size &&
 				_useCompression == settings.UseCompression &&
-				_targetFrameLength == settings.TargetFrameLength &&
+				_fixedRewindInterval == settings.ConsistentRewindFrequency &&
+				(_fixedRewindInterval ? _targetRewindInterval == settings.TargetRewindFrequency : _targetFrameLength == settings.TargetFrameLength) &&
 				_backingStoreType == settings.BackingStore;
 		}
 
@@ -160,7 +178,7 @@ namespace BizHawk.Client.Common
 				// not much we can say here, so just take a state
 				return true;
 			}
-			return frameDiff >= ComputeIdealRewindInterval();		
+			return frameDiff >= ComputeIdealRewindInterval();
 		}
 
 		private bool ShouldCapture(int frame)
@@ -349,7 +367,9 @@ namespace BizHawk.Client.Common
 				ret = new ZwinderBuffer(new RewindConfig
 				{
 					BufferSize = (int)(size >> 20),
+					ConsistentRewindFrequency = false,
 					TargetFrameLength = targetFrameLength,
+					TargetRewindFrequency = 5,
 					UseCompression = useCompression
 				});
 				if (ret.Size != size || ret._sizeMask != sizeMask)

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
@@ -46,10 +46,8 @@
 			this.labelEx2 = new BizHawk.WinForms.Controls.LabelEx();
 			this.labelEx1 = new BizHawk.WinForms.Controls.LabelEx();
 			this.cbDeltaCompression = new System.Windows.Forms.CheckBox();
-			this.ConsistentIntervalBox = new System.Windows.Forms.CheckBox();
-			this.TargetRewindFrequencyNumeric = new System.Windows.Forms.NumericUpDown();
 			this.TargetFrameLengthNumeric = new System.Windows.Forms.NumericUpDown();
-			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
+			this.TargetRewindIntervalNumeric = new System.Windows.Forms.NumericUpDown();
 			this.EstTimeLabel = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.label11 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.ApproxFramesLabel = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -75,11 +73,13 @@
 			this.label16 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.BackupSavestatesCheckbox = new System.Windows.Forms.CheckBox();
 			this.label12 = new BizHawk.WinForms.Controls.LocLabelEx();
+			this.TargetFrameLengthRadioButton = new System.Windows.Forms.RadioButton();
+			this.TargetRewindIntervalRadioButton = new System.Windows.Forms.RadioButton();
 			((System.ComponentModel.ISupportInitialize)(this.BufferSizeUpDown)).BeginInit();
 			this.groupBox4.SuspendLayout();
 			this.locSingleRowFLP1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.TargetFrameLengthNumeric)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.TargetRewindFrequencyNumeric)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.TargetRewindIntervalNumeric)).BeginInit();
 			this.groupBox6.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarCompression)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.nudCompression)).BeginInit();
@@ -123,9 +123,9 @@
 			// UseCompression
 			// 
 			this.UseCompression.AutoSize = true;
-			this.UseCompression.Location = new System.Drawing.Point(15, 170);
+			this.UseCompression.Location = new System.Drawing.Point(15, 194);
 			this.UseCompression.Name = "UseCompression";
-			this.UseCompression.Size = new System.Drawing.Size(306, 17);
+			this.UseCompression.Size = new System.Drawing.Size(324, 17);
 			this.UseCompression.TabIndex = 5;
 			this.UseCompression.Text = "Use zlib compression (economizes buffer usage at cost of CPU)";
 			this.UseCompression.UseVisualStyleBackColor = true;
@@ -139,25 +139,25 @@
 			// 
 			// BufferSizeUpDown
 			// 
-			this.BufferSizeUpDown.Location = new System.Drawing.Point(0, 0);
+			this.BufferSizeUpDown.Location = new System.Drawing.Point(25, 3);
 			this.BufferSizeUpDown.Maximum = new decimal(new int[] {
-            15,
-            0,
-            0,
-            0});
+			15,
+			0,
+			0,
+			0});
 			this.BufferSizeUpDown.Minimum = new decimal(new int[] {
-            6,
-            0,
-            0,
-            0});
+			6,
+			0,
+			0,
+			0});
 			this.BufferSizeUpDown.Name = "BufferSizeUpDown";
 			this.BufferSizeUpDown.Size = new System.Drawing.Size(52, 20);
 			this.BufferSizeUpDown.TabIndex = 8;
 			this.BufferSizeUpDown.Value = new decimal(new int[] {
-            9,
-            0,
-            0,
-            0});
+			9,
+			0,
+			0,
+			0});
 			this.BufferSizeUpDown.ValueChanged += new System.EventHandler(this.BufferSizeUpDown_ValueChanged);
 			// 
 			// label3
@@ -192,12 +192,12 @@
 			// 
 			// groupBox4
 			// 
+			this.groupBox4.Controls.Add(this.TargetRewindIntervalRadioButton);
+			this.groupBox4.Controls.Add(this.TargetFrameLengthRadioButton);
 			this.groupBox4.Controls.Add(this.locSingleRowFLP1);
 			this.groupBox4.Controls.Add(this.cbDeltaCompression);
 			this.groupBox4.Controls.Add(this.TargetFrameLengthNumeric);
-			this.groupBox4.Controls.Add(this.ConsistentIntervalBox);
-			this.groupBox4.Controls.Add(this.TargetRewindFrequencyNumeric);
-			this.groupBox4.Controls.Add(this.label2);
+			this.groupBox4.Controls.Add(this.TargetRewindIntervalNumeric);
 			this.groupBox4.Controls.Add(this.UseCompression);
 			this.groupBox4.Controls.Add(this.RewindEnabledBox);
 			this.groupBox4.Controls.Add(this.label3);
@@ -213,7 +213,7 @@
 			this.groupBox4.Controls.Add(this.StateSizeLabel);
 			this.groupBox4.Location = new System.Drawing.Point(12, 12);
 			this.groupBox4.Name = "groupBox4";
-			this.groupBox4.Size = new System.Drawing.Size(371, 218);
+			this.groupBox4.Size = new System.Drawing.Size(371, 248);
 			this.groupBox4.TabIndex = 2;
 			this.groupBox4.TabStop = false;
 			this.groupBox4.Text = "RewindSettings";
@@ -249,72 +249,56 @@
 			// cbDeltaCompression
 			// 
 			this.cbDeltaCompression.AutoSize = true;
-			this.cbDeltaCompression.Location = new System.Drawing.Point(15, 193);
+			this.cbDeltaCompression.Location = new System.Drawing.Point(15, 217);
 			this.cbDeltaCompression.Name = "cbDeltaCompression";
-			this.cbDeltaCompression.Size = new System.Drawing.Size(149, 17);
+			this.cbDeltaCompression.Size = new System.Drawing.Size(332, 17);
 			this.cbDeltaCompression.TabIndex = 35;
 			this.cbDeltaCompression.Text = "Use delta compression (economizes buffer usage at cost of CPU)";
 			this.cbDeltaCompression.UseVisualStyleBackColor = true;
 			// 
-			// ConsistentIntervalBox
-			// 
-			this.ConsistentIntervalBox.AutoSize = true;
-			this.ConsistentIntervalBox.Location = new System.Drawing.Point(250, 135);
-			this.ConsistentIntervalBox.Name = "ConsistentIntervalBox";
-			this.ConsistentIntervalBox.Size = new System.Drawing.Size(100, 17);
-			this.ConsistentIntervalBox.TabIndex = 35;
-			this.ConsistentIntervalBox.Text = "Force consistent rewind intervals";
-			this.ConsistentIntervalBox.UseVisualStyleBackColor = true;
-			// 
-			// TargetRewindFrequencyNumeric
-			// 
-			this.TargetRewindFrequencyNumeric.Location = new System.Drawing.Point(200, 135);
-			this.TargetRewindFrequencyNumeric.Maximum = new decimal(new int[] {
-            500000,
-            0,
-            0,
-            0});
-			this.TargetRewindFrequencyNumeric.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-			this.TargetRewindFrequencyNumeric.Name = "TargetRewindFrequencyNumeric";
-			this.TargetRewindFrequencyNumeric.Size = new System.Drawing.Size(52, 20);
-			this.TargetRewindFrequencyNumeric.TabIndex = 21;
-			this.TargetRewindFrequencyNumeric.Value = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-			// 
 			// TargetFrameLengthNumeric
 			// 
-			this.TargetFrameLengthNumeric.Location = new System.Drawing.Point(125, 135);
+			this.TargetFrameLengthNumeric.Location = new System.Drawing.Point(146, 138);
 			this.TargetFrameLengthNumeric.Maximum = new decimal(new int[] {
-            500000,
-            0,
-            0,
-            0});
+			500000,
+			0,
+			0,
+			0});
 			this.TargetFrameLengthNumeric.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+			1,
+			0,
+			0,
+			0});
 			this.TargetFrameLengthNumeric.Name = "TargetFrameLengthNumeric";
 			this.TargetFrameLengthNumeric.Size = new System.Drawing.Size(52, 20);
 			this.TargetFrameLengthNumeric.TabIndex = 21;
 			this.TargetFrameLengthNumeric.Value = new decimal(new int[] {
-            600,
-            0,
-            0,
-            0});
+			600,
+			0,
+			0,
+			0});
 			// 
-			// label2
+			// TargetRewindIntervalNumeric
 			// 
-			this.label2.Location = new System.Drawing.Point(12, 138);
-			this.label2.Name = "label2";
-			this.label2.Text = "Desired frame length:";
+			this.TargetRewindIntervalNumeric.Location = new System.Drawing.Point(231, 162);
+			this.TargetRewindIntervalNumeric.Maximum = new decimal(new int[] {
+			500000,
+			0,
+			0,
+			0});
+			this.TargetRewindIntervalNumeric.Minimum = new decimal(new int[] {
+			1,
+			0,
+			0,
+			0});
+			this.TargetRewindIntervalNumeric.Name = "TargetRewindIntervalNumeric";
+			this.TargetRewindIntervalNumeric.Size = new System.Drawing.Size(52, 20);
+			this.TargetRewindIntervalNumeric.TabIndex = 21;
+			this.TargetRewindIntervalNumeric.Value = new decimal(new int[] {
+			5,
+			0,
+			0,
+			0});
 			// 
 			// EstTimeLabel
 			// 
@@ -402,7 +386,7 @@
 			this.trackBarCompression.Location = new System.Drawing.Point(22, 37);
 			this.trackBarCompression.Maximum = 9;
 			this.trackBarCompression.Name = "trackBarCompression";
-			this.trackBarCompression.Size = new System.Drawing.Size(157, 42);
+			this.trackBarCompression.Size = new System.Drawing.Size(157, 45);
 			this.trackBarCompression.TabIndex = 1;
 			this.toolTip1.SetToolTip(this.trackBarCompression, "0 = None; 9 = Maximum");
 			this.trackBarCompression.Value = 1;
@@ -412,18 +396,18 @@
 			// 
 			this.nudCompression.Location = new System.Drawing.Point(185, 37);
 			this.nudCompression.Maximum = new decimal(new int[] {
-            9,
-            0,
-            0,
-            0});
+			9,
+			0,
+			0,
+			0});
 			this.nudCompression.Name = "nudCompression";
 			this.nudCompression.Size = new System.Drawing.Size(52, 20);
 			this.nudCompression.TabIndex = 2;
 			this.nudCompression.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+			1,
+			0,
+			0,
+			0});
 			this.nudCompression.ValueChanged += new System.EventHandler(this.NudCompression_ValueChanged);
 			// 
 			// groupBox7
@@ -466,23 +450,23 @@
 			// 
 			this.BigScreenshotNumeric.Location = new System.Drawing.Point(212, 267);
 			this.BigScreenshotNumeric.Maximum = new decimal(new int[] {
-            8192,
-            0,
-            0,
-            0});
+			8192,
+			0,
+			0,
+			0});
 			this.BigScreenshotNumeric.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+			1,
+			0,
+			0,
+			0});
 			this.BigScreenshotNumeric.Name = "BigScreenshotNumeric";
 			this.BigScreenshotNumeric.Size = new System.Drawing.Size(58, 20);
 			this.BigScreenshotNumeric.TabIndex = 32;
 			this.BigScreenshotNumeric.Value = new decimal(new int[] {
-            128,
-            0,
-            0,
-            0});
+			128,
+			0,
+			0,
+			0});
 			// 
 			// LowResLargeScreenshotsCheckbox
 			// 
@@ -545,6 +529,28 @@
 			this.label12.Name = "label12";
 			this.label12.Text = "Compression Level";
 			// 
+			// TargetFrameLengthRadioButton
+			// 
+			this.TargetFrameLengthRadioButton.AutoSize = true;
+			this.TargetFrameLengthRadioButton.Location = new System.Drawing.Point(15, 138);
+			this.TargetFrameLengthRadioButton.Name = "TargetFrameLengthRadioButton";
+			this.TargetFrameLengthRadioButton.Size = new System.Drawing.Size(125, 17);
+			this.TargetFrameLengthRadioButton.TabIndex = 48;
+			this.TargetFrameLengthRadioButton.TabStop = true;
+			this.TargetFrameLengthRadioButton.Text = "Desired frame length:";
+			this.TargetFrameLengthRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// TargetRewindIntervalRadioButton
+			// 
+			this.TargetRewindIntervalRadioButton.AutoSize = true;
+			this.TargetRewindIntervalRadioButton.Location = new System.Drawing.Point(15, 162);
+			this.TargetRewindIntervalRadioButton.Name = "TargetRewindIntervalRadioButton";
+			this.TargetRewindIntervalRadioButton.Size = new System.Drawing.Size(210, 17);
+			this.TargetRewindIntervalRadioButton.TabIndex = 49;
+			this.TargetRewindIntervalRadioButton.TabStop = true;
+			this.TargetRewindIntervalRadioButton.Text = "Rewinds every fixed number of frames: ";
+			this.TargetRewindIntervalRadioButton.UseVisualStyleBackColor = true;
+			// 
 			// RewindConfig
 			// 
 			this.AcceptButton = this.OK;
@@ -569,7 +575,7 @@
 			this.locSingleRowFLP1.ResumeLayout(false);
 			this.locSingleRowFLP1.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.TargetFrameLengthNumeric)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.TargetRewindFrequencyNumeric)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.TargetRewindIntervalNumeric)).EndInit();
 			this.groupBox6.ResumeLayout(false);
 			this.groupBox6.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarCompression)).EndInit();
@@ -620,14 +626,14 @@
 				private BizHawk.WinForms.Controls.LocLabelEx label16;
 				private System.Windows.Forms.CheckBox BackupSavestatesCheckbox;
 				private BizHawk.WinForms.Controls.LocLabelEx label20;
-		private System.Windows.Forms.CheckBox ConsistentIntervalBox;
 		private System.Windows.Forms.NumericUpDown TargetFrameLengthNumeric;
-		private System.Windows.Forms.NumericUpDown TargetRewindFrequencyNumeric;
-		private BizHawk.WinForms.Controls.LocLabelEx label2;
+		private System.Windows.Forms.NumericUpDown TargetRewindIntervalNumeric;
 		private System.Windows.Forms.CheckBox cbDeltaCompression;
 		private WinForms.Controls.LocSingleRowFLP locSingleRowFLP1;
 		private WinForms.Controls.LabelEx labelEx3;
 		private WinForms.Controls.LabelEx labelEx2;
 		private WinForms.Controls.LabelEx labelEx1;
+		private System.Windows.Forms.RadioButton TargetFrameLengthRadioButton;
+		private System.Windows.Forms.RadioButton TargetRewindIntervalRadioButton;
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.Designer.cs
@@ -46,6 +46,8 @@
 			this.labelEx2 = new BizHawk.WinForms.Controls.LabelEx();
 			this.labelEx1 = new BizHawk.WinForms.Controls.LabelEx();
 			this.cbDeltaCompression = new System.Windows.Forms.CheckBox();
+			this.ConsistentIntervalBox = new System.Windows.Forms.CheckBox();
+			this.TargetRewindFrequencyNumeric = new System.Windows.Forms.NumericUpDown();
 			this.TargetFrameLengthNumeric = new System.Windows.Forms.NumericUpDown();
 			this.label2 = new BizHawk.WinForms.Controls.LocLabelEx();
 			this.EstTimeLabel = new BizHawk.WinForms.Controls.LocLabelEx();
@@ -77,6 +79,7 @@
 			this.groupBox4.SuspendLayout();
 			this.locSingleRowFLP1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.TargetFrameLengthNumeric)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.TargetRewindFrequencyNumeric)).BeginInit();
 			this.groupBox6.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarCompression)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.nudCompression)).BeginInit();
@@ -192,6 +195,8 @@
 			this.groupBox4.Controls.Add(this.locSingleRowFLP1);
 			this.groupBox4.Controls.Add(this.cbDeltaCompression);
 			this.groupBox4.Controls.Add(this.TargetFrameLengthNumeric);
+			this.groupBox4.Controls.Add(this.ConsistentIntervalBox);
+			this.groupBox4.Controls.Add(this.TargetRewindFrequencyNumeric);
 			this.groupBox4.Controls.Add(this.label2);
 			this.groupBox4.Controls.Add(this.UseCompression);
 			this.groupBox4.Controls.Add(this.RewindEnabledBox);
@@ -250,6 +255,38 @@
 			this.cbDeltaCompression.TabIndex = 35;
 			this.cbDeltaCompression.Text = "Use delta compression (economizes buffer usage at cost of CPU)";
 			this.cbDeltaCompression.UseVisualStyleBackColor = true;
+			// 
+			// ConsistentIntervalBox
+			// 
+			this.ConsistentIntervalBox.AutoSize = true;
+			this.ConsistentIntervalBox.Location = new System.Drawing.Point(250, 135);
+			this.ConsistentIntervalBox.Name = "ConsistentIntervalBox";
+			this.ConsistentIntervalBox.Size = new System.Drawing.Size(100, 17);
+			this.ConsistentIntervalBox.TabIndex = 35;
+			this.ConsistentIntervalBox.Text = "Force consistent rewind intervals";
+			this.ConsistentIntervalBox.UseVisualStyleBackColor = true;
+			// 
+			// TargetRewindFrequencyNumeric
+			// 
+			this.TargetRewindFrequencyNumeric.Location = new System.Drawing.Point(200, 135);
+			this.TargetRewindFrequencyNumeric.Maximum = new decimal(new int[] {
+            500000,
+            0,
+            0,
+            0});
+			this.TargetRewindFrequencyNumeric.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+			this.TargetRewindFrequencyNumeric.Name = "TargetRewindFrequencyNumeric";
+			this.TargetRewindFrequencyNumeric.Size = new System.Drawing.Size(52, 20);
+			this.TargetRewindFrequencyNumeric.TabIndex = 21;
+			this.TargetRewindFrequencyNumeric.Value = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
 			// 
 			// TargetFrameLengthNumeric
 			// 
@@ -532,6 +569,7 @@
 			this.locSingleRowFLP1.ResumeLayout(false);
 			this.locSingleRowFLP1.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.TargetFrameLengthNumeric)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.TargetRewindFrequencyNumeric)).EndInit();
 			this.groupBox6.ResumeLayout(false);
 			this.groupBox6.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarCompression)).EndInit();
@@ -582,7 +620,9 @@
 				private BizHawk.WinForms.Controls.LocLabelEx label16;
 				private System.Windows.Forms.CheckBox BackupSavestatesCheckbox;
 				private BizHawk.WinForms.Controls.LocLabelEx label20;
+		private System.Windows.Forms.CheckBox ConsistentIntervalBox;
 		private System.Windows.Forms.NumericUpDown TargetFrameLengthNumeric;
+		private System.Windows.Forms.NumericUpDown TargetRewindFrequencyNumeric;
 		private BizHawk.WinForms.Controls.LocLabelEx label2;
 		private System.Windows.Forms.CheckBox cbDeltaCompression;
 		private WinForms.Controls.LocSingleRowFLP locSingleRowFLP1;

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -49,10 +49,10 @@ namespace BizHawk.Client.EmuHawk
 			UseCompression.Checked = _config.Rewind.UseCompression;
 			cbDeltaCompression.Checked = _config.Rewind.UseDelta;
 			BufferSizeUpDown.Value = Math.Max((decimal) Math.Log(_config.Rewind.BufferSize, 2), BufferSizeUpDown.Minimum);
-			TargetFrameLengthRadioButton.Checked = !_config.Rewind.ConsistentRewindFrequency;
-			TargetRewindIntervalRadioButton.Checked = _config.Rewind.ConsistentRewindFrequency;
+			TargetFrameLengthRadioButton.Checked = !_config.Rewind.UseFixedRewindInterval;
+			TargetRewindIntervalRadioButton.Checked = _config.Rewind.UseFixedRewindInterval;
 			TargetFrameLengthNumeric.Value = Math.Max(_config.Rewind.TargetFrameLength, TargetFrameLengthNumeric.Minimum);
-			TargetRewindIntervalNumeric.Value = Math.Max(_config.Rewind.TargetRewindFrequency, TargetRewindIntervalNumeric.Minimum);
+			TargetRewindIntervalNumeric.Value = Math.Max(_config.Rewind.TargetRewindInterval, TargetRewindIntervalNumeric.Minimum);
 			StateSizeLabel.Text = FormatKB(_avgStateSize);
 			CalculateEstimates();
 
@@ -114,9 +114,9 @@ namespace BizHawk.Client.EmuHawk
 			_config.Rewind.UseCompression = PutRewindSetting(_config.Rewind.UseCompression, UseCompression.Checked);
 			_config.Rewind.Enabled = PutRewindSetting(_config.Rewind.Enabled, RewindEnabledBox.Checked);
 			_config.Rewind.BufferSize = PutRewindSetting(_config.Rewind.BufferSize, 1L << (int) BufferSizeUpDown.Value);
-			_config.Rewind.ConsistentRewindFrequency = PutRewindSetting(_config.Rewind.ConsistentRewindFrequency, TargetRewindIntervalRadioButton.Checked);
+			_config.Rewind.UseFixedRewindInterval = PutRewindSetting(_config.Rewind.UseFixedRewindInterval, TargetRewindIntervalRadioButton.Checked);
 			_config.Rewind.TargetFrameLength = PutRewindSetting(_config.Rewind.TargetFrameLength, (int)TargetFrameLengthNumeric.Value);
-			_config.Rewind.TargetRewindFrequency = PutRewindSetting(_config.Rewind.TargetRewindFrequency, (int)TargetRewindIntervalNumeric.Value);
+			_config.Rewind.TargetRewindInterval = PutRewindSetting(_config.Rewind.TargetRewindInterval, (int)TargetRewindIntervalNumeric.Value);
 			_config.Rewind.UseDelta = PutRewindSetting(_config.Rewind.UseDelta, cbDeltaCompression.Checked);
 
 			// These settings are not used by DoRewindSettings

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -49,7 +49,9 @@ namespace BizHawk.Client.EmuHawk
 			UseCompression.Checked = _config.Rewind.UseCompression;
 			cbDeltaCompression.Checked = _config.Rewind.UseDelta;
 			BufferSizeUpDown.Value = Math.Max((decimal) Math.Log(_config.Rewind.BufferSize, 2), BufferSizeUpDown.Minimum);
+            ConsistentIntervalBox.Checked = _config.Rewind.ConsistentRewindFrequency;
 			TargetFrameLengthNumeric.Value = Math.Max(_config.Rewind.TargetFrameLength, TargetFrameLengthNumeric.Minimum);
+			TargetRewindFrequencyNumeric.Value = Math.Max(_config.Rewind.TargetRewindFrequency, TargetRewindFrequencyNumeric.Minimum);
 			StateSizeLabel.Text = FormatKB(_avgStateSize);
 			CalculateEstimates();
 
@@ -111,7 +113,9 @@ namespace BizHawk.Client.EmuHawk
 			_config.Rewind.UseCompression = PutRewindSetting(_config.Rewind.UseCompression, UseCompression.Checked);
 			_config.Rewind.Enabled = PutRewindSetting(_config.Rewind.Enabled, RewindEnabledBox.Checked);
 			_config.Rewind.BufferSize = PutRewindSetting(_config.Rewind.BufferSize, 1L << (int) BufferSizeUpDown.Value);
+			_config.Rewind.ConsistentRewindFrequency = PutRewindSetting(_config.Rewind.ConsistentRewindFrequency, ConsistentIntervalBox.Checked);
 			_config.Rewind.TargetFrameLength = PutRewindSetting(_config.Rewind.TargetFrameLength, (int)TargetFrameLengthNumeric.Value);
+			_config.Rewind.TargetRewindFrequency = PutRewindSetting(_config.Rewind.TargetRewindFrequency, (int)TargetRewindFrequencyNumeric.Value);
 			_config.Rewind.UseDelta = PutRewindSetting(_config.Rewind.UseDelta, cbDeltaCompression.Checked);
 
 			// These settings are not used by DoRewindSettings

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -49,9 +49,10 @@ namespace BizHawk.Client.EmuHawk
 			UseCompression.Checked = _config.Rewind.UseCompression;
 			cbDeltaCompression.Checked = _config.Rewind.UseDelta;
 			BufferSizeUpDown.Value = Math.Max((decimal) Math.Log(_config.Rewind.BufferSize, 2), BufferSizeUpDown.Minimum);
-            ConsistentIntervalBox.Checked = _config.Rewind.ConsistentRewindFrequency;
+			TargetFrameLengthRadioButton.Checked = !_config.Rewind.ConsistentRewindFrequency;
+			TargetRewindIntervalRadioButton.Checked = _config.Rewind.ConsistentRewindFrequency;
 			TargetFrameLengthNumeric.Value = Math.Max(_config.Rewind.TargetFrameLength, TargetFrameLengthNumeric.Minimum);
-			TargetRewindFrequencyNumeric.Value = Math.Max(_config.Rewind.TargetRewindFrequency, TargetRewindFrequencyNumeric.Minimum);
+			TargetRewindIntervalNumeric.Value = Math.Max(_config.Rewind.TargetRewindFrequency, TargetRewindIntervalNumeric.Minimum);
 			StateSizeLabel.Text = FormatKB(_avgStateSize);
 			CalculateEstimates();
 
@@ -113,9 +114,9 @@ namespace BizHawk.Client.EmuHawk
 			_config.Rewind.UseCompression = PutRewindSetting(_config.Rewind.UseCompression, UseCompression.Checked);
 			_config.Rewind.Enabled = PutRewindSetting(_config.Rewind.Enabled, RewindEnabledBox.Checked);
 			_config.Rewind.BufferSize = PutRewindSetting(_config.Rewind.BufferSize, 1L << (int) BufferSizeUpDown.Value);
-			_config.Rewind.ConsistentRewindFrequency = PutRewindSetting(_config.Rewind.ConsistentRewindFrequency, ConsistentIntervalBox.Checked);
+			_config.Rewind.ConsistentRewindFrequency = PutRewindSetting(_config.Rewind.ConsistentRewindFrequency, TargetRewindIntervalRadioButton.Checked);
 			_config.Rewind.TargetFrameLength = PutRewindSetting(_config.Rewind.TargetFrameLength, (int)TargetFrameLengthNumeric.Value);
-			_config.Rewind.TargetRewindFrequency = PutRewindSetting(_config.Rewind.TargetRewindFrequency, (int)TargetRewindFrequencyNumeric.Value);
+			_config.Rewind.TargetRewindFrequency = PutRewindSetting(_config.Rewind.TargetRewindFrequency, (int)TargetRewindIntervalNumeric.Value);
 			_config.Rewind.UseDelta = PutRewindSetting(_config.Rewind.UseDelta, cbDeltaCompression.Checked);
 
 			// These settings are not used by DoRewindSettings
@@ -175,5 +176,6 @@ namespace BizHawk.Client.EmuHawk
 		{
 			nudCompression.Value = SaveStateConfig.DefaultCompressionLevelNormal;
 		}
+
 	}
 }

--- a/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
+++ b/src/BizHawk.Client.EmuHawk/config/RewindConfig.cs
@@ -176,6 +176,5 @@ namespace BizHawk.Client.EmuHawk
 		{
 			nudCompression.Value = SaveStateConfig.DefaultCompressionLevelNormal;
 		}
-
 	}
 }


### PR DESCRIPTION
Fix #2463

No changes to TAStudio.
Outside of TAStudio, there's now an option to specify a fixed rewind interval instead of a desired frame length:

![grafik](https://user-images.githubusercontent.com/8490534/127876667-96c62943-a0db-4013-aa34-8e32fcf5d187.png)

This is how the rewind frequency used to be specified in the pre 2.5 rewind system.
While the new way of specifying a "desired frame length" is great for TAStudio, it is very cumbersome outside of it: For one, with a buffer size of >20'000 frames, you need to specify a huge desired frame length of 100'000 to (approximately) get 5-frame rewinds.  And, more importantly, even if you set a desired frame length of 100'000, then the rewind intervals still vary (more or less randomly) between 4-6 frames, as the state size differs from frame to frame. This "randomness" makes them very awkward to use.

Don't get me wrong, TAStudio is an amazing tool for making highly optimized TASes, doing small tweaks to your inputs, re-adjusting lag frames, etc. However, for non micro-optimized runs or glitch hunting, 5-frame (or even 2-frame) rewinds are a lot faster to use.