### PR TITLE
Add optional sort parameter to SetDropdownItems method

### DIFF
--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
@@ -1168,9 +1168,9 @@ namespace BizHawk.Client.EmuHawk
 			return 0;
 		}
 
-		[LuaMethodExample("forms.setdropdownitems( 332, { \"item1\", \"item2\" } );")]
-		[LuaMethod("setdropdownitems", "Sets the items for a given dropdown box")]
-		public void SetDropdownItems(int handle, LuaTable items)
+		[LuaMethodExample("forms.setdropdownitems( 332, { \"item1\", \"item2\" }, false );")]
+		[LuaMethod("setdropdownitems", "Sets the items for a given dropdown box. Sort is an optional property to disable automatic alphabetical sorting of list items.")]
+		public void SetDropdownItems(int handle, LuaTable items, bool sort = true)
 		{
 			try
 			{
@@ -1189,7 +1189,10 @@ namespace BizHawk.Client.EmuHawk
 							if (control is LuaDropDown)
 							{
 								var dropdownItems = _th.EnumerateValues<string>(items).ToList();
-								dropdownItems.Sort();
+								if (sort)
+								{
+									dropdownItems.Sort();
+								}
 								(control as LuaDropDown).SetItems(dropdownItems);
 							}
 

--- a/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
+++ b/src/BizHawk.Client.EmuHawk/tools/Lua/Libraries/FormsLuaLibrary.cs
@@ -1168,9 +1168,9 @@ namespace BizHawk.Client.EmuHawk
 			return 0;
 		}
 
-		[LuaMethodExample("forms.setdropdownitems( 332, { \"item1\", \"item2\" }, false );")]
-		[LuaMethod("setdropdownitems", "Sets the items for a given dropdown box. Sort is an optional property to disable automatic alphabetical sorting of list items.")]
-		public void SetDropdownItems(int handle, LuaTable items, bool sort = true)
+		[LuaMethodExample("forms.setdropdownitems(dropdown_handle, { \"item1\", \"item2\" });")]
+		[LuaMethod("setdropdownitems", "Updates the item list of a dropdown menu. The optional third parameter toggles alphabetical sorting of items, pass false to skip sorting.")]
+		public void SetDropdownItems(int handle, LuaTable items, bool alphabetize = true)
 		{
 			try
 			{
@@ -1186,16 +1186,12 @@ namespace BizHawk.Client.EmuHawk
 					{
 						if (control.Handle == ptr)
 						{
-							if (control is LuaDropDown)
+							if (control is LuaDropDown ldd)
 							{
 								var dropdownItems = _th.EnumerateValues<string>(items).ToList();
-								if (sort)
-								{
-									dropdownItems.Sort();
-								}
-								(control as LuaDropDown).SetItems(dropdownItems);
+								if (alphabetize) dropdownItems.Sort();
+								ldd.SetItems(dropdownItems);
 							}
-
 							return;
 						}
 					}


### PR DESCRIPTION
Allows to disable automatic alphabetical sorting for the SetDropdownItems method by use of an optional "sort" parameter.
With this, it's possible to provide the form with a preordered list of options to allow for custom sorting algorithms, for example to force special characters to the end of the list, or to allow ordering by different metrics.