### PR TITLE
Add automagic patching capability to `FirmwareManager`

### DIFF
--- a/src/BizHawk.Emulation.Common/Database/FirmwarePatchData.cs
+++ b/src/BizHawk.Emulation.Common/Database/FirmwarePatchData.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+using System;
+
+namespace BizHawk.Emulation.Common
+{
+	/// <summary>
+	/// Represents a binary patch, to be applied to a byte array. Patches must be contiguous; multiple instances can be used to for non-contiguous patches.
+	/// Patches usually contain data which needs to be XOR'd with a base file, but with <see cref="Overwrite"/> set to <see langword="true"/>, this struct can represent data which should replace part of a base file.
+	/// </summary>
+	/// <remarks>TODO no mechanism to change length, would that be useful? --yoshi</remarks>
+	public readonly struct FirmwarePatchData
+	{
+		public readonly byte[] Contents;
+
+		/// <summary>position in base file where patch should start</summary>
+		/// <remarks>in bytes (octets)</remarks>
+		public readonly int Offset;
+
+		/// <summary>base file should be overwritten with patch iff <see langword="true"/>, XOR'd otherwise</summary>
+		public readonly bool Overwrite;
+
+		public FirmwarePatchData(int offset, byte[] contents, bool overwrite = false)
+		{
+			Contents = contents;
+			Offset = offset;
+			Overwrite = overwrite;
+		}
+
+		/// <summary>applies this patch to <paramref name="base"/> in-place, and returns the same reference</summary>
+		public readonly byte[] ApplyToMutating(byte[] @base)
+		{
+			if (Overwrite)
+			{
+				Array.Copy(Contents, 0, @base, Offset, Contents.Length);
+			}
+			else
+			{
+				var iBase = Offset;
+				var iPatch = 0;
+				var l = Contents.Length;
+				while (iPatch < l) @base[iBase++] ^= Contents[iPatch++];
+			}
+			return @base;
+		}
+	}
+}

--- a/src/BizHawk.Emulation.Common/Database/FirmwarePatchOption.cs
+++ b/src/BizHawk.Emulation.Common/Database/FirmwarePatchOption.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace BizHawk.Emulation.Common
+{
+	public readonly struct FirmwarePatchOption
+	{
+		/// <summary>hash of base file patch should be applied to</summary>
+		public readonly string BaseHash;
+
+		public readonly IReadOnlyList<FirmwarePatchData> Patches;
+
+		/// <summary>hash of file produced by patching</summary>
+		public readonly string TargetHash;
+
+		public FirmwarePatchOption(string baseHash, IReadOnlyList<FirmwarePatchData> patches, string targetHash)
+		{
+			BaseHash = baseHash;
+			Patches = patches;
+			TargetHash = targetHash;
+		}
+
+		public FirmwarePatchOption(string baseHash, FirmwarePatchData patch, string targetHash)
+			: this(baseHash, new[] { patch }, targetHash) {}
+	}
+}

--- a/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISettable.cs
+++ b/src/BizHawk.Emulation.Cores/Consoles/Nintendo/Gameboy/Gambatte.ISettable.cs
@@ -106,11 +106,6 @@ namespace BizHawk.Emulation.Cores.Nintendo.Gameboy
 			[DefaultValue(false)]
 			public bool EnableBIOS { get; set; }
 
-			[DisplayName("Patch Similar BootROMs")]
-			[Description("If true, BootROMs (or \"BIOSes\") are patched a similar other. GBC is patched to GBA. DMG is patched to MGB (and vice versa). Should not be used for unofficial BootROMs. Ignored (treated as false) when booting without a BIOS.")]
-			[DefaultValue(false)]
-			public bool PatchBIOS { get; set; }
-
 			public enum ConsoleModeType
 			{
 				Auto,


### PR DESCRIPTION
Replaces hack in Hawk-side Gambatte. (I recall seeing other hacks, but can't find any.) Would also work for NDS if the hashes of all N permutations were hardcoded... I have ideas for how to get around that limitation.

I also added a simple tool to `Help` > `Debug Utilities` for trying out this feature without needing to mess around with firmware customisations and sync settings.

edit 2021-09-18: Force-pushed because of #2917. The extra two patchsets added in that PR (which happen to be identical to existing ones) are now included here. I also realised it was stupid to hardcode the reverse of a patchset instead of computing it, so that's gone.