### PR TITLE
Add a password type to textbox to allow replacing text with asterisks

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
@@ -1402,6 +1402,9 @@ namespace BizHawk.Client.EmuHawk
 					case "INT":
 						textbox.SetType(BoxType.Signed);
 						break;
+					case "PASSWORD":
+						textbox.PasswordChar = '*';
+						break;
 				}
 			}
 


### PR DESCRIPTION
This will enable lua scripts/plugins to store passwords, API keys or other types of credentials, without being visible in the settings menu.